### PR TITLE
Add SHA-256 and SHA-512 hashes

### DIFF
--- a/grml-live
+++ b/grml-live
@@ -1440,6 +1440,10 @@ else
              touch -r ${ISO_NAME} ${ISO_NAME}.md5
              sha1sum ${ISO_NAME} > ${ISO_NAME}.sha1 && \
              touch -r ${ISO_NAME} ${ISO_NAME}.sha1
+             sha256sum ${ISO_NAME} ${ISO_NAME}.sha256 && \
+             touch -r ${ISO_NAME} ${ISO_NAME}.sha256
+             sha512sum ${ISO_NAME} ${ISO_NAME}.sha512 && \
+             touch -r ${ISO_NAME} ${ISO_NAME}.sha512
            fi
          )
          ;;
@@ -1520,6 +1524,8 @@ create_netbootpackage() {
     (
       cd $(dirname "${OUTPUT_FILE}")
       sha1sum $(basename "${OUTPUT_FILE}") > "${OUTPUT_FILE}.sha1"
+      sha256sum $(basename "${OUTPUT_FILE}") > "${OUTPUT_FILE}.sha256"
+      sha512sum $(basename "${OUTPUT_FILE}") > "${OUTPUT_FILE}.sha512"
     )
     einfo "Generated netboot package ${OUTPUT_FILE}" ; eend 0
     rm -rf "${OUTPUTDIR}"


### PR DESCRIPTION
Most security-conscious users expect to find SHA-256 hashes of files, since both MD5 and SHA-1 are considered weak.  SHA-512 additionally has the benefit that it is significantly faster than SHA-256 on 64-bit systems, processing twice as much data per chunk with only 125% of the operations.  Generate both SHA-256 and SHA-512 hashes anywhere we provide SHA-1 hashes.