### PR TITLE
Drop debian2hd boot option

### DIFF
--- a/templates/GRML/grml-cheatcodes.txt
+++ b/templates/GRML/grml-cheatcodes.txt
@@ -242,26 +242,6 @@ grml nouveau.modeset=0 nomodeset      Disable Kernel Mode Setting (KMS) for Nouv
 grml cirrus.modeset=0  nomodeset      Disable Kernel Mode Setting (KMS) for Cirrus driver.
 grml mgag200.modeset=0 nomodeset      Disable Kernel Mode Setting (KMS) for MGAG200 driver.
 
-Installation related settings:
-------------------------------
-
-Caution: do *NOT* use the debian2hd bootoption if you do not know what you are doing!
-
-Install plain Debian via debian2hd bootoption (which runs grml-debootstrap in non-interactive mode):
-
-debian2hd <options>                   ... whereas valid options for debian2hd are:
-
-  target=       target partition/directory of the new Debian system, e.g.: target=/dev/sda1
-  grub=         where to install grub to, e.g.: grub=/dev/sda
-  release=      specify release of new Debian system (default is stable), e.g.: release=sid
-  mirror=       specify mirror for apt-get/aptitude, e,g.: mirror=http://ftp.debian.org/debian
-  password=     set passwort of user root without prompting for it, e.g.: password=AiTh5ahn
-
-  Usage example for automatic installation:
-
-    debian2hd target=/dev/sda1 grub=/dev/sda mirror=http://ftp.debian.org/debian password=foobar
-
-  See http://grml.org/grml-debootstrap/ for more information.
 
 Additional notes:
 -----------------

--- a/templates/boot/isolinux/hidden.cfg
+++ b/templates/boot/isolinux/hidden.cfg
@@ -3,11 +3,6 @@ menu hide
 kernel /boot/%SHORT_NAME%/vmlinuz
 append apm=power-off vga=791 initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% splash nomce net.ifnames=0 
 
-label debian2hd
-menu hide
-kernel /boot/%SHORT_NAME%/vmlinuz
-append apm=power-off vga=791 initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% BOOT_IMAGE=debian2hd nomce net.ifnames=0 
-
 label debug
 menu hide
 kernel /boot/%SHORT_NAME%/vmlinuz


### PR DESCRIPTION
grml-autoconfig dropped this, as it is broken under systemd and nobody seems to be using it.

See https://github.com/grml/grml-autoconfig/pull/17
