### PR TITLE
Add puppet to grml-full

### DIFF
--- a/etc/grml/fai/config/package_config/GRML_FULL
+++ b/etc/grml/fai/config/package_config/GRML_FULL
@@ -277,6 +277,7 @@ facter
 flashrom
 mcollective
 memtester
+puppet
 
 # virtualization support
 imvirt


### PR DESCRIPTION
Shipping puppet in GRML_FULL allows to use puppet receipes for system management out of the box.
