### PR TITLE
GRML_FULL, GRML_SMALL: Stop installing reiserfsprogs

### DIFF
--- a/etc/grml/fai/config/package_config/GRML_FULL
+++ b/etc/grml/fai/config/package_config/GRML_FULL
@@ -102,7 +102,6 @@ exfatprogs
 f2fs-tools
 jfsutils
 ntfs-3g
-reiserfsprogs
 tcplay
 xfsdump
 xfsprogs

--- a/etc/grml/fai/config/package_config/GRML_SMALL
+++ b/etc/grml/fai/config/package_config/GRML_SMALL
@@ -76,7 +76,6 @@ psmisc
 qemu-guest-agent
 qrencode
 rdnssd
-reiserfsprogs
 rfkill
 rpcbind
 screen


### PR DESCRIPTION
Will probably go away in the Debian trixie release.