### PR TITLE
Fix DHCP situation with grml-full unstable/sid

### DIFF
--- a/debian/grml-live.maintscript
+++ b/debian/grml-live.maintscript
@@ -6,3 +6,4 @@ rm_conffile /etc/grml/fai/config/files/etc/systemd/system/serial-getty@ttyS0.ser
 rm_conffile /etc/grml/fai/config/scripts/GRMLBASE/36-cpufrequtils 0.33.0~
 rm_conffile /etc/grml/fai/config/scripts/GRMLBASE/40-deborphan 0.35.0~
 rm_conffile /etc/grml/fai/config/scripts/GRMLBASE/93-update-usbids 0.45.0~
+rm_conffile /etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_SID 0.47.10~

--- a/etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_SID
+++ b/etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_SID
@@ -1,3 +1,0 @@
-# official debian repository:
-  deb     http://ftp.debian.org/debian/ sid main contrib non-free-firmware non-free
-  deb-src http://ftp.debian.org/debian/ sid main contrib non-free-firmware non-free

--- a/grml-live
+++ b/grml-live
@@ -681,11 +681,14 @@ extract_iso
 
 # on-the-fly configuration {{{
 
-# does this suck? YES!
-# /usr/share/debootstrap/scripts/unstable does not exist, instead use 'sid':
-case $SUITE in
+case "${SUITE}" in
+  # /usr/share/debootstrap/scripts/unstable does not exist, so use 'sid'
+  # for bootstrapping, but DEBIAN_UNSTABLE elsewhere:
    unstable) SUITE='sid' ; CLASSES="DEBIAN_UNSTABLE,$CLASSES" ;;
-   *) CLASSES="DEBIAN_$(echo $SUITE | tr 'a-z' 'A-Z'),$CLASSES";;
+  # avoid having to maintain DEBIAN_UNSTABLE *and* DEBIAN_SID class files:
+        sid)               CLASSES="DEBIAN_UNSTABLE,$CLASSES" ;;
+  # otherwise map e.g. bookworm to DEBIAN_BOOKWORM:
+          *)               CLASSES="DEBIAN_$(echo $SUITE | tr 'a-z' 'A-Z'),$CLASSES";;
 esac
 export SUITE # make sure it's available in FAI scripts
 


### PR DESCRIPTION
On our recent grml64-full sid/unstable daily ISOs we ended up with udhcpc (the busybox DHCP client implementation) instead of dhcpcd.

We build our daily ISOs with grml-live, using `-s sid -c DEBORPHAN,GRMLBASE,GRML_FULL,RELEASE,AMD64,IGNORE`. The class selection then gets mapped to FAI classes `DEBIAN_SID DEBORPHAN GRMLBASE GRML_FULL RELEASE AMD64 IGNORE`.

For handling the isc-dhcp-client/dhcpcd situation, we need to enable its according DEBIAN_* class (as we can handle this only for releases newer than bookworm, as cloud-init had a hard dependency on isc-dhcp-client up until and including bookworm, see https://bugs.debian.org/1051421 for details).

So in /etc/grml/fai/config/package_config/DEBIAN_UNSTABLE we already handle the isc-dhcp-client -> dhcpcd switch for unstable, but now that we mapped the `-s sid` to FAI class `DEBIAN_SID`, the `DEBIAN_UNSTABLE` configuration never got active.

If we'd add another DEBIAN_SID class file as duplicate of DEBIAN_UNSTABLE, this would mean further maintenance and debugging efforts. Instead let's drop the single one DEBIAN_SID configuration file we had so far, and map the `sid` codename to the DEBIAN_UNSTABLE class instead.

Thanks: @jkirk for assistance in tracking this down