### PR TITLE
debian/rules: get rid of build files in clean target

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -24,6 +24,13 @@ override_dh_install:
 	# zsh completion
 	dh_install etc/zsh/completion.d/_grml-live usr/share/zsh/vendor-completions
 
+override_dh_clean:
+	rm -f docs/grml-live-db.8 docs/grml-live-db.html docs/grml-live-db.xml
+	rm -f docs/grml-live-remaster.8	docs/grml-live-remaster.html docs/grml-live-remaster.xml
+	rm -f docs/grml-live.8 docs/grml-live.html docs/grml-live.xml
+	rm -f docs/html-stamp docs/man-stamp
+	dh_clean
+
 override_dh_fixperms:
 	dh_fixperms
 	# make sure they are executable:


### PR DESCRIPTION
Otherwise executing `fakeroot debian/rules clean` leaves plenty of files around.