### PR TITLE
Use ssh-keygen -A to generate host keys

### DIFF
--- a/etc/grml/fai/config/files/etc/systemd/system/ssh.service/GRMLBASE
+++ b/etc/grml/fai/config/files/etc/systemd/system/ssh.service/GRMLBASE
@@ -9,10 +9,7 @@ ConditionPathExists=!/etc/ssh/sshd_not_to_be_run
 
 [Service]
 EnvironmentFile=-/etc/default/ssh
-ExecStartPre=-/bin/sh -c "[ ! -f /etc/ssh/ssh_host_rsa_key ]      && /usr/bin/ssh-keygen -t rsa     -f /etc/ssh/ssh_host_rsa_key     -C '' -N ''"
-ExecStartPre=-/bin/sh -c "[ ! -f /etc/ssh/ssh_host_dsa_key ]      && /usr/bin/ssh-keygen -t dsa     -f /etc/ssh/ssh_host_dsa_key     -C '' -N ''"
-ExecStartPre=-/bin/sh -c "[ ! -f /etc/ssh/ssh_host_ecdsa_key ]    && /usr/bin/ssh-keygen -t ecdsa   -f /etc/ssh/ssh_host_ecdsa_key   -C '' -N ''"
-ExecStartPre=-/bin/sh -c "[ ! -f /etc/ssh/ssh_host_ed25519_key ]  && /usr/bin/ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -C '' -N ''"
+ExecStartPre=-/bin/sh -c "/usr/bin/ssh-keygen -A"
 ExecStart=/usr/sbin/sshd -D $SSHD_OPTS
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process


### PR DESCRIPTION
ssh-keygen -A (from manpage):
  For each of the key types (rsa1, rsa, dsa, ecdsa and
  ed25519) for which host keys do not exist, generate the host keys
  with the default key file path, an empty passphrase, default bits for
  the key type, and default comment.  This is used by system
  administration scripts to generate new host keys.