### PR TITLE
Additional software

### DIFF
--- a/etc/grml/fai/config/package_config/GRML_FULL
+++ b/etc/grml/fai/config/package_config/GRML_FULL
@@ -31,6 +31,7 @@ psmisc
 sudo
 sysstat
 sysvinit-utils
+tree
 tzdata
 util-linux
 

--- a/etc/grml/fai/config/package_config/GRML_FULL
+++ b/etc/grml/fai/config/package_config/GRML_FULL
@@ -63,6 +63,7 @@ iotop
 lsscsi
 mpt-status
 multipath-tools
+ncdu
 nocache
 nvme-cli
 scsitools


### PR DESCRIPTION
add `tree` and `ncdu` to `GRML_FULL`. IMHO they are quite useful and donot consume much space (might be candidates for `GRML_SMALL` as well?!).