### PR TITLE
Add boot option pnet (Predictable Network Interface Names)

### DIFF
--- a/templates/boot/grub/%SHORT_NAME%_options.cfg
+++ b/templates/boot/grub/%SHORT_NAME%_options.cfg
@@ -1,4 +1,12 @@
 submenu "%GRML_NAME% - advanced options  ->" --class=submenu {
+menuentry "%GRML_NAME% - Enable Predictable Network Interface Names" {
+    set gfxpayload=keep
+    echo 'Loading kernel...'
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" "${kernelopts}" 
+    echo 'Loading initrd...'
+    initrd /boot/%SHORT_NAME%/initrd.img
+}
+
 menuentry "%GRML_NAME% - enable persistency mode" {
     set gfxpayload=keep
     echo 'Loading kernel...'

--- a/templates/boot/isolinux/grml.cfg
+++ b/templates/boot/isolinux/grml.cfg
@@ -13,6 +13,15 @@ label debug
                                         bootup sequence.
   endtext
 
+label pnet
+  menu label %GRML_NAME% - Enable Predictable ^Network Interface Names
+  kernel /boot/%SHORT_NAME%/vmlinuz
+  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce 
+
+  text help
+                                        Boot Grml with Predictable Network Interface Names.
+  endtext
+
 label nofb
   menu label %GRML_NAME% - Dis^able Framebuffer
   kernel /boot/%SHORT_NAME%/vmlinuz


### PR DESCRIPTION
Grml should use Predictable Network Interface Names by default.

To make that switch easier we added a new boot options "pnet".

The kernel command line options "net.ifnames=0" is currently in every
boot option (except "pnet") but should be removed when Predictable
Network Interface Names works for us.

See: grml/grml#127