### PR TITLE
Added support for netboot.xyz

### DIFF
--- a/templates/boot/grub/addons.cfg
+++ b/templates/boot/grub/addons.cfg
@@ -9,6 +9,11 @@ menuentry "iPXE - boot via network/PXE" {
     linux16 /boot/addons/ipxe.lkrn
 }
 
+menuentry "Netboot.xyz" {
+    insmod linux16
+    linux16 /boot/addons/netboot.xyz.lkrn
+}
+
 menuentry "GRUB - all in one image" {
     insmod linux16
     linux16  /boot/addons/memdisk

--- a/templates/boot/isolinux/addon_27_netboot.cfg
+++ b/templates/boot/isolinux/addon_27_netboot.cfg
@@ -1,0 +1,8 @@
+label netboot.xyz
+  menu label Run ^Netboot.xyz
+  kernel /boot/addons/netboot.xyz.lkrn
+
+  text help
+                                        Start Netboot.xyz for booting
+                                        over the network.
+  endtext


### PR DESCRIPTION
Added configuration for isolinux and grub to add a menu entry to boot
netboot.xyz. The actual netboot.xyz.lkrn needs to be part of
grml-live-addons to make this work, see PR #8 in grml-live-grml:
grml/grml-live-grml#8