### PR TITLE
grml-live: isohybrid is the default, reflect that.

### DIFF
--- a/docs/grml-live.txt
+++ b/docs/grml-live.txt
@@ -347,11 +347,12 @@ ISO size.
 defining a Grml system. Important parts of the buildprocess are specified in
 this class as well, so unless you have a really good reason you should always
 use this class. Please be aware that using *just* the GRMLBASE class won't be
-enough, because the kernel packages (e.g. linux-image-*) are chosen in further
-GRML_* classes (to provide maximum flexibility with kernel selection). If you
-don't want to use the existing GRML_FULL or GRML_SMALL classes, define your own
-CLASS file choosing the kernel package you want to use (and don't forget to
-include your CLASS in the arguments of grml-live's -c... command line option).
+enough, because the kernel packages (e.g. linux-image-pass:[*]) are chosen in
+further GRML_pass:[*] classes (to provide maximum flexibility with kernel
+selection). If you don't want to use the existing GRML_FULL or GRML_SMALL
+classes, define your own CLASS file choosing the kernel package you want to use
+(and don't forget to include your CLASS in the arguments of grml-live's `-c...`
+command line option).
 
 * GRML_FULL: full featured Grml, also known as the "normal", full grml as
 introduced in December 2011 (~750 ISO size).

--- a/docs/grml-live.txt
+++ b/docs/grml-live.txt
@@ -685,14 +685,14 @@ That's it.  All downloaded files will be cached in /var/cache/apt-cacher-ng then
 How do I revert the manifold feature from an ISO?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The so called manifold feature Grml ISOs use by default allows one to use the same
-ISO for CD boot and USB boot. If you notice any problems when booting just
-revert the manifold feature running:
+The so-called manifold feature Grml ISOs can, but by default do not, use allows
+one to use the same ISO for CD boot and USB boot. If you notice any problems
+when booting manifold-crafted media, just revert the manifold feature running:
 
   % dd if=/dev/zero of=grml.iso bs=512 count=1 conv=notrunc
 
 To switch from manifold to isohybrid mode (an alternative approach provided by
-syslinux) then just execute:
+syslinux, used by default for official Grml images) then just execute:
 
   % isohybrid grml.iso
 

--- a/etc/grml/grml-live.conf
+++ b/etc/grml/grml-live.conf
@@ -152,10 +152,12 @@
 # boot the CD using normal el torito mode or copy it to USB device
 # *without* having to run grml2usb (like: 'dd if=grml.iso of=/dev/sdX')
 # - working both with the same ISO
+# Note that the manifold method is currently not be compatible with UEFI
+# setups.
 # HYBRID_METHOD='disable'   # do not create a hybrid ISO
-# HYBRID_METHOD='isohybrid' # use isohybrid from SYSLINUX
+# HYBRID_METHOD='isohybrid' # use isohybrid from SYSLINUX (default)
 # HYBRID_METHOD='grub2'     # use manifold with GRUB 2
-# HYBRID_METHOD='manifold'  # use manifold with ISOLINUX (default)
+# HYBRID_METHOD='manifold'  # use manifold with ISOLINUX
 
 # Secure Boot method that should be used (amd64 only).
 # If unset defaults to "disabled" (which means no Secure Boot will be present)


### PR DESCRIPTION
While isolinux's "manifold" mode was used by default a long time ago,
Grml switched to the isohybrid method in late 2011, mostly due to manifold
being incompatible with UEFI systems.

Documentation and configuration files weren't updated at that time,
though.

Do it now.