### PR TITLE
Get rid of grml-runtty

### DIFF
--- a/etc/grml/fai/config/files/etc/systemd/system/getty@tty1.service.d/override.conf/GRMLBASE
+++ b/etc/grml/fai/config/files/etc/systemd/system/getty@tty1.service.d/override.conf/GRMLBASE
@@ -1,11 +1,15 @@
 # This file was deployed via grml-live.
 
 [Service]
-Type=idle
-ExecStart=
-ExecStart=-/sbin/grml-runtty /dev/tty1 /usr/share/grml-scripts/run-welcome root
-# ExecStart=-/sbin/agetty --autologin $USERNAME --noclear %I 38400 linux
+Type=simple
+Restart=always
+StandardInput=tty
+StandardOutput=tty
+TTYPath=/dev/tty1
 TTYVTDisallocate=no
+ExecStart=
+ExecStart=-/usr/share/grml-scripts/run-welcome
 
 [Unit]
+Description=grml-quickconfig on tty1
 After=grml-autoconfig.service

--- a/etc/grml/fai/config/files/etc/systemd/system/getty@tty2.service.d/override.conf/GRMLBASE
+++ b/etc/grml/fai/config/files/etc/systemd/system/getty@tty2.service.d/override.conf/GRMLBASE
@@ -6,6 +6,7 @@ Restart=always
 StandardInput=tty
 StandardOutput=tty
 TTYPath=/dev/tty2
+Environment="SHELL=/bin/zsh"
 ExecStart=
 ExecStart=-/usr/share/grml-scripts/run-screen
 

--- a/etc/grml/fai/config/files/etc/systemd/system/getty@tty2.service.d/override.conf/GRMLBASE
+++ b/etc/grml/fai/config/files/etc/systemd/system/getty@tty2.service.d/override.conf/GRMLBASE
@@ -2,5 +2,12 @@
 
 [Service]
 Type=idle
+Restart=always
+StandardInput=tty
+StandardOutput=tty
+TTYPath=/dev/tty2
 ExecStart=
-ExecStart=-/sbin/grml-runtty /dev/tty2 /usr/share/grml-scripts/run-screen root
+ExecStart=-/usr/share/grml-scripts/run-screen
+
+[Unit]
+Description=screen on tty2

--- a/etc/grml/fai/config/files/etc/systemd/system/getty@tty3.service.d/override.conf/GRMLBASE
+++ b/etc/grml/fai/config/files/etc/systemd/system/getty@tty3.service.d/override.conf/GRMLBASE
@@ -6,6 +6,7 @@ Restart=always
 StandardInput=tty
 StandardOutput=tty
 TTYPath=/dev/tty3
+Environment="SHELL=/bin/zsh"
 ExecStart=
 ExecStart=-/usr/share/grml-scripts/run-screen
 

--- a/etc/grml/fai/config/files/etc/systemd/system/getty@tty3.service.d/override.conf/GRMLBASE
+++ b/etc/grml/fai/config/files/etc/systemd/system/getty@tty3.service.d/override.conf/GRMLBASE
@@ -2,5 +2,12 @@
 
 [Service]
 Type=idle
+Restart=always
+StandardInput=tty
+StandardOutput=tty
+TTYPath=/dev/tty3
 ExecStart=
-ExecStart=-/sbin/grml-runtty /dev/tty3 /usr/share/grml-scripts/run-screen root
+ExecStart=-/usr/share/grml-scripts/run-screen
+
+[Unit]
+Description=screen on tty3

--- a/etc/grml/fai/config/files/etc/systemd/system/getty@tty4.service.d/override.conf/GRMLBASE
+++ b/etc/grml/fai/config/files/etc/systemd/system/getty@tty4.service.d/override.conf/GRMLBASE
@@ -6,6 +6,7 @@ Restart=always
 StandardInput=tty
 StandardOutput=tty
 TTYPath=/dev/tty4
+Environment="SHELL=/bin/zsh"
 User=$USERNAME
 ExecStart=
 ExecStart=-/usr/share/grml-scripts/run-screen

--- a/etc/grml/fai/config/files/etc/systemd/system/getty@tty4.service.d/override.conf/GRMLBASE
+++ b/etc/grml/fai/config/files/etc/systemd/system/getty@tty4.service.d/override.conf/GRMLBASE
@@ -2,5 +2,13 @@
 
 [Service]
 Type=idle
+Restart=always
+StandardInput=tty
+StandardOutput=tty
+TTYPath=/dev/tty4
+User=$USERNAME
 ExecStart=
-ExecStart=-/sbin/grml-runtty /dev/tty4 /usr/share/grml-scripts/run-screen $USERNAME
+ExecStart=-/usr/share/grml-scripts/run-screen
+
+[Unit]
+Description=screen ($USERNAME) on tty4


### PR DESCRIPTION
What once was done by grml-runtty can be now be accomplished by systemd.

That said, there is a weird behavior when starting GNU/screen via
"run-screen". When started via grml-runtty screen runs zsh, but
when started directly via systemd screen runs /bin/sh (= dash).

The reason for that is, that the SHELL variable is empty when called
directly via systemd whereas SHELL=/bin/zsh when started via
grml-runtty. I could not figure out why but a solution would be to set
the "Environment"-option in the systemd-unit which is proposed in a
separate commit.

(partly) fixes grml/grml#14