### PR TITLE
Update cheatcodes to clarify hardware clock and timezone defaults

### DIFF
--- a/templates/GRML/grml-cheatcodes.txt
+++ b/templates/GRML/grml-cheatcodes.txt
@@ -40,10 +40,9 @@ Regional settings:
 grml lang=at|de|cn|da|es|fr|it      Specify language ($LANG, $LC_ALL, $LANGUAGE - utf8) + keyboard
 grml lang=nl|pl|ru|sk|tr|tw|us      Specify language ($LANG, $LC_ALL, $LANGUAGE - utf8) + keyboard
 grml lang=$LANG-iso                 Activate $LANG (use like in lines above) with iso-mode instead of utf8
-grml gmt                            Use GMT-based time (UTC=yes)
-grml utc                            Use Coordinated Universal Time (UTC=yes)
-grml localtime                      Use local time (UTC=no)
-grml tz=Europe/Vienna               Use specified timezone for TZ
+grml utc|gmt                        Hardware Clock is set to Coordinated Universal Time (UTC)
+grml localtime                      Hardware Clock is set to local time (LOCAL), this is the default
+grml tz=Europe/Vienna               Use specified timezone for TZ, defaults to TZ=UTC
 grml keyboard=us xkeyboard=us       Use different keyboard layout (text-console/X)
 
 Configuration settings:


### PR DESCRIPTION
While debugging grml/grml#61, it was unclear for me what the expected
behavior should be. Grml defaults to LOCAL (in /etc/adjtime) which
means that Hardware Clock is expected to be set in local time (which is
usually the case on Windows only systems).

The time zone defaults to UTC.