### PR TITLE
docs: update usage instructions for setting up Grml repository

### DIFF
--- a/docs/grml-live.txt
+++ b/docs/grml-live.txt
@@ -536,7 +536,7 @@ Instructions
   EOF
 
   # get keyring for apt:
-  apt-get update
+  apt-get -o Acquire::AllowInsecureRepositories=true update
   apt-get --allow-unauthenticated install grml-debian-keyring
 
   # optionally(!) install basefile so we don't have to build basic


### PR DESCRIPTION
By default `apt-get update` fails on recent Debian releases (also see apt-secure(8), if the chain of trust hasn't been established yet:

```
| # apt-get update
| Get:1 http://deb.debian.org/debian bookworm InRelease [151 kB] | Get:2 http://deb.debian.org/debian bookworm-updates InRelease [55.4 kB] | Get:3 http://deb.debian.org/debian-security bookworm-security InRelease [48.0 kB] | Get:4 http://deb.grml.org grml-stable InRelease [8382 B] | Get:5 http://deb.grml.org grml-testing InRelease [15.1 kB] | Get:6 http://deb.debian.org/debian bookworm/main amd64 Packages [8786 kB] | Err:4 http://deb.grml.org grml-stable InRelease
|   The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 21E0CA38EA2EA4AB
| Get:7 http://deb.debian.org/debian bookworm-updates/main amd64 Packages [12.7 kB]
| Get:8 http://deb.debian.org/debian-security bookworm-security/main amd64 Packages [145 kB]
| Err:5 http://deb.grml.org grml-testing InRelease
|   The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 21E0CA38EA2EA4AB
| Reading package lists... Done
| W: GPG error: http://deb.grml.org grml-stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 21E0CA38EA2EA4AB
| E: The repository 'http://deb.grml.org grml-stable InRelease' is not signed.
| N: Updating from such a repository can't be done securely, and is therefore disabled by default.
| N: See apt-secure(8) manpage for repository creation and user configuration details.
| W: GPG error: http://deb.grml.org grml-testing InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 21E0CA38EA2EA4AB
| E: The repository 'http://deb.grml.org grml-testing InRelease' is not signed.
| N: Updating from such a repository can't be done securely, and is therefore disabled by default.
| N: See apt-secure(8) manpage for repository creation and user configuration details.
| Reading package lists... Done
| Building dependency tree... Done
| Reading state information... Done
| E: Unable to locate package grml-debian-keyring
```

Whereas with `Acquire::AllowInsecureRepositories=true` we manage to retrieve the repository information for later usage:

```
| root@dc4d0fb0205e:/# apt-get -o Acquire::AllowInsecureRepositories=true update | Hit:1 http://deb.debian.org/debian bookworm InRelease | Get:2 http://deb.grml.org grml-stable InRelease [8382 B] | Hit:3 http://deb.debian.org/debian bookworm-updates InRelease | Hit:4 http://deb.debian.org/debian-security bookworm-security InRelease | Get:5 http://deb.grml.org grml-testing InRelease [15.1 kB] | Ign:2 http://deb.grml.org grml-stable InRelease
| Get:6 http://deb.grml.org grml-stable/main amd64 Packages [9529 B] | Ign:5 http://deb.grml.org grml-testing InRelease | Get:7 http://deb.grml.org grml-testing/main amd64 Packages [9529 B] | Fetched 42.5 kB in 1s (62.6 kB/s)
| Reading package lists... Done
| W: GPG error: http://deb.grml.org grml-stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 21E0CA38EA2EA4AB | W: The repository 'http://deb.grml.org grml-stable InRelease' is not signed. | N: Data from such a repository can't be authenticated and is therefore potentially dangerous to use. | N: See apt-secure(8) manpage for repository creation and user configuration details. | W: GPG error: http://deb.grml.org grml-testing InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 21E0CA38EA2EA4AB | W: The repository 'http://deb.grml.org grml-testing InRelease' is not signed. | N: Data from such a repository can't be authenticated and is therefore potentially dangerous to use. | N: See apt-secure(8) manpage for repository creation and user configuration details.
```

Thanks: anarcat for reporting