### PR TITLE
Provide new grml-boot.target

### DIFF
--- a/etc/grml/fai/config/files/etc/systemd/system/grml-boot.target/GRMLBASE
+++ b/etc/grml/fai/config/files/etc/systemd/system/grml-boot.target/GRMLBASE
@@ -1,0 +1,8 @@
+[Unit]
+Description=Grml Live System
+Documentation=man:systemd.special(7)
+Requires=getty.target systemd-user-sessions.service systemd-logind.service basic.target
+Conflicts=rescue.service rescue.target
+After=rescue.service rescue.target
+AllowIsolate=yes
+

--- a/etc/grml/fai/config/files/etc/systemd/system/ssh-bootoption.service/GRMLBASE
+++ b/etc/grml/fai/config/files/etc/systemd/system/ssh-bootoption.service/GRMLBASE
@@ -16,4 +16,4 @@ KillMode=process
 Restart=on-failure
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=grml-boot.target

--- a/etc/grml/fai/config/scripts/GRMLBASE/15-initsetup
+++ b/etc/grml/fai/config/scripts/GRMLBASE/15-initsetup
@@ -24,17 +24,7 @@ systemd_setup() {
   $ROOTCMD systemctl mask systemd-machine-id-commit.service || echo "failed to mask $systemd-machine-id-commit.service"
   $ROOTCMD systemctl preset-all
 
-  $ROOTCMD systemctl set-default multi-user.target
-  # TODO ->
-
-  # * avoid startup of any LSB scripts; NOTE: jessie doesn't support that
-  #   system-generators approach yet, only >=stretch
-      mkdir -p "${target}"/etc/systemd/system-generators/
-      ln -sf /dev/null "${target}"/etc/systemd/system-generators/systemd-sysv-generator
-  #   -> revert /etc/systemd/system-generators/systemd-sysv-generator && systemctl daemon-reload during *bootup*
-  #      + possibly move this into startup so it's always executed on bootup, even with persistency enabled
-  #      where the change towards systemd-sysv-generator might persist across
-  #      reboots -> LSB scripts executed on reboots
+  $ROOTCMD systemctl set-default grml-boot.target
 }
 
 file_rc_setup() {


### PR DESCRIPTION
With this new target we can now define which services are started on
boot.

Prior this target some services (without a systemd-service file) were
automatically started because of the systemd-sysv-generator (i.e.
ser2net).

Thanks: Felipe Sateler
Closes grml/release-planning#2 @ GH