### PR TITLE
GRUB: drop loopback usage for balder10/FreeDOS.

### DIFF
--- a/templates/boot/grub/addons.cfg
+++ b/templates/boot/grub/addons.cfg
@@ -40,8 +40,7 @@ if [ "${grub_platform}" != "efi" ] ; then
     menuentry "FreeDOS" {
         insmod linux16
         linux16  /boot/addons/memdisk
-        loopback balder /boot/addons/balder10.imz
-        initrd16 (balder)+2880
+        initrd16 /boot/addons/balder10.imz
     }
 
     if [ ${iso_path} ] ; then


### PR DESCRIPTION
Looks like a relic from the bad, old days.

It's certainly not needed any longer, since the initrd16 command can
load the file just fine and newer grub versions are not able to load
compressed files in such a manner, since the length (+2880) refers to
the uncompressed size. Grub will see that the file is smaller than that
and error out. If we were to give it the compressed size, decompression
would fail due to the buffer being too small.