### PR TITLE
Set SHELL variable in tty1

### DIFF
--- a/etc/grml/fai/config/files/etc/systemd/system/getty@tty1.service.d/override.conf/GRMLBASE
+++ b/etc/grml/fai/config/files/etc/systemd/system/getty@tty1.service.d/override.conf/GRMLBASE
@@ -7,6 +7,7 @@ StandardInput=tty
 StandardOutput=tty
 TTYPath=/dev/tty1
 TTYVTDisallocate=no
+Environment="SHELL=/bin/zsh"
 ExecStart=
 ExecStart=-/usr/share/grml-scripts/run-welcome
 


### PR DESCRIPTION
The SHELL variable is not set in our tty1 when `run-welcome` is called (instead of agetty(8) + login(1)).

So, when invoking `screen` we end up in `/bin/sh` instead of a zsh shell.

We also had the same problem for tty2 - tty4 and fixed it in grml/grml-live@6871972 (to fix grml/grml#14).

We now use the same approach to fix tty1 although the SHELL variable should (most probably) be set in `run-welcome` and `run-screen` itself.

Issue: grml/grml#135