### PR TITLE
Update bootprompt / cheatcodes documentation

### DIFF
--- a/templates/GRML/grml-cheatcodes.txt
+++ b/templates/GRML/grml-cheatcodes.txt
@@ -128,10 +128,6 @@ grml live-media-path=/live/grml...  Sets the path to the live filesystem on the 
                                     By default, it is set to /live/$GRML_FLAVOUR/ (where $GRML_FLAVOUR
                                     is corresponding to grml64-full, grml32-full, grml64-small,...
                                     [Note: this option is mandatory since release 2011.12]
-grml nostats                        Don't send any information to the Grml project at startup.
-                                    Parameters sent are Grml version, if the cpu supports 64bit,
-                                    anonymized boot parameters and boot source (remote or local).
-                                    [Note: only available since release 2011.12]
 grml module=grml                    Instead of using the default "$name.module" another file can
                                     be specified without the extension ".module"; it should be placed
                                     on "/live" directory of the live medium

--- a/templates/GRML/grml-cheatcodes.txt
+++ b/templates/GRML/grml-cheatcodes.txt
@@ -1,10 +1,11 @@
       CHEATCODES AND HINTS FOR GRML
 ==============================================================================
 
-These options work from the (isolinux/grub) bootprompt of Grml based (live) systems.
+Isolinux bootprompt options:
+----------------------------
 
-The following kernel options are available (do NOT use them as 'grml $OPTION',
-use them as '$OPTION'!):
+These options work from the isolinux bootprompt of Grml based (live) systems.
+(Do NOT use them as 'grml $OPTION', use them as '$OPTION'!):
 
 grml                                Use default settings (same as just pressing return)
 grml2ram                            Copy Grml's squashfs file to RAM and

--- a/templates/boot/isolinux/addon_10_grub2.cfg
+++ b/templates/boot/isolinux/addon_10_grub2.cfg
@@ -1,4 +1,4 @@
-label grub2
+label grub
   menu label Run Bootloader Grub^2
   kernel /boot/addons/mboot.c32 /boot/grub/grub.img
 


### PR DESCRIPTION
The stats feature was removed, therefore we also do not need the nostats
option anymore.

The stats feature was removed in grml-autconfig-commit# 7138a24fb

Partly fixes grml/grml#9