### PR TITLE
Added package syslinux-utils to GRMLBASE

### DIFF
--- a/etc/grml/fai/config/package_config/GRMLBASE
+++ b/etc/grml/fai/config/package_config/GRMLBASE
@@ -51,7 +51,7 @@ resolvconf
 rsync
 rsyslog
 strace
-syslinux syslinux-common
+syslinux syslinux-common syslinux-utils
 udev
 usbutils
 uuid-runtime


### PR DESCRIPTION
Package syslinux-utils added to package config GRMLBASE to support
booting with memdisk. The package includes the binary memdiskfind which
is needed during the boot process when booting using memdisk and iPXE.
Without memdiskfind the initrd just continues without errors and tries to find the root filesystem somewhere else. When booting with iPXE and memdisk this leads to the following error:
(initramfs) Unable to find a medium containing a live file system.

How to reproduce/How I tested: Download ipxe.iso and boot from there, e.g. kvm -cdrom ipxe.iso -m 1024 -k en-u
Hit Ctrl-B after IP address was assigned to get to the shell and type:
initrd http://localhost/grml.iso
chain http://localhost/memdisk iso

(My test iso and the memdisk binary were copied to my nginx root directory)
