### PR TITLE
SW: add toilet to GRML_SMALL + GRML_FULL and lolcat to GRML_FULL

### DIFF
--- a/etc/grml/fai/config/package_config/GRML_FULL
+++ b/etc/grml/fai/config/package_config/GRML_FULL
@@ -346,6 +346,10 @@ stress
 # docs
 man-db
 
+# special terminal output
+lolcat
+toilet
+
 PACKAGES install I386
 # kernel related
 linux-image-686

--- a/etc/grml/fai/config/package_config/GRML_SMALL
+++ b/etc/grml/fai/config/package_config/GRML_SMALL
@@ -108,6 +108,9 @@ xfsprogs
 zip
 zsh
 
+# special terminal output
+toilet
+
 PACKAGES install I386
 linux-image-686
 


### PR DESCRIPTION
Disk space requirements:

* lolcat on grml-small: ~28.5 MB of additional disk space
* toilet on grml-small: ~1800 kB of additional disk space

-> so let's only add toilet to GRML_SMALL

* lolcat on grml-full:  ~152 kB of additional disk space
* toilet on grml-full: ~1800 kB of additional disk space

-> it's about 2MB of additional disk space for GRML_FULL in total,
   so we can add both lolcat and toilet without too much overhead