### PR TITLE
Drop vestigial genisoimage/mkisofs support

### DIFF
--- a/etc/grml/fai/config/package_config/GRML_FULL
+++ b/etc/grml/fai/config/package_config/GRML_FULL
@@ -100,7 +100,6 @@ e2fsprogs
 exfat-fuse
 exfatprogs
 f2fs-tools
-genisoimage
 jfsutils
 ntfs-3g
 reiserfsprogs
@@ -108,6 +107,7 @@ tcplay
 xfsdump
 xfsprogs
 xmount
+xorriso
 
 # foreign os support/recovery
 chntpw
@@ -120,7 +120,6 @@ mtools
 cpp
 sqlite3
 whois
-xorriso
 
 # install linux
 cdebootstrap

--- a/grml-live
+++ b/grml-live
@@ -1617,23 +1617,18 @@ else
       einfo "Forcing rebuild of ISO because files on ISO have been modified."
    fi
 
-   # support xorriso as well mkisofs and genisoimage
    if which xorriso >/dev/null 2>&1 ; then
       MKISOFS='xorriso -as mkisofs'
-    elif which mkisofs >/dev/null 2>&1; then
-      MKISOFS='mkisofs'
-   elif which genisoimage >/dev/null 2>&1; then
-      MKISOFS='genisoimage'
    else
-      log    "Error: neither xorriso nor mkisofs nor genisoimage available - can not create ISO."
-      eerror "Error: neither xorriso nor mkisofs nor genisoimage available - can not create ISO." ; eend 1
+      log    "Error: xorriso not available - can not create ISO."
+      eerror "Error: xorriso not available - can not create ISO." ; eend 1
       bailout
    fi
 
    einfo "Using ${MKISOFS} to build ISO." ;  eend 0
-   case "${ARCH}-${MKISOFS}" in
+   case "${ARCH}" in
      # using -eltorito-alt-boot is limited to xorriso for now
-     amd64-xorriso*)
+     amd64)
        eindent
 
        if ! dpkg --compare-versions $(dpkg-query -W -f='${Version}\n' xorriso 2>/dev/null) gt-nl 1.1.6-1 ; then

--- a/remaster/grml-live-remaster
+++ b/remaster/grml-live-remaster
@@ -21,15 +21,10 @@ fi
 
 set -e # exit on any error
 
-if [ -d /run/live/medium/ ] ; then # since Dec 2018
-  LIVE_PATH_MAIN='/run/live/medium/'
-  LIVE_PATH_BOOT='/run/live/medium/boot/'
-else # until Dec 2018
-  LIVE_PATH_MAIN='/lib/live/mount/medium/'
-  LIVE_PATH_BOOT='/lib/live/mount/medium/boot/'
-fi
+LIVE_PATH_MAIN='/run/live/medium/'
+LIVE_PATH_BOOT='/run/live/medium/boot/'
 
-VERSION='0.0.4'
+VERSION='0.0.5'
 GRML_LIVE_EDITOR=${VISUAL:-${EDITOR:-vi}}
 
 # source core functions {{{

--- a/remaster/grml-live-remaster
+++ b/remaster/grml-live-remaster
@@ -49,16 +49,12 @@ if ! isgrmlcd ; then
 fi
 
 # make sure we have what we need {{{
-if check4progs mkisofs >/dev/null 2>&1 ; then
-  MKISO=mkisofs
-fi
-
-if check4progs genisoimage >/dev/null 2>&1 ; then
-  MKISO=genisoimage
+if check4progs xorriso >/dev/null 2>&1 ; then
+  MKISO='xorriso -as mkisofs'
 fi
 
 if [ -z "$MKISO" ] ; then
-  echo "Error: neither mkisofs nor genisoimage available. Exiting." >&2
+  echo "Error: xorriso not installed. Exiting." >&2
   exit 1
 fi
 
@@ -69,7 +65,7 @@ if [ -z "$MKSQUASHFS" ] ; then
   if which mksquashfs >/dev/null 2>&1 ; then
     MKSQUASHFS=mksquashfs
   else
-    echo "Error: mksquashfs is not available. Exiting." >&2
+    echo "Error: mksquashfs not installed. Exiting." >&2
     exit 1
   fi
 fi


### PR DESCRIPTION
Since 3c0d23bcd80c75ab4390d467f3bfceed42bce0c7 (from 2018!) grml-live hard-depended on `xorriso`. Remove leftover genisoimage/mkisofs support.

Also drop genisoimage from `GRML_FULL`, which already must include `xorriso` (for grml-live).