### PR TITLE
Remove Grml release name from the boot options

### DIFF
--- a/templates/boot/grub/%SHORT_NAME%_options.cfg
+++ b/templates/boot/grub/%SHORT_NAME%_options.cfg
@@ -1,5 +1,5 @@
 submenu "%GRML_NAME% - advanced options  ->" --class=submenu {
-menuentry "%GRML_NAME% - Enable Predictable Network Interface Names" {
+menuentry "Enable Predictable Network Interface Names" {
     set gfxpayload=keep
     echo 'Loading kernel...'
     linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} 
@@ -7,7 +7,7 @@ menuentry "%GRML_NAME% - Enable Predictable Network Interface Names" {
     initrd /boot/%SHORT_NAME%/initrd.img
 }
 
-menuentry "%GRML_NAME% - Enable SSH (with random password)" {
+menuentry "Enable SSH (with random password)" {
     set gfxpayload=keep
     echo 'Loading kernel...'
     linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} ssh 
@@ -15,7 +15,7 @@ menuentry "%GRML_NAME% - Enable SSH (with random password)" {
     initrd /boot/%SHORT_NAME%/initrd.img
 }
 
-menuentry "%GRML_NAME% - Load Grml to RAM" {
+menuentry "Load Grml to RAM" {
     set gfxpayload=keep
     echo 'Loading kernel...'
     linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} toram=%GRML_NAME%.squashfs 
@@ -23,7 +23,7 @@ menuentry "%GRML_NAME% - Load Grml to RAM" {
     initrd /boot/%SHORT_NAME%/initrd.img
 }
 
-menuentry "%GRML_NAME% - Load whole medium to RAM" {
+menuentry "Load whole medium to RAM" {
     set gfxpayload=keep
     echo 'Loading kernel...'
     linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} toram 
@@ -31,7 +31,7 @@ menuentry "%GRML_NAME% - Load whole medium to RAM" {
     initrd /boot/%SHORT_NAME%/initrd.img
 }
 
-menuentry "%GRML_NAME% - Forensic Mode" {
+menuentry "Forensic Mode" {
     set gfxpayload=keep
     echo 'Loading kernel...'
     linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} read-only nofstab noraid nodmraid nolvm noautoconfig noswap raid=noautodetect 
@@ -39,7 +39,7 @@ menuentry "%GRML_NAME% - Forensic Mode" {
     initrd /boot/%SHORT_NAME%/initrd.img
 }
 
-menuentry "%GRML_NAME% - Persistency Mode" {
+menuentry "Persistency Mode" {
     set gfxpayload=keep
     echo 'Loading kernel...'
     linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} persistence 
@@ -47,7 +47,7 @@ menuentry "%GRML_NAME% - Persistency Mode" {
     initrd /boot/%SHORT_NAME%/initrd.img
 }
 
-menuentry "%GRML_NAME% - German Settings" {
+menuentry "Load German Keyboard Layout" {
     set gfxpayload=keep
     echo 'Loading kernel...'
     linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} lang=de 
@@ -55,7 +55,7 @@ menuentry "%GRML_NAME% - German Settings" {
     initrd /boot/%SHORT_NAME%/initrd.img
 }
 
-menuentry "%GRML_NAME% - Graphical Mode" {
+menuentry "Graphical Mode" {
     set gfxpayload=keep
     echo 'Loading kernel...'
     linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} startx 
@@ -63,7 +63,7 @@ menuentry "%GRML_NAME% - Graphical Mode" {
     initrd /boot/%SHORT_NAME%/initrd.img
 }
 
-menuentry "%GRML_NAME% - Disable Framebuffer" {
+menuentry "Disable Framebuffer" {
     set gfxpayload=text
     echo 'Loading kernel...'
     linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} video=ofonly radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset 
@@ -71,7 +71,7 @@ menuentry "%GRML_NAME% - Disable Framebuffer" {
     initrd /boot/%SHORT_NAME%/initrd.img
 }
 
-menuentry "%GRML_NAME% - Disable Kernel Mode-Setting" {
+menuentry "Disable Video Kernel Mode Setting" {
     set gfxpayload=keep
     echo 'Loading kernel...'
     linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset 
@@ -79,7 +79,7 @@ menuentry "%GRML_NAME% - Disable Kernel Mode-Setting" {
     initrd /boot/%SHORT_NAME%/initrd.img
 }
 
-menuentry "%GRML_NAME% - Debug Mode" {
+menuentry "Debug Mode" {
     set gfxpayload=keep
     echo 'Loading kernel...'
     linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} initcall verbose debug=vc systemd.log_level=debug systemd.log_target=kmsg log_buf_len=1M 
@@ -87,7 +87,7 @@ menuentry "%GRML_NAME% - Debug Mode" {
     initrd /boot/%SHORT_NAME%/initrd.img
 }
 
-menuentry "%GRML_NAME% - Serial Console" {
+menuentry "Serial Console" {
     set gfxpayload=text
     echo 'Loading kernel...'
     linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} video=vesafb:off console=tty1 console=ttyS0,115200n8 

--- a/templates/boot/isolinux/grml.cfg
+++ b/templates/boot/isolinux/grml.cfg
@@ -3,17 +3,17 @@
 # generic ones
 
 label pnet
-  menu label %GRML_NAME% - Enable Predictable ^Network Interface Names
+  menu label Enable Predictable ^Network Interface Names
   kernel /boot/%SHORT_NAME%/vmlinuz
   append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce 
 
   text help
-                                        Boot Grml with Predictable
-                                        Network Interface Names.
+                                        Boot Grml with Predictable Network
+                                        Interface Names.
   endtext
 
 label ssh
-  menu label %GRML_NAME% - Enable ^SSH (with random password)
+  menu label Enable ^SSH (with random password)
   kernel /boot/%SHORT_NAME%/vmlinuz
   append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce net.ifnames=0 ssh 
 
@@ -28,12 +28,12 @@ label ssh
   endtext
 
 label grml2ram
-  menu label %GRML_NAME% - Load Grml to ^RAM
+  menu label Load Grml to ^RAM
   kernel /boot/%SHORT_NAME%/vmlinuz
   append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce net.ifnames=0 toram=%SQUASHFS_NAME% 
 
   text help
-                                        Load Grml into the memory (RAM).
+                                        Load Grml into RAM.
                                         This allows you to remove the Grml
                                         media after Grml finished booting.
 
@@ -43,12 +43,12 @@ label grml2ram
   endtext
 
 label grmlmedium2ram
-  menu label %GRML_NAME% - Load ^whole medium to RAM
+  menu label Load ^whole medium to RAM
   kernel /boot/%SHORT_NAME%/vmlinuz
   append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce net.ifnames=0 toram 
 
   text help
-                                        Load whole medium into the memory (RAM).
+                                        Load whole medium into RAM.
                                         This allows you to remove the Grml
                                         media after Grml has finished booting,
                                         and also to access the rest of the
@@ -60,7 +60,7 @@ label grmlmedium2ram
   endtext
 
 label forensic
-  menu label %GRML_NAME% - F^orensic Mode
+  menu label F^orensic Mode
   kernel /boot/%SHORT_NAME%/vmlinuz
   append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off nomce net.ifnames=0 vga=791 nofstab noraid nodmraid nolvm noautoconfig noswap raid=noautodetect read-only 
 
@@ -73,7 +73,7 @@ label forensic
   endtext
 
 label persistence
-  menu label %GRML_NAME% - ^Persistency mode
+  menu label ^Persistency mode
   kernel /boot/%SHORT_NAME%/vmlinuz
   append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce net.ifnames=0 persistence 
 
@@ -85,16 +85,16 @@ label persistence
   endtext
 
 label lang-de
-  menu label %GRML_NAME% - ^German Settings
+  menu label Load ^German Keyboard Layout
   kernel /boot/%SHORT_NAME%/vmlinuz
   append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce net.ifnames=0 lang=de 
 
   text help
-                                        Boot Grml with german settings.
+                                        Boot Grml with German keyboard layout.
   endtext
 
 label %GRML_NAME%x
-  menu label %GRML_NAME% - Graphical ^Mode
+  menu label Graphical ^Mode
   kernel /boot/%SHORT_NAME%/vmlinuz
   append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce net.ifnames=0 startx 
 
@@ -104,7 +104,7 @@ label %GRML_NAME%x
   endtext
 
 label nofb
-  menu label %GRML_NAME% - Dis^able Framebuffer
+  menu label Dis^able Framebuffer
   kernel /boot/%SHORT_NAME%/vmlinuz
   append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=normal radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset nomce net.ifnames=0 
 
@@ -113,17 +113,17 @@ label nofb
   endtext
 
 label nokms
-  menu label %GRML_NAME% - Disable ^Kernel Mode-Setting
+  menu label Disable Video ^Kernel Mode Setting
   kernel /boot/%SHORT_NAME%/vmlinuz
   append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset nomce net.ifnames=0 vga=791 
 
   text help
-                                        Boot Grml without KMS (Kernel
-                                        Mode Setting).
+                                        Boot Grml without Kernel Mode Setting
+                                        for various video drivers.
   endtext
 
 label debug
-  menu label %GRML_NAME% - ^Debug Mode
+  menu label ^Debug Mode
   kernel /boot/%SHORT_NAME%/vmlinuz
   append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 verbose debug=vc initcall nomce net.ifnames=0 systemd.log_level=debug systemd.log_target=kmsg log_buf_len=1M
 
@@ -134,7 +134,7 @@ label debug
   endtext
 
 label serial
-  menu label %GRML_NAME% - Serial ^Console
+  menu label Serial ^Console
   kernel /boot/%SHORT_NAME%/vmlinuz
   append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=normal video=vesafb:off nomce net.ifnames=0 console=tty1 console=ttyS0,115200n8 
 


### PR DESCRIPTION
The Grml release name is shown on top of the additional boot option menu and also in front of every boot option.
This limits the readable title length. We decided to remove it.

Changed "German Settings" to "Load German Keyboard Layout" because that is what it does (i.e. it runs `grml-lang de`).

Also changed the description of some entries as they were cut off, on the boot screen.
Closes: grml/grml#10