### PR TITLE
TTY6/VT6 should start a shell if bootoption startx is not given

### DIFF
--- a/etc/grml/fai/config/files/etc/systemd/system/getty@tty6.service.d/override.conf/GRMLBASE
+++ b/etc/grml/fai/config/files/etc/systemd/system/getty@tty6.service.d/override.conf/GRMLBASE
@@ -1,4 +1,4 @@
 [Service]
 Type=idle
 ExecStart=
-ExecStart=-/bin/zsh --login -c "[ ! -e /var/run/grml_startx.started ] && (touch /var/run/grml_startx.started && /sbin/grml-runtty /dev/tty6 /etc/init.d/startx root; chvt 1) || /sbin/grml-runtty /dev/tty6 /bin/zsh $USERNAME" >/dev/tty6 2>&1 < /dev/tty6
+ExecStart=-/bin/zsh --login -c "[ ! -e /var/run/grml_startx.started ] && [ -x /etc/init.d/startx ] && (touch /var/run/grml_startx.started && /sbin/grml-runtty /dev/tty6 /etc/init.d/startx root; chvt 1) || /sbin/grml-runtty /dev/tty6 /bin/zsh $USERNAME" >/dev/tty6 2>&1 < /dev/tty6


### PR DESCRIPTION
When the bootoption "startx" is given, the helper-script
"/etc/init.d/startx" is created during the bootprocess (via
grml-autoconfig).

That means, that if the booptions "startx" is not given, the
helper-script is not created and tty6/vt6 should not try to start X but
should just start a grml-user-shell.

Related to grml/grml#20