### PR TITLE
Unify boot options order

### DIFF
--- a/templates/boot/grub/%SHORT_NAME%_options.cfg
+++ b/templates/boot/grub/%SHORT_NAME%_options.cfg
@@ -1,5 +1,5 @@
 submenu "%GRML_NAME% - advanced options  ->" --class=submenu {
-menuentry "%GRML_NAME% - enable Predictable Network Interface Names" {
+menuentry "%GRML_NAME% - Enable Predictable Network Interface Names" {
     set gfxpayload=keep
     echo 'Loading kernel...'
     linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} 
@@ -7,15 +7,15 @@ menuentry "%GRML_NAME% - enable Predictable Network Interface Names" {
     initrd /boot/%SHORT_NAME%/initrd.img
 }
 
-menuentry "%GRML_NAME% - enable persistency mode" {
+menuentry "%GRML_NAME% - Enable SSH (with random password) {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} persistence 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} ssh 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
 
-menuentry "%GRML_NAME% - copy Grml to RAM" {
+menuentry "%GRML_NAME% - Load Grml to RAM" {
     set gfxpayload=keep
     echo 'Loading kernel...'
     linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} toram=%GRML_NAME%.squashfs 
@@ -23,7 +23,7 @@ menuentry "%GRML_NAME% - copy Grml to RAM" {
     initrd /boot/%SHORT_NAME%/initrd.img
 }
 
-menuentry "%GRML_NAME% - copy whole medium to RAM" {
+menuentry "%GRML_NAME% - Load whole medium to RAM" {
     set gfxpayload=keep
     echo 'Loading kernel...'
     linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} toram 
@@ -31,31 +31,7 @@ menuentry "%GRML_NAME% - copy whole medium to RAM" {
     initrd /boot/%SHORT_NAME%/initrd.img
 }
 
-menuentry "%GRML_NAME% - start X by default" {
-    set gfxpayload=keep
-    echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} startx 
-    echo 'Loading initrd...'
-    initrd /boot/%SHORT_NAME%/initrd.img
-}
-
-menuentry "%GRML_NAME% - disable framebuffer" {
-    set gfxpayload=text
-    echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} video=ofonly radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset 
-    echo 'Loading initrd...'
-    initrd /boot/%SHORT_NAME%/initrd.img
-}
-
-menuentry "%GRML_NAME% - disable Kernel Mode-Setting" {
-    set gfxpayload=keep
-    echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset 
-    echo 'Loading initrd...'
-    initrd /boot/%SHORT_NAME%/initrd.img
-}
-
-menuentry "%GRML_NAME% - forensic mode" {
+menuentry "%GRML_NAME% - Forensic Mode" {
     set gfxpayload=keep
     echo 'Loading kernel...'
     linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} read-only nofstab noraid nodmraid nolvm noautoconfig noswap raid=noautodetect 
@@ -63,7 +39,47 @@ menuentry "%GRML_NAME% - forensic mode" {
     initrd /boot/%SHORT_NAME%/initrd.img
 }
 
-menuentry "%GRML_NAME% - debug mode" {
+menuentry "%GRML_NAME% - Persistency Mode" {
+    set gfxpayload=keep
+    echo 'Loading kernel...'
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} persistence 
+    echo 'Loading initrd...'
+    initrd /boot/%SHORT_NAME%/initrd.img
+}
+
+menuentry "%GRML_NAME% - German Settings" {
+    set gfxpayload=keep
+    echo 'Loading kernel...'
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} lang=de 
+    echo 'Loading initrd...'
+    initrd /boot/%SHORT_NAME%/initrd.img
+}
+
+menuentry "%GRML_NAME% - Graphical Mode" {
+    set gfxpayload=keep
+    echo 'Loading kernel...'
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} startx 
+    echo 'Loading initrd...'
+    initrd /boot/%SHORT_NAME%/initrd.img
+}
+
+menuentry "%GRML_NAME% - Disable Framebuffer" {
+    set gfxpayload=text
+    echo 'Loading kernel...'
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} video=ofonly radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset 
+    echo 'Loading initrd...'
+    initrd /boot/%SHORT_NAME%/initrd.img
+}
+
+menuentry "%GRML_NAME% - Disable Kernel Mode-Setting" {
+    set gfxpayload=keep
+    echo 'Loading kernel...'
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset 
+    echo 'Loading initrd...'
+    initrd /boot/%SHORT_NAME%/initrd.img
+}
+
+menuentry "%GRML_NAME% - Debug Mode" {
     set gfxpayload=keep
     echo 'Loading kernel...'
     linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} initcall verbose debug=vc systemd.log_level=debug systemd.log_target=kmsg log_buf_len=1M 
@@ -71,7 +87,7 @@ menuentry "%GRML_NAME% - debug mode" {
     initrd /boot/%SHORT_NAME%/initrd.img
 }
 
-menuentry "%GRML_NAME% - serial mode" {
+menuentry "%GRML_NAME% - Serial Console" {
     set gfxpayload=text
     echo 'Loading kernel...'
     linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} video=vesafb:off console=tty1 console=ttyS0,115200n8 

--- a/templates/boot/isolinux/grml.cfg
+++ b/templates/boot/isolinux/grml.cfg
@@ -2,17 +2,6 @@
 
 # generic ones
 
-label debug
-  menu label %GRML_NAME% - ^Debug Mode
-  kernel /boot/%SHORT_NAME%/vmlinuz
-  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 verbose debug=vc initcall nomce net.ifnames=0 systemd.log_level=debug systemd.log_target=kmsg log_buf_len=1M 
-
-  text help
-                                        Boot Grml in debug mode, which
-                                        activates debug shells during
-                                        bootup sequence.
-  endtext
-
 label pnet
   menu label %GRML_NAME% - Enable Predictable ^Network Interface Names
   kernel /boot/%SHORT_NAME%/vmlinuz
@@ -21,25 +10,6 @@ label pnet
   text help
                                         Boot Grml with Predictable
                                         Network Interface Names.
-  endtext
-
-label nofb
-  menu label %GRML_NAME% - Dis^able Framebuffer
-  kernel /boot/%SHORT_NAME%/vmlinuz
-  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=normal radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset nomce net.ifnames=0 
-
-  text help
-                                        Boot Grml without framebuffer.
-  endtext
-
-label nokms
-  menu label %GRML_NAME% - Disable ^Kernel Mode-Setting
-  kernel /boot/%SHORT_NAME%/vmlinuz
-  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset nomce net.ifnames=0 vga=791 
-
-  text help
-                                        Boot Grml without KMS (Kernel
-                                        Mode Setting).
   endtext
 
 label ssh
@@ -57,6 +27,38 @@ label ssh
                                         ssh=secret).
   endtext
 
+label grml2ram
+  menu label %GRML_NAME% - Load Grml to ^RAM
+  kernel /boot/%SHORT_NAME%/vmlinuz
+  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce net.ifnames=0 toram=%SQUASHFS_NAME% 
+
+  text help
+                                        Load Grml into the memory (RAM).
+                                        This allows you to remove the Grml
+                                        media after Grml finished booting.
+
+                                        Note: you should have enough RAM
+                                        (>= size of ISO * 1.2) to be able
+                                        to use this option.
+  endtext
+
+label grmlmedium2ram
+  menu label %GRML_NAME% - Load ^whole medium to RAM
+  kernel /boot/%SHORT_NAME%/vmlinuz
+  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce net.ifnames=0 toram 
+
+  text help
+                                        Load whole medium into the memory (RAM).
+                                        This allows you to remove the Grml
+                                        media after Grml has finished booting,
+                                        and also to access the rest of the
+                                        media.
+
+                                        Note: you should have enough RAM
+                                        (>= size of ISO * 1.2) to be able
+                                        to use this option.
+  endtext
+
 label forensic
   menu label %GRML_NAME% - F^orensic Mode
   kernel /boot/%SHORT_NAME%/vmlinuz
@@ -68,6 +70,18 @@ label forensic
                                         during hardware recognition and
                                         forces all blockdevices to read-only
                                         mode.
+  endtext
+
+label persistence
+  menu label %GRML_NAME% - ^Persistency mode
+  kernel /boot/%SHORT_NAME%/vmlinuz
+  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce net.ifnames=0 persistence 
+
+  text help
+                                        Boot Grml and enable persistency
+                                        feature to store system and
+                                        settings on an external device
+                                        with label persistence.
   endtext
 
 label lang-de
@@ -89,31 +103,34 @@ label %GRML_NAME%x
                                         grml-x to start X Window System.
   endtext
 
-label grml2ram
-  menu label %GRML_NAME% - Load to ^RAM
+label nofb
+  menu label %GRML_NAME% - Dis^able Framebuffer
   kernel /boot/%SHORT_NAME%/vmlinuz
-  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce net.ifnames=0 toram=%SQUASHFS_NAME% 
+  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=normal radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset nomce net.ifnames=0 
 
   text help
-                                        Load Grml into the memory (RAM).
-                                        This allows you to remove the Grml
-                                        media after Grml finished booting.
-
-                                        Note: you should have enough RAM
-                                        (>= size of ISO * 1.2) to be able
-                                        to use this option.
+                                        Boot Grml without framebuffer.
   endtext
 
-label persistence
-  menu label %GRML_NAME% - ^Persistency mode
+label nokms
+  menu label %GRML_NAME% - Disable ^Kernel Mode-Setting
   kernel /boot/%SHORT_NAME%/vmlinuz
-  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce net.ifnames=0 persistence 
+  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset nomce net.ifnames=0 vga=791 
 
   text help
-                                        Boot Grml and enable persistency
-                                        feature to store system and
-                                        settings on an external device
-                                        with label persistence.
+                                        Boot Grml without KMS (Kernel
+                                        Mode Setting).
+  endtext
+
+label debug
+  menu label %GRML_NAME% - ^Debug Mode
+  kernel /boot/%SHORT_NAME%/vmlinuz
+  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 verbose debug=vc initcall nomce net.ifnames=0 systemd.log_level=debug systemd.log_target=kmsg log_buf_len=1M
+
+  text help
+                                        Boot Grml in debug mode, which
+                                        activates debug shells during
+                                        bootup sequence.
   endtext
 
 label serial


### PR DESCRIPTION
The boot order and the naming of the isolinux boot menu and Grub boot menu were not in sync. I tried to standardize the boot menu entries, according to the proposal in
https://github.com/grml/grml/issues/10#issuecomment-1625729783

Related: grml/grml#10