### PR TITLE
Set up Unicode/UTF8 via console-setup

### DIFF
--- a/etc/grml/fai/config/files/etc/systemd/system-preset/10-grml.preset/GRMLBASE
+++ b/etc/grml/fai/config/files/etc/systemd/system-preset/10-grml.preset/GRMLBASE
@@ -4,6 +4,7 @@
 enable getty@.service
 
 # enable grml-specific services
+enable console-setup.service
 enable gpm.service
 enable grml-autoconfig.service
 enable debug-shell.service

--- a/etc/grml/fai/config/files/etc/systemd/system/grml-boot.target/GRMLBASE
+++ b/etc/grml/fai/config/files/etc/systemd/system/grml-boot.target/GRMLBASE
@@ -3,7 +3,7 @@
 [Unit]
 Description=Grml Live System
 Documentation=man:systemd.special(7)
-Requires=getty.target systemd-user-sessions.service systemd-logind.service basic.target
+Requires=getty.target systemd-user-sessions.service systemd-logind.service basic.target console-setup.service
 Conflicts=rescue.service rescue.target
 After=rescue.service rescue.target
 AllowIsolate=yes

--- a/etc/grml/fai/config/scripts/GRMLBASE/26-console-setup
+++ b/etc/grml/fai/config/scripts/GRMLBASE/26-console-setup
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Filename:      ${GRML_FAI_CONFIG}/config/scripts/GRMLBASE/26-console-setup
+# Purpose:       console-setup (utf8) configuration of the live system
+# Authors:       grml-team (grml.org), (c) Darshaka Pathirana <dpat@syn-net.org>
+# Bug-Reports:   see http://grml.org/bugs/
+# License:       This file is licensed under the GPL v2 or any later version.
+################################################################################
+
+set -u
+set -e
+
+if $ROOTCMD dpkg --list console-setup 2>&1 | grep -q '^ii' ; then
+  if [ -e $target/etc/default/console-setup ]; then
+    $ROOTCMD sed -i -e "s|^ *ACTIVE_CONSOLES=.*|ACTIVE_CONSOLES=\"/dev/tty\{1..12\}\"|" /etc/default/console-setup
+    $ROOTCMD sed -i -e "s|^ *CHARMAP=.*|CHARMAP=\"UTF-8\"|" /etc/default/console-setup
+  fi
+fi
+
+## END OF FILE #################################################################
+# vim:ft=sh expandtab ai tw=80 tabstop=4 shiftwidth=2


### PR DESCRIPTION
This change fixes a couple of problems where strange characters were
shown at the console on input (like when typing german umlauts) and on
output (e.g. `pstree`).

We tried to fix that by changing the order in which we set up the fonts,
then run loadkeys and finally invoked unicode_start via grml-autoconfig
(see: grml/grml-autoconfig@c820a66). But this only changed the behavior
on tty1, the other consoles still had problems when trying to display
unicode characters.

I believe that the "activate unicode console if running within utf8
environment" code in the config_language() function in grml-autoconfig
is not needed after applying this change (i.e. we then do not have to run
unicode_start in grml-autoconfig anymore). But this needs testing.

One more note regarding the "Requires:"-line in `grml-boot.target`: I am
not quite sure why I had to add `console-setup.service` in there,
although the service is enabled via `10-grml.preset`. But without adding
`console-setup.service` to the "Requires:"-line the service is not
started on boot. I suspect this has to do with the fact that the service
has `WantedBy=multi-user.target` in the `[Install]` section, but so has
`rsyslog.service` which starts fine (the other enabled services have
other dependencies). This needs investiagation.

Thanks for feedback: Michael Schierl (@schierlm) and @qlplq
Relates to: grml/grml#101
Closes: grml/grml-autoconfig#9, grml/grml#50