### PR TITLE
SW: add scdaemon to GRML_FULL

### DIFF
--- a/etc/grml/fai/config/package_config/GRML_FULL
+++ b/etc/grml/fai/config/package_config/GRML_FULL
@@ -224,6 +224,9 @@ zip
 apg
 pwgen
 
+# privacy tools
+scdaemon
+
 # popular VCS to pull config from
 git
 


### PR DESCRIPTION
As brought up by bremner on IRC, useful for usage on airgapped systems, only requires 549 kB of additional disk space.