### PR TITLE
Fix BUILD_ONLY mode inside Docker

### DIFF
--- a/etc/grml/fai/config/hooks/instsoft.GRMLBASE
+++ b/etc/grml/fai/config/hooks/instsoft.GRMLBASE
@@ -13,7 +13,8 @@ set -e
 # and can't skip instsoft.GRMLBASE we have to make sure
 # we exit here as well
 if [ -n "$BUILD_ONLY" ] ; then
-   "Exiting hooks/instsoft.GRMLBASE as BUILD_ONLY environment is set."
+   echo "Exiting hooks/instsoft.GRMLBASE as BUILD_ONLY environment is set."
+   echo "W: This place was reached because updatebase.GRMLBASE failed."
    exit 0
 fi
 

--- a/etc/grml/fai/config/hooks/updatebase.GRMLBASE
+++ b/etc/grml/fai/config/hooks/updatebase.GRMLBASE
@@ -34,7 +34,7 @@ if [ "$FAI_ACTION" = "softupdate" ] ; then
    fi
    # some packages must access /sys even in chroot environment
    if ! [ -d $FAI_ROOT/sys/kernel ] ; then
-      mount -t sysfs sysfs $FAI_ROOT/sys
+      mount -t sysfs sysfs $FAI_ROOT/sys || true
    fi
    # if we are using udev, also mount it into $FAI_ROOT
    if [ -f /etc/init.d/udev ] ; then
@@ -42,7 +42,7 @@ if [ "$FAI_ACTION" = "softupdate" ] ; then
    fi
 
    if [ -d $FAI_ROOT/run ] ; then
-      mount -t tmpfs tmpfs $FAI_ROOT/run
+      mount -t tmpfs tmpfs $FAI_ROOT/run || true
       mkdir $FAI_ROOT/run/lock
    fi
 


### PR DESCRIPTION
`updatebase.GRMLBASE` mounts various special filesystems. This fails in Docker, where mounting filesystems (even existing ones) does not work.

Half of the mounts were already guarded with `|| true`. Guard the others too, so they can be skipped.

