### PR TITLE
Exclude /var/lib/dkms/* from squashfs

### DIFF
--- a/etc/grml/fai/config/grml/squashfs-excludes
+++ b/etc/grml/fai/config/grml/squashfs-excludes
@@ -1,3 +1,4 @@
 run/*
 var/run/*
 var/lock/*
+var/lib/dkms/*

--- a/etc/grml/fai/config/package_config/ZFS
+++ b/etc/grml/fai/config/package_config/ZFS
@@ -1,0 +1,7 @@
+PACKAGES install
+
+build-essential
+zfs-dkms
+zfsutils-linux
+dwarves
+

--- a/etc/grml/fai/config/package_config/ZFS
+++ b/etc/grml/fai/config/package_config/ZFS
@@ -1,7 +1,9 @@
 PACKAGES install
 
 build-essential
+# pahole(1), provided by the dwwarves package in older Debian releases and the pahole package in sid as of 2022-08, can be needed to build kernel modules (depending on kernel config?)
+# TODO: add a script that removes it once dkms install succeeded so that it doesn't bloat the iso
+dwarves
 zfs-dkms
 zfsutils-linux
-dwarves
 

--- a/etc/grml/fai/config/scripts/GRMLBASE/18-timesetup
+++ b/etc/grml/fai/config/scripts/GRMLBASE/18-timesetup
@@ -13,7 +13,7 @@ set -e
 # by default it's set to UTC=no
 if [ -n "$UTC" ] && [ "$UTC" = "yes" ] ; then
    echo "UTC is set to 'yes', setting hwclock parameter UTC"
-   sed -i "s/^LOCAL/UTC/" "${target}/etc/adjtime"
+   [ -e "${target}/etc/adjtime" ] && sed -i "s/^LOCAL/UTC/" "${target}/etc/adjtime"
 fi
 
 # default timezone settings


### PR DESCRIPTION
These files and directories are created by dkms while it builds modules on
demand and are only relevant during the module build/installation process.
The .ko files are then installed in /lib/modules; shipping /var/lib/dkms/*
inside the squashfs only takes up space without providing a tangible
benefit.