### PR TITLE
etc/fstab/GRMLBASE: use reserved IP following RFC5737

### DIFF
--- a/etc/grml/fai/config/files/etc/fstab/GRMLBASE
+++ b/etc/grml/fai/config/files/etc/fstab/GRMLBASE
@@ -16,11 +16,11 @@ devpts         /dev/pts         devpts noauto,mode=0622                      0  
 /dev/dvd       /media/dvd       auto   user,noauto,exec,ro                   0      0
 # some other examples:
 # /dev/hda1      /Grml         ext3    dev,suid,user,noauto 0  2
-# //1.2.3.4/pub  /smb/pub      smbfs   defaults,user,noauto,uid=grml,gid=grml 0 0
+# //192.0.2.42/pub  /smb/pub      smbfs   defaults,user,noauto,uid=grml,gid=grml 0 0
 # linux:/pub     /beer         nfs     defaults             0  0
 # tmpfs          /tmp          tmpfs   size=300M            0  0
 # none           /proc/bus/usb usbfs   defaults,nodev,noexec,nosuid,noauto,devgid=1001,devmode=664 0 0
-# 192.168.1.101:/backups /media/nfs nfs  defaults,user,wsize=8192,rsize=8192 0 0
+# 192.0.2.42:/backups /media/nfs nfs  defaults,user,wsize=8192,rsize=8192 0 0
 #
 # Warning! Please do *not* change any lines below because they are auto-generated.
 # If you want to disable rebuildfstab set CONFIG_FSTAB='no' in /etc/grml/autoconfig.


### PR DESCRIPTION
Usage of IP addresses like 1.2.3.4 is not recommended, as they might point to actually used and non-reserved IPs.

Quoting from RFC 5737 AKA "IPv4 Address Blocks Reserved for Documentation" (see https://datatracker.ietf.org/doc/html/rfc5737):

```
| The blocks 192.0.2.0/24 (TEST-NET-1), 198.51.100.0/24 (TEST-NET-2), and
| 203.0.113.0/24 (TEST-NET-3) are provided for use in documentation.
```

So use 192.0.2.42 instead.