### PR TITLE
SW: cryptsetup-initramfs (fix persistence-encryption)

### DIFF
--- a/etc/grml/fai/config/package_config/GRMLBASE
+++ b/etc/grml/fai/config/package_config/GRMLBASE
@@ -4,6 +4,7 @@ busybox
 bzip2
 console-data
 console-setup
+cryptsetup-initramfs
 dbus
 deborphan
 dmidecode


### PR DESCRIPTION
*cryptsetup in initramfs* has been moved to a [separate package](https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=cryptsetup-initramfs), instead of setting `CRYPTSETUP=y` for the default initramfs scripts, since current stable debian *buster*. This is necessary to boot *grml* with `persistence-encryption=luks` as described [here](https://wiki.grml.org/doku.php?id=persistency).