### PR TITLE
persistent → persistence update due to changes in live-boot

### DIFF
--- a/templates/GRML/grml-cheatcodes.txt
+++ b/templates/GRML/grml-cheatcodes.txt
@@ -63,7 +63,7 @@ grml file=foobar.tbz                Use specified file as name for configuration
                                     instead of the default one (config.tbz)
 grml extract=/etc                   Extract only /etc from configuration archive,
                                     use it in combination with myconfig or netconfig
-grml persistent                     Enable persistency feature, more details available at
+grml persistence                    Enable persistency feature, more details available at
                                     http://wiki.grml.org/doku.php?id=persistency
 grml hostname=...                   Set hostname to given argument
 grml hostname                       Set a random hostname

--- a/templates/boot/grub/%SHORT_NAME%_options.cfg
+++ b/templates/boot/grub/%SHORT_NAME%_options.cfg
@@ -1,8 +1,8 @@
 submenu "%GRML_NAME% - advanced options  ->" --class=submenu {
-menuentry "%GRML_NAME% - enable persistent mode" {
+menuentry "%GRML_NAME% - enable persistence mode" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" "${kernelopts}" persistent 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" "${kernelopts}" persistence 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }

--- a/templates/boot/isolinux/grml.cfg
+++ b/templates/boot/isolinux/grml.cfg
@@ -94,16 +94,17 @@ label grml2ram
                                         to use this option.
   endtext
 
-label persistent
+label persistence
   menu label %GRML_NAME% - ^Persistent mode
   kernel /boot/%SHORT_NAME%/vmlinuz
-  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce persistent 
+  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce persistence 
 
   text help
                                         Boot Grml and enable persistency
                                         feature to store system and
                                         settings on an external device
-                                        with label live-rw / home-rw.
+                                        with label custom-ov or
+                                        (deprecated) live-rw / home-rw.
   endtext
 
 label serial


### PR DESCRIPTION
the option was renamed in live-boot 3.0~a27
update cheatcodes and boot configs accordingly
