### PR TITLE
SW: drop reiser4progs (to be removed from Debian)

### DIFF
--- a/etc/grml/fai/config/package_config/GRML_FULL
+++ b/etc/grml/fai/config/package_config/GRML_FULL
@@ -104,7 +104,6 @@ genisoimage
 hfsutils
 jfsutils
 ntfs-3g
-reiser4progs
 reiserfsprogs
 tcplay
 xfsdump


### PR DESCRIPTION
Debian will drop the package, see
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1078247