### PR TITLE
Add more filesystems to modular GRUB2

### DIFF
--- a/etc/grml/fai/config/scripts/GRMLBASE/45-grub-images
+++ b/etc/grml/fai/config/scripts/GRMLBASE/45-grub-images
@@ -49,6 +49,7 @@ TMP_CONFIG="${TMP_CONFIG##${target}}"
 for arch in ${ARCHS[@]} ; do
 $ROOTCMD grub-mkimage -O $arch -o /boot/$arch.img --prefix=/boot/grub/ --config="$TMP_CONFIG" \
   echo iso9660 part_msdos search_fs_file test \
+  fat ext2 reiserfs xfs btrfs squash4 part_gpt lvm \
   ${ADDITIONAL_MODULES[$arch]}
 done
 


### PR DESCRIPTION
This fixes the bug described in http://bts.grml.org/grml/issue1306
that a grml2usb prepared medium cannot boot from (U)EFI.

Added a few more filesystems just in case somebody wants to use
grml2usb with a non-mainstream filesystem.

I am unable to reproduce the second bug in that issue, when dd-ing
the ISO to a USB device - this scenario works fine with the (U)EFI
implementation used by VirtualBox.
