### PR TITLE
Provide workaround for kmod/initramfs-tools issue with NFS/netboot

### DIFF
--- a/etc/grml/fai/config/files/etc/initramfs-tools/modules/GRMLBASE
+++ b/etc/grml/fai/config/files/etc/initramfs-tools/modules/GRMLBASE
@@ -1,0 +1,28 @@
+# This file was deployed via grml-live's
+# ${GRML_FAI_CONFIG}/config/scripts/GRMLBASE/80-initramfs script, using
+# ${GRML_FAI_CONFIG}/config/files/etc/initramfs-tools/modules/GRMLBASE
+################################################################################
+# List of modules that you want to include in your initramfs.
+# They will be loaded at boot time in the order below.
+#
+# Syntax:  module_name [args ...]
+#
+# You must run update-initramfs(8) to effect this change.
+#
+# Examples:
+#
+# raid1
+# sd_mod
+
+# workaround for broken netboot images, see
+# https://bugs.debian.org/1022172 +
+# https://github.com/grml/grml/issues/192
+auth_rpcgss
+grace
+lockd
+nfs
+nfs_acl
+nfsv3
+rpcrdma
+rpcsec_gss_krb5
+sunrpc

--- a/etc/grml/fai/config/scripts/GRMLBASE/80-initramfs
+++ b/etc/grml/fai/config/scripts/GRMLBASE/80-initramfs
@@ -11,6 +11,7 @@ set -e
 
 fcopy -v /etc/initramfs-tools/hooks/000-udev-shutup
 fcopy -v /etc/initramfs-tools/conf.d/xz-compress
+fcopy -v /etc/initramfs-tools/modules
 
 if ! [ -f $target/usr/share/initramfs-tools/scripts/live ] ; then
   echo "Error: live-boot/-initramfs does not seem to be present, can not create initramfs. Exiting.">&2


### PR DESCRIPTION
As of kmod v30+20220905-1 (as present in current Debian/bookworm), the output of the "modprobe --all --set-version="..." --ignore-install --quiet --show-depends nfs" command line, as used by initramfs-tools to identify dependencies of the the nfs module, changed. See https://bugs.debian.org/1022172 for further details.

Until the situation between kmod, /lib/modprobe.d/50-nfs.conf and initramfs-tools has been resolved, let's provide a workaround, so our initramfs includes the required modules for netboot usage with NFS.

Thanks: András Korn
Closes: https://github.com/grml/grml/issues/192