### PR TITLE
GRUB: remove erroneous quotes around kernelopts

### DIFF
--- a/templates/boot/grub/%SHORT_NAME%_default.cfg
+++ b/templates/boot/grub/%SHORT_NAME%_default.cfg
@@ -1,7 +1,7 @@
 menuentry "%GRML_NAME% - release %VERSION% (default)" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux   /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% "${loopback}" "${kernelopts}" nomce net.ifnames=0 
+    linux   /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% "${loopback}" ${kernelopts} nomce net.ifnames=0 
     echo 'Loading initrd...'
     initrd  /boot/%SHORT_NAME%/initrd.img
 }

--- a/templates/boot/grub/%SHORT_NAME%_options.cfg
+++ b/templates/boot/grub/%SHORT_NAME%_options.cfg
@@ -2,7 +2,7 @@ submenu "%GRML_NAME% - advanced options  ->" --class=submenu {
 menuentry "%GRML_NAME% - enable Predictable Network Interface Names" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" "${kernelopts}" 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -10,7 +10,7 @@ menuentry "%GRML_NAME% - enable Predictable Network Interface Names" {
 menuentry "%GRML_NAME% - enable persistency mode" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" "${kernelopts}" persistence 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} persistence 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -18,7 +18,7 @@ menuentry "%GRML_NAME% - enable persistency mode" {
 menuentry "%GRML_NAME% - copy Grml to RAM" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" "${kernelopts}" toram=%GRML_NAME%.squashfs 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} toram=%GRML_NAME%.squashfs 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -26,7 +26,7 @@ menuentry "%GRML_NAME% - copy Grml to RAM" {
 menuentry "%GRML_NAME% - copy whole medium to RAM" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" "${kernelopts}" toram 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} toram 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -34,7 +34,7 @@ menuentry "%GRML_NAME% - copy whole medium to RAM" {
 menuentry "%GRML_NAME% - start X by default" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" "${kernelopts}" startx 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} startx 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -42,7 +42,7 @@ menuentry "%GRML_NAME% - start X by default" {
 menuentry "%GRML_NAME% - disable framebuffer" {
     set gfxpayload=text
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" "${kernelopts}" video=ofonly radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} video=ofonly radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -50,7 +50,7 @@ menuentry "%GRML_NAME% - disable framebuffer" {
 menuentry "%GRML_NAME% - disable Kernel Mode-Setting" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" "${kernelopts}" radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -58,7 +58,7 @@ menuentry "%GRML_NAME% - disable Kernel Mode-Setting" {
 menuentry "%GRML_NAME% - forensic mode" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" "${kernelopts}" read-only nofstab noraid nodmraid nolvm noautoconfig noswap raid=noautodetect 
+    linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} read-only nofstab noraid nodmraid nolvm noautoconfig noswap raid=noautodetect 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -66,7 +66,7 @@ menuentry "%GRML_NAME% - forensic mode" {
 menuentry "%GRML_NAME% - debug mode" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" "${kernelopts}" initcall verbose debug=vc systemd.log_level=debug systemd.log_target=kmsg log_buf_len=1M 
+    linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} initcall verbose debug=vc systemd.log_level=debug systemd.log_target=kmsg log_buf_len=1M 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -74,7 +74,7 @@ menuentry "%GRML_NAME% - debug mode" {
 menuentry "%GRML_NAME% - serial mode" {
     set gfxpayload=text
     echo 'Loading kernel...'
-    linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" "${kernelopts}" video=vesafb:off console=tty1 console=ttyS0,9600n8 
+    linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} video=vesafb:off console=tty1 console=ttyS0,9600n8 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }


### PR DESCRIPTION
kernelopts are used by grml-rescueboot to communicate kernel arguments from the host's grub to the grub within the grml ISO. E.g., the host grub boot entry will contains something like:

````
kernelopts=" arg1 arg2 blacklist=foo etc "
export kernelopts
````

Currently, grub within the grml ISO will pass this entire string as one single argument to the kernel. Remove the quotes such that the arguments are interpreted as intended.

Fixes https://github.com/grml/grml-rescueboot/issues/5