### PR TITLE
add placeholder and explanation inviting local patches to isolinux.cfg

### DIFF
--- a/templates/boot/isolinux/isolinux.cfg
+++ b/templates/boot/isolinux/isolinux.cfg
@@ -76,6 +76,26 @@ timeout 300
 # use this to control the bootup via a serial port:
 # serial 0 9600
 
+# following is a placeholder just in case you want to patch your own startup
+# options right into the grml ISO. Feel free to use a hex editor like dhex to
+# adapt this part of the file inside the ISO to your needs. You can search for
+# the string a8bd612867ae71d0b17f9d33f80f61ab261aa354 in the ISO file binary to
+# find the right place
+
+# the following are 10 lines of 70 characters
+######################################################################
+######################################################################
+######################################################################
+######################################################################
+######################################################################
+######################################################################
+######################################################################
+######################################################################
+######################################################################
+######################################################################
+
 # finally either include 'console.cfg' for console based bootsplash
 # or 'vesamenu.cfg' for graphic menu version of bootsplash (adjusted
 # automatically in build process via grml-live):
+
+


### PR DESCRIPTION
this closes grml/grml-live #45

This is unfortunately completely untested, since to multiple issues, one
of them being grml/grml-live #44 and grml/grml-live #46 are still
unaddressed, I cannot currently reliably build grml images. As it is a
comment-only patch, this can be safely applied and I'll happily test a
daily image afterwards.