### PR TITLE
SW: drop hfsutils (unavailable in Debian/testing and deprecated filesystem)

### DIFF
--- a/etc/grml/fai/config/package_config/GRML_FULL
+++ b/etc/grml/fai/config/package_config/GRML_FULL
@@ -101,7 +101,6 @@ exfat-fuse
 exfatprogs
 f2fs-tools
 genisoimage
-hfsutils
 jfsutils
 ntfs-3g
 reiser4progs


### PR DESCRIPTION
The package is missing in Debian/testing due to `hfsutils: ftbfs with GCC-14` (see https://bugs.debian.org/1075067).

HFS dates pack to 1985 and as of Mac OS 10.6 Apple dropped support for writing HFS. Since Mac OS 10.15 HFS also can't be read anymore.

Given that HFS shouldn't be really relevant for Grml users those days, let's drop it from our package list.