### PR TITLE
Add boot option legacynet (Legacy Network Interface Names)

### DIFF
--- a/templates/GRML/grml-cheatcodes.txt
+++ b/templates/GRML/grml-cheatcodes.txt
@@ -15,6 +15,7 @@ fb1280x1024                         Use fixed framebuffer graphics (1)
 fb1024x768                          Use fixed framebuffer graphics (2) [notice: Grml's default]
 fb800x600                           Use fixed framebuffer graphics (3)
 nofb                                Disable framebuffer
+legacynet                           Use Legacy Network Interface Names
 floppy                              Boot from floppydisk
 hd / hd1 / hd2 / hd3                Boot from (local) primary / secondary /... harddisk
 debug                               Get shells during process of booting for debugging

--- a/templates/boot/grub/%SHORT_NAME%_options.cfg
+++ b/templates/boot/grub/%SHORT_NAME%_options.cfg
@@ -1,4 +1,20 @@
 submenu "%GRML_NAME% - advanced options  ->" --class=submenu {
+menuentry "%GRML_NAME% - Legacy Network Interface Names" {
+    set gfxpayload=keep
+    echo 'Loading kernel...'
+    linux   /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% "${loopback}" "${kernelopts}" nomce net.ifnames=0 
+    echo 'Loading initrd...'
+    initrd /boot/%SHORT_NAME%/initrd.img
+}
+
+menuentry "%GRML_NAME% - Predictable Network Interface Names" {
+    set gfxpayload=keep
+    echo 'Loading kernel...'
+    linux   /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% "${loopback}" "${kernelopts}" nomce 
+    echo 'Loading initrd...'
+    initrd /boot/%SHORT_NAME%/initrd.img
+}
+
 menuentry "%GRML_NAME% - enable persistency mode" {
     set gfxpayload=keep
     echo 'Loading kernel...'

--- a/templates/boot/isolinux/f3
+++ b/templates/boot/isolinux/f3
@@ -5,6 +5,7 @@
  grml   [options, list via F4-F10]                          boot Grml default  
  memtest                                     memtest86+ (memory test program)  
  fb1280x1024, fb1024x768 or fb800x600   use framebuffer mode (e.g. notebooks)  
+ legacynet                                 use legacy network interface names  
  nofb                                                disable framebuffer mode  
  hd / hd1 / hd2 / hd3 / floppy       boot from (1st/2nd/..) harddisk / floppy  
  serial                                               activate serial console  
@@ -14,7 +15,6 @@
  grub                                    boot GRand Unified Bootloader (GRUB)  
  dos                                                         boot FreeDOS 1.0  
  hdt                                             boot Hardware Detection Tool  
-                                                                               
                                                                                
  A list with all supported boot options can be found on the CD at              
  /run/live/medium/grml/*/grml-cheatcodes.txt                                   

--- a/templates/boot/isolinux/grml.cfg
+++ b/templates/boot/isolinux/grml.cfg
@@ -13,6 +13,24 @@ label debug
                                         bootup sequence.
   endtext
 
+label legacynet
+  menu label %GRML_NAME% - Do not use Predictable Network Interface Names (^Legacy Network Interface Names)
+  kernel /boot/%SHORT_NAME%/vmlinuz
+  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce net.ifnames=0
+
+  text help
+                                        Boot Grml without Predictable Network Interface Names
+  endtext
+
+label pnet
+  menu label %GRML_NAME% - Use Predictable Network Interface Names
+  kernel /boot/%SHORT_NAME%/vmlinuz
+  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce
+
+  text help
+                                        Boot Grml with Predictable Network Interface Names
+  endtext
+
 label nofb
   menu label %GRML_NAME% - Dis^able Framebuffer
   kernel /boot/%SHORT_NAME%/vmlinuz


### PR DESCRIPTION
Grml should use Predictable Network Interface Names by default.

To make that switch easier we added two new boot options:
"legacynet" and "pnet".

The boot option "legacynet" provides an easy way to use the old (legacy)
network interface names by adding "net.ifnames=0" to the kernel
command line, see: https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/

The kernel command line options "net.ifnames=0" currently in every other
boot option (except "pnet") but will be removed as soon as we switch to
Predictable Network Interface Names by default.

The boot options "pnet" is temporary (and therefor not documented
grml-cheatcodes.txt and in the isolinux help page) as this should just
help us boot Grml with Predictable Network Interface Names enabled.
As this will be our new default anyway, this boot options will be
removed as soon as the transition is completed.

See: grml/grml#127