### PR TITLE
SOURCES: move directory instead of bind-mounting it in

### DIFF
--- a/etc/grml/fai/config/scripts/GRMLBASE/03-get-sources
+++ b/etc/grml/fai/config/scripts/GRMLBASE/03-get-sources
@@ -16,9 +16,11 @@ fi
 set -u
 
 PACKAGE_LIST=$(mktemp)
+SOURCES_PATH=/grml-live/grml_sources/
+SOURCES_ERRORS_LOG="${SOURCES_PATH}"errors.log
 
 bailout() {
-  rm -f "${target}/grml-live/sources/errors.log"
+  rm -f "${target}${SOURCES_ERRORS_LOG}"
   rm -f "$PACKAGE_LIST"
 }
 
@@ -31,7 +33,7 @@ if ! [ -r "${PACKAGE_LIST}" ] ; then
   bailout
   exit 1
 else
-  mkdir -p "${target}"/grml-live/sources
+  mkdir -p "${target}${SOURCES_PATH}"
 
   # needs to be done for each package to get:
   # | Picking 'acpi-support' as source package instead of 'acpi-fakekey'
@@ -39,22 +41,22 @@ else
   # | E: Unable to find a source package for acpi-fakekey
   for package in $(grep -v '^#' ${PACKAGE_LIST}) ; do
     cat << EOT | chroot "$target" /bin/bash
-cd /grml-live/sources
-apt-get --download-only source "$package" 2>>/grml-live/sources/errors.log
+cd "${SOURCES_PATH}"
+apt-get --download-only source "$package" 2>>"${SOURCES_ERRORS_LOG}"
 EOT
   done
 
-  if grep -q '^E:' "${target}/grml-live/sources/errors.log" ; then
+  if grep -q '^E:' "${target}${SOURCES_ERRORS_LOG}" ; then
     echo "Errors noticed while retrieving sources:" >&2
-    cat "${target}/grml-live/sources/errors.log" >&2
+    cat "${target}${SOURCES_ERRORS_LOG}" >&2
     bailout
     exit 1
-  elif grep -q '^W:' "${target}/grml-live/sources/errors.log" ; then
+  elif grep -q '^W:' "${target}${SOURCES_ERRORS_LOG}" ; then
     echo "Warnings noticed while retrieving sources (not failing the build though):"
-    cat "${target}/grml-live/sources/errors.log"
-  elif grep -q '.' "${target}/grml-live/sources/errors.log" ; then
+    cat "${target}${SOURCES_ERRORS_LOG}"
+  elif grep -q '.' "${target}${SOURCES_ERRORS_LOG}" ; then
     echo "Unclassified problems noticed while retrieving sources:" >&2
-    cat "${target}/grml-live/sources/errors.log" >&2
+    cat "${target}${SOURCES_ERRORS_LOG}" >&2
     bailout
     exit 1
   fi

--- a/grml-live
+++ b/grml-live
@@ -177,7 +177,6 @@ umount_all() {
      /usr/lib/fai/mkramdisk -u "$(readlink -f ${CHROOT_OUTPUT}/var/lib/dpkg)" >/dev/null 2>&1 || /bin/true
    fi
 
-   umount "${CHROOT_OUTPUT}/grml-live/sources/" 2>/dev/null || /bin/true
    [ -n "$MIRROR_DIRECTORY" ] && umount "${CHROOT_OUTPUT}/${MIRROR_DIRECTORY}"
 }
 # }}}
@@ -777,8 +776,7 @@ else
          mount --bind "${MIRROR_DIRECTORY}" "${CHROOT_OUTPUT}/${MIRROR_DIRECTORY}"
       fi
 
-      mkdir -p "${OUTPUT}/grml_sources/" "${CHROOT_OUTPUT}/grml-live/sources/"
-      mount --bind "${OUTPUT}/grml_sources/" "${CHROOT_OUTPUT}/grml-live/sources/"
+      mkdir -p "${CHROOT_OUTPUT}/grml-live/grml_sources/"
 
       log "Executed FAI command line:"
       log "BUILD_ONLY=$BUILD_ONLY BOOTSTRAP_ONLY=$BOOTSTRAP_ONLY GRML_LIVE_CONFIG=$CONFIGDUMP WAYBACK_DATE=$WAYBACK_DATE fai $VERBOSE -C $GRML_FAI_CONFIG -s file:///$GRML_FAI_CONFIG/config -c$CLASSES -u $HOSTNAME $FAI_ACTION $CHROOT_OUTPUT $FAI_ARGS"
@@ -793,6 +791,9 @@ else
         eerror "Error: critical error while executing fai [exit code ${RC}]. Exiting." ; eend 1
         bailout 1
       fi
+
+      mv "${CHROOT_OUTPUT}/grml-live/grml_sources/" "${OUTPUT}/"
+      rmdir "${CHROOT_OUTPUT}/grml-live"
 
       # provide inform fai about the ISO we build, needs to be provided
       # *after* FAI stage, otherwise FAI skips the debootstrap stage if


### PR DESCRIPTION
Necessary for building in (unprivileged) docker, where bind mounts are not allowed.