### PR TITLE
Enable and disable services by using systemd.presets

### DIFF
--- a/etc/grml/fai/config/files/etc/systemd/system-preset/10-grml.preset/GRMLBASE
+++ b/etc/grml/fai/config/files/etc/systemd/system-preset/10-grml.preset/GRMLBASE
@@ -1,0 +1,17 @@
+# enable TTY logins
+enable getty@tty*.service.d
+
+# disable unwanted services
+disable cron.service
+disable lvm2-lvmetad.service
+disable lvm2-lvmetad.socket
+disable lvm2-lvmpolld.socket
+disable lvm2-monitor.service
+disable mdadm-raid.service
+disable smartd.service
+disable ssh.service
+disable swap.target
+disable systemd-timesyncd.service
+disable wpa_supplicant.service
+disable wpa_supplicant@.service
+disable uuidd.service

--- a/etc/grml/fai/config/scripts/GRMLBASE/15-initsetup
+++ b/etc/grml/fai/config/scripts/GRMLBASE/15-initsetup
@@ -16,7 +16,7 @@ set -e
 . "$GRML_LIVE_CONFIG"
 
 systemd_setup() {
-  fcopy -i -B -v -r /etc/systemd
+  fcopy -M -i -B -v -r /etc/systemd
 
   echo "Enabling user '$USERNAME' for autologin"
   sed -i "s/\$USERNAME/$USERNAME/" "$target"/etc/systemd/system/getty@tty*.service.d/override.conf

--- a/etc/grml/fai/config/scripts/GRMLBASE/15-initsetup
+++ b/etc/grml/fai/config/scripts/GRMLBASE/15-initsetup
@@ -21,14 +21,6 @@ systemd_setup() {
   echo "Enabling user '$USERNAME' for autologin"
   sed -i "s/\$USERNAME/$USERNAME/" "$target"/etc/systemd/system/getty@tty*.service.d/override.conf
 
-  # enable TTY logins
-  local service
-  for file in "${target}"/etc/systemd/system/getty@tty*.service.d ; do
-    service=$(basename "$file" .d)
-    $ROOTCMD systemctl enable "$service" || echo "failed to enable $service"
-  done
-  unset service
-
   # FIXME - ssh-keygen isn't executed yet before ssh-bootoption + ssh services
   $ROOTCMD systemctl enable ssh-bootoption.service || echo "failed to enable ssh-bootoption.service"
   $ROOTCMD systemctl enable ssh-keygen.service     || echo "failed to enable ssh-keygen.service"
@@ -36,25 +28,6 @@ systemd_setup() {
   # fails on overlayfs with
   # "Failed to unmount transient /etc/machine-id file in our private namespace: Invalid argument"
   $ROOTCMD systemctl mask systemd-machine-id-commit.service || echo "failed to mask $systemd-machine-id-commit.service"
-
-  # disable unwanted services
-  local service
-  for service in \
-    cron.service \
-    lvm2-lvmetad.service \
-    lvm2-lvmetad.socket \
-    lvm2-lvmpolld.socket \
-    lvm2-monitor.service \
-    mdadm-raid.service \
-    smartd.service \
-    ssh.service \
-    swap.target \
-    systemd-timesyncd.service \
-    uuidd.service
-  do
-    $ROOTCMD systemctl disable ${service} || echo "failed to disable $service"
-  done
-  unset service
 
   # TODO ->
 


### PR DESCRIPTION
To enabled or disable services on boot-time we should use systemd.presets. This change implements the effort of `15-initsetup` in `/etc/systemd/system/system-preset/10-grml.preset`.

And: There is also a "minor" fix where `fcopy` did not set ownership/permission correctly when copying `/etc/systemd`.