### PR TITLE
grml-live: clean up MIRROR_DIRECTORY if provided.

### DIFF
--- a/grml-live
+++ b/grml-live
@@ -180,7 +180,10 @@ umount_all() {
    fi
 
    umount "${CHROOT_OUTPUT}/grml-live/sources/" 2>/dev/null || /bin/true
-   [ -n "$MIRROR_DIRECTORY" ] && umount "${CHROOT_OUTPUT}/${MIRROR_DIRECTORY}"
+   if [ -n "${MIRROR_DIRECTORY}" ]; then
+     umount "${CHROOT_OUTPUT}/${MIRROR_DIRECTORY}"
+     rmdir -p "${CHROOT_OUTPUT}/${MIRROR_DIRECTORY}"
+   fi
 }
 # }}}
 


### PR DESCRIPTION
Won't actually cause harm, but a spurious empty directory in the resulting squashfs root image looks weird.