### PR TITLE
Create a bigger image for the filesystem which holds the EFI binaries

### DIFF
--- a/grml-live
+++ b/grml-live
@@ -925,7 +925,7 @@ grub_setup() {
       bailout 50
     fi
 
-    dd if=/dev/zero of="${CHROOT_OUTPUT}/${EFI_IMG}" bs=4M count=1 2>/dev/null || bailout 50
+    dd if=/dev/zero of="${CHROOT_OUTPUT}/${EFI_IMG}" bs=8M count=1 2>/dev/null || bailout 50
     mkfs.vfat -n GRML "${CHROOT_OUTPUT}/${EFI_IMG}" >/dev/null || bailout 51
     mmd -i "${CHROOT_OUTPUT}/${EFI_IMG}" ::EFI || bailout 52
     mmd -i "${CHROOT_OUTPUT}/${EFI_IMG}" ::EFI/BOOT || bailout 52
@@ -1004,7 +1004,7 @@ grub_setup() {
       bailout 50
     fi
 
-    dd if=/dev/zero of="${CHROOT_OUTPUT}/${EFI_IMG}" bs=4M count=1 2>/dev/null || bailout 50
+    dd if=/dev/zero of="${CHROOT_OUTPUT}/${EFI_IMG}" bs=8M count=1 2>/dev/null || bailout 50
     mkfs.vfat -n GRML "${CHROOT_OUTPUT}/${EFI_IMG}" >/dev/null || bailout 51
     mmd -i "${CHROOT_OUTPUT}/${EFI_IMG}" ::EFI || bailout 52
     mmd -i "${CHROOT_OUTPUT}/${EFI_IMG}" ::EFI/BOOT || bailout 52


### PR DESCRIPTION
Due to a missing full rebuild I have skipped over the fact that the new EFI binaries are larger than 4Mb totally.

```
du /usr/share/grml-live/templates/EFI/debian/BOOT/
4696	/usr/share/grml-live/templates/EFI/debian/BOOT/
```

If one have commit 721a4734446cf9e1dd9b4e4c1360c22821b86986 then the build fails with the unhelpful `disk full` message.

Luckily the `bailout` mechanism helps here a lot, it was easy to pinpoint the failing `mcopy` command and track that back to `dd`

Now I have done:
- a full rebuild
- write the resulting image with `grml2usb` to a USB stick
- boot from that USB stick with Secure Boot enabled

Everything was as it should be.