### PR TITLE
Fix grml-live build from testing

### DIFF
--- a/etc/grml/fai/config/package_config/GRML_FULL
+++ b/etc/grml/fai/config/package_config/GRML_FULL
@@ -156,7 +156,6 @@ dnsutils
 ethstatus
 ethtool
 hostapd
-hping3
 ifenslave
 iftop
 ifupdown

--- a/etc/grml/fai/config/package_config/XORG
+++ b/etc/grml/fai/config/package_config/XORG
@@ -16,8 +16,6 @@ grml-x
 grml-desktop
 # osd_cat:
 xosd-bin
-# Esetroot:
-eterm
 # x-terminal:
 xterm
 # links2 provides a small X browser named xlinks2:


### PR DESCRIPTION
Both `eterm` and `hping3` has been removed from debian testing(trixie) and checking their tracker page I assume that they will not reenter soon.

* https://tracker.debian.org/pkg/hping3
* https://tracker.debian.org/pkg/eterm

In order to presevere the build-ability of testing let's remove those packages for now