### PR TITLE
SW: drop haveged from GRMLBASE

### DIFF
--- a/etc/grml/fai/config/package_config/GRMLBASE
+++ b/etc/grml/fai/config/package_config/GRMLBASE
@@ -26,7 +26,6 @@ grml-scripts
 grml-scripts-core
 grml-tips
 grml-udev-config
-haveged
 hdparm
 hwinfo
 initramfs-tools


### PR DESCRIPTION
Quoting from https://github.com/jirka-h/haveged/blob/master/README.md:

```
  Starting from Linux kernel v5.4, the HAVEGED inspired algorithm has been
  included in the Linux kernel (see the LKML article and the Linux Kernel
  commit). Additionally, since v5.6, as soon as the CRNG (the Linux
  cryptographic-strength random number generator) gets ready, /dev/random
  does not block on reads anymore (see this commit).
```

Given that even oldstable AKA bullseye is at kernel version 5.10, let's give it a try to run our live systems without haveged by default.