### PR TITLE
add stressant package into Grml

### DIFF
--- a/etc/grml/fai/config/package_config/GRML_FULL
+++ b/etc/grml/fai/config/package_config/GRML_FULL
@@ -286,6 +286,7 @@ flashrom
 mcollective
 memtester
 puppet
+stressant
 
 # virtualization support
 imvirt


### PR DESCRIPTION
to quote from the control file:

> Stressant is a simple stress testing and burn-in tool
> 
> It is designed to run on new machines to make sure they will work
> reliably by testing various parts of the system (CPU, RAM, disk,
> network) by putting them under heavy load and try to detect failures.
> 
> As much as possible, stressant tries to reuse existing tools to
> perform the various tasks and aims to be run automatically.

it has just entered Debian sid and will pull at least 3 new
dependencies in (python-humanize, python-colorlog and stress-ng)

adding this is essential for the Stressant project to continue
collaborating with Grml.