### PR TITLE
Use stretch-backports instead of jessie-backports for stable

### DIFF
--- a/etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_STABLE
+++ b/etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_STABLE
@@ -7,5 +7,5 @@
   deb-src http://security.debian.org/ stable/updates main contrib
 
 # backports:
-  deb     http://ftp.debian.org/debian/ jessie-backports main contrib non-free
-  deb-src http://ftp.debian.org/debian/ jessie-backports main contrib non-free
+  deb     http://ftp.debian.org/debian/ stretch-backports main contrib non-free
+  deb-src http://ftp.debian.org/debian/ stretch-backports main contrib non-free


### PR DESCRIPTION
I assume that Debian stable should track Stretch in grml-live so then we need to track stretch-backports instead of jessie-backports for the DEBIAN_STABLE apt source file.