### PR TITLE
sudoers has to be owned by uid 0

### DIFF
--- a/etc/grml/fai/config/scripts/GRMLBASE/20-sudo
+++ b/etc/grml/fai/config/scripts/GRMLBASE/20-sudo
@@ -13,6 +13,7 @@ set -e
 fcopy -v /etc/sudoers
 sed -i "s/\$USERNAME/$USERNAME/" $target/etc/sudoers
 chmod 440 $target/etc/sudoers
+chown 0:0 $target/etc/sudoers
 
 ## END OF FILE #################################################################
 # vim:ft=sh expandtab ai tw=80 tabstop=4 shiftwidth=2


### PR DESCRIPTION
fcopy copies the owner of the file per default
when building from git cloned by a user, the owner is the user
fix it by chowning /etc/sudoers to 0:0

(not using fcopy's -m flag for better readability)
