### PR TITLE
Change systemd default target to multi-user.target

### DIFF
--- a/etc/grml/fai/config/scripts/GRMLBASE/15-initsetup
+++ b/etc/grml/fai/config/scripts/GRMLBASE/15-initsetup
@@ -24,6 +24,7 @@ systemd_setup() {
   $ROOTCMD systemctl mask systemd-machine-id-commit.service || echo "failed to mask $systemd-machine-id-commit.service"
   $ROOTCMD systemctl preset-all
 
+  $ROOTCMD systemctl set-default multi-user.target
   # TODO ->
 
   # * avoid startup of any LSB scripts; NOTE: jessie doesn't support that


### PR DESCRIPTION
The default target used to be graphical.target which is not appropriate
for Grml