### PR TITLE
Make startx boot option work with systemd

### DIFF
--- a/etc/grml/fai/config/files/etc/systemd/system/getty@tty6.service.d/override.conf/GRMLBASE
+++ b/etc/grml/fai/config/files/etc/systemd/system/getty@tty6.service.d/override.conf/GRMLBASE
@@ -1,4 +1,4 @@
 [Service]
 Type=idle
 ExecStart=
-ExecStart=-/sbin/grml-runtty /dev/tty6 /bin/zsh $USERNAME
+ExecStart=-/bin/zsh --login -c "[ ! -e /var/run/grml_startx.started ] && (touch /var/run/grml_startx.started && /sbin/grml-runtty /dev/tty6 /etc/init.d/startx root; chvt 1) || /sbin/grml-runtty /dev/tty6 /bin/zsh $USERNAME" >/dev/tty6 2>&1 < /dev/tty6


### PR DESCRIPTION
The desired behavior (with systemd and the boot option "startx") is to start
the X window system automatically.

This is achieved by getty@tty6.service which starts grml-x as user "grml" on
vt6/tty6 and switches back to vt1/tty1 after exit. (This alone could be
achieved with systemd-unit option Type=oneshot and Restart=no). But when
switiching back to vt6/tty6 (again) we would like to start a zsh (for user
"grml") and restart the zsh if exited. That means that grml-x should only be
started on the very first run and the zsh on every other.

We could not figure out how to change the systemd-unit option "Type"
dynamically, so we kept it on "idle" which means that the "actual execution of
the service binary is delayed until all active jobs are dispatched". That's why
we need to switch to vt6/tty6 (via grml-autoconfig) iff the boot option
"startx" is given.

We also do not know yet how to dynamically change the behavior of the
systemd-unit in a safe way. Rewriting the unit-file (override.conf) after
grml-x exits (i.e. with ExecStopPost) doesn't seem to work reliably (especially
when calling "systemctl daemon-reload" in it). That's why we use a state-file
(/var/run/grml_startx.started) to start up grml-x on the first call and the zsh
else.

This also means that grml-x is started automatically when switching to vt6/tty6
manually (when no "startx" boot option was given) once and the zsh on the
following calls.

Closes grml/grml#1