### PR TITLE
add depends for the wrapper script

### DIFF
--- a/etc/grml/fai/config/package_config/GRMLBASE
+++ b/etc/grml/fai/config/package_config/GRMLBASE
@@ -33,6 +33,7 @@ grub-pc
 hdparm
 hwinfo
 initramfs-tools
+iptstate
 kbd
 less
 live-boot-grml live-boot-grml-doc


### PR DESCRIPTION
grml-iptstate doesn't start without it (iptstate).
