### PR TITLE
Work around regression in GRUB 2.00-22 when loading FreeDOS image

### DIFF
--- a/templates/boot/grub/addons.cfg
+++ b/templates/boot/grub/addons.cfg
@@ -18,7 +18,8 @@ menuentry "GRUB - all in one image" {
 menuentry "FreeDOS" {
     insmod linux16
     linux16  /boot/addons/memdisk
-    initrd16 /boot/addons/balder10.imz
+    loopback balder /boot/addons/balder10.imz
+    initrd16 (balder)+2880
 }
 
 if [ ${iso_path} ] ; then


### PR DESCRIPTION
Seems that Grub 2.00-22 cannot properly load a gzipped initrd file
with 'linux16' command (which is used to load the gzipped FreeDOS
memdisk image). As a workaround, mount the filesystem using the
'loopback' command (which transparently decompresses it) and then use
blocklist syntax to load the whole mounted filesystem as an initrd.
