### PR TITLE
Documentation correction - when running from git ...

### DIFF
--- a/docs/grml-live.txt
+++ b/docs/grml-live.txt
@@ -812,6 +812,7 @@ Usage example:
 
     # export GRML_FAI_CONFIG=$(pwd)/etc/grml/fai
     # export SCRIPTS_DIRECTORY=$(pwd)/scripts
+    # export TEMPLATE_DIRECTORY=$(pwd)/templates
     # ./grml-live -s sid -a amd64 -c GRMLBASE,GRML_FULL,AMD64
 
 [[source]]


### PR DESCRIPTION
Need to set templates directory as well when running from git

You may want to use the "-t $(pwd)/templates" variation like in the README file. I chose the env var to advertise it's availability as well.