### PR TITLE
Remove genisoimage from dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,7 @@ Depends: bc,
          rsync,
          squashfs-tools (>= 1:4.2-0~bpo60),
          syslinux,
-         xorriso | genisoimage,
+         xorriso,
          ${misc:Depends}
 Recommends: grml-live-db,
             grub-pc-bin,


### PR DESCRIPTION
When running grml-live with genisoimage (9:1.1.11-3+b2) on Debian/stretch the
following error is shown:

```
# ./grml-live -s sid -a amd64 -c GRMLBASE,GRML_SMALL,AMD64 -t $(pwd)/templates/ -o /dev/shm/grml-live
  [...]
    [*] Finished execution of stage 'squashfs'
    [*] Forcing rebuild of ISO because files on ISO have been modified.
    [*] Using genisoimage to build ISO.
  genisoimage: -i option no longer supported.
  stat: cannot stat '/dev/shm/grml-live/grml_isos/grml_0.0.1.iso': No such file or directory
    [!] Error: there was a critical error executing stage 'iso build
```

Closes: grml/grml-live#65