### PR TITLE
grml-cheatcodes.txt: document usage of bootfrom=/dev/disk/by-label* + drop deprecated tohd

### DIFF
--- a/templates/GRML/grml-cheatcodes.txt
+++ b/templates/GRML/grml-cheatcodes.txt
@@ -104,11 +104,12 @@ grml toram=filename.squashfs          Copy the specified file to RAM and run fro
                                       Usage example: grml toram=grml-medium.squashfs
                                       Notice: grml2ram is an alias for this option which
                                       corresponds with the grml flavour settings by default
-grml tohd=/dev/sda1                   Copy Grml's squashfs file to harddisk partition for later
-                                      use via "grml bootfrom=/dev/sda1"
 grml bootfrom=/dev/sda1               Use the squashfs file from directory 'live' of the specified device
-                                      Setup can be done booting 'grml tohd=/dev/sda1' or
-                                      running 'rsync -a --progress /run/live/medium/live /media/sda1/'
+                                      Setup can be done by executing:
+                                        rsync -a --progress /run/live/medium/live /media/sda1/
+                                      NOTE: you can can also use bootfrom=/dev/disk/by-label/yourlabel
+                                      (adjust yourlabel as needed), which should prevent choosing the
+                                      wrong block device (e.g. if more than one disk is present).
 grml bootfrom=removable               Restrict search for the live media to removable type only.
 grml bootfrom=removable-usb           Restrict search for the live media to usb mass storage only.
 grml isofrom=[fs:][/device]/grml.iso  Use specified ISO image for booting.
@@ -122,8 +123,11 @@ grml isofrom=[fs:][/device]/grml.iso  Use specified ISO image for booting.
                                       override the automatic detection, like in "reiserfs:/dev/sda1/grml.iso".
                                       As an example, boot the according grml kernel and initrd using the
                                       bootoptions "boot=live isofrom=btrfs:/dev/vda40/path/to/grml.iso"
-                                      Notice: "fromiso" does the same as "isofrom", it's just there
+                                      NOTE: "fromiso" does the same as "isofrom", it's just there
                                       to prevent any typing errors
+                                      NOTE: you can can also use isofrom=/dev/disk/by-label/yourlabel
+                                      (adjust yourlabel as needed), which should prevent choosing the
+                                      wrong block device (e.g. if more than one disk is present).
 grml findiso=/grml_2010.12.iso        Look for the specified ISO file on all disks where it usually
                                       looks for the .squashfs file (so you don't have to know the device name
                                       as in isofrom=....).


### PR DESCRIPTION
One can use bootfrom=/dev/disk/by-label/yourlabel or also isofrom=/dev/disk/by-label/yourlabel to avoid choosing the wrong block device.

We dropped the tohd feature back in 2016 (see grml-autoconfig commit 0fb27bae), so drop it while at it.

Thanks: Csillag Tamas