### PR TITLE
Improve addons-absent code flow, drop syslinux on arm64

### DIFF
--- a/etc/grml/fai/config/package_config/GRMLBASE
+++ b/etc/grml/fai/config/package_config/GRMLBASE
@@ -29,7 +29,6 @@ grml-udev-config
 hdparm
 hwinfo
 initramfs-tools
-isolinux
 kbd
 less
 live-boot-grml live-boot-grml-doc
@@ -40,7 +39,6 @@ openssh-client
 openssh-server
 pciutils
 physlock
-pxelinux
 resolvconf
 rsync
 rsyslog
@@ -81,6 +79,8 @@ PACKAGES install I386
 grub-pc
 grub-efi-amd64-bin
 grub-efi-ia32-bin
+isolinux
+pxelinux
 syslinux syslinux-common syslinux-utils
 grml2usb
 
@@ -88,6 +88,8 @@ PACKAGES install AMD64
 grub-pc
 grub-efi-amd64-bin
 grub-efi-ia32-bin
+isolinux
+pxelinux
 syslinux syslinux-common syslinux-utils
 grml2usb
 

--- a/grml-live
+++ b/grml-live
@@ -30,7 +30,6 @@ GRML_LIVE_VERSION='***UNRELEASED***'
 # global variables
 PN=$(basename "$0")
 CMDLINE="$0 $*"
-ADDONS_LIST_FILE='/boot/isolinux/addons_list.cfg'
 # }}}
 
 # usage information {{{
@@ -315,6 +314,24 @@ copy_addon_file() {
   msg="Missing addon file: \"$1\""
   ewarn "$msg" ; eend 1
   log "copy_addon_file: $msg"
+  return 1
+}
+
+# Usage: copy_optional_file_logged /path/to/destination/filename /sources /src1 ...
+copy_optional_file_logged() {
+  local dest="$1"
+  shift
+  local source_root="$1"
+  shift
+  local source
+
+  for source in "$@" ; do
+    if [ -r "${source_root}${source}" ] ; then
+      log "Installing ${source} as ${dest}"
+      cp "${source_root}${source}" "${dest}"
+      return 0
+    fi
+  done
   return 1
 }
 
@@ -1077,8 +1094,7 @@ if [ -n "$BOOTSTRAP_ONLY" ] ; then
   log   "Skipping stage 'boot' as building with bootstrap only."
   ewarn "Skipping stage 'boot' as building with bootstrap only." ; eend 0
 else
-  # booting stuff:
-  mkdir -p "$BUILD_OUTPUT"/boot/isolinux
+  # Install boot code
   mkdir -p "$BUILD_OUTPUT"/boot/"${SHORT_NAME}"
 
   # this is a variable we're using for adjusting boot templates, not only in
@@ -1178,17 +1194,20 @@ else
     bailout 8
   fi
 
-  # copy _required_ isolinux files
-  if [ -d "${CHROOT_OUTPUT}/usr/lib/ISOLINUX" ] ; then
-    copy_addon_file isolinux.bin /usr/lib/ISOLINUX isolinux
-    for file in "${CHROOT_OUTPUT}"/usr/lib/syslinux/modules/bios/*.c32 ; do
-      copy_addon_file "$(basename "$file")"  /usr/lib/syslinux/modules/bios/ isolinux
-    done
-  fi
+  if [ "$ARCH" != "arm64" ] ; then
+    # copy _required_ isolinux files
+    mkdir -p "$BUILD_OUTPUT"/boot/isolinux
+    if [ -d "${CHROOT_OUTPUT}/usr/lib/ISOLINUX" ] ; then
+      copy_addon_file isolinux.bin /usr/lib/ISOLINUX isolinux
+      for file in "${CHROOT_OUTPUT}"/usr/lib/syslinux/modules/bios/*.c32 ; do
+        copy_addon_file "$(basename "$file")"  /usr/lib/syslinux/modules/bios/ isolinux
+      done
+    fi
 
-  # *always* copy files to output directory so the variables
-  # get adjusted according to the build.
-  cp "${TEMPLATE_DIRECTORY}"/boot/isolinux/*  "$BUILD_OUTPUT"/boot/isolinux/
+    # *always* copy files to output directory so the variables
+    # get adjusted according to the build.
+    cp "${TEMPLATE_DIRECTORY}"/boot/isolinux/*  "$BUILD_OUTPUT"/boot/isolinux/
+  fi
 
   mkdir -p "${BUILD_OUTPUT}/boot/grub"
   cp -a "${TEMPLATE_DIRECTORY}"/boot/grub/* "$BUILD_OUTPUT"/boot/grub/
@@ -1239,18 +1258,20 @@ else
          "${BUILD_OUTPUT}/boot/addons/memtest"
     fi
 
-    # since syslinux(-common) v3:6.03~pre1+dfsg-4 the files are in a
-    # different directory :(
-    if [ -d "${CHROOT_OUTPUT}/usr/lib/syslinux/modules/bios/" ] ; then
-      syslinux_modules_dir=/usr/lib/syslinux/modules/bios/
-    else
-      syslinux_modules_dir=/usr/lib/syslinux
-    fi
-    for file in chain.c32 hdt.c32 mboot.c32 menu.c32; do
-      copy_addon_file "${file}" "${syslinux_modules_dir}" addons
-    done
+    if [ "$ARCH" != "arm64" ] ; then
+      # since syslinux(-common) v3:6.03~pre1+dfsg-4 the files are in a
+      # different directory :(
+      if [ -d "${CHROOT_OUTPUT}/usr/lib/syslinux/modules/bios/" ] ; then
+        syslinux_modules_dir=/usr/lib/syslinux/modules/bios/
+      else
+        syslinux_modules_dir=/usr/lib/syslinux
+      fi
+      for file in chain.c32 hdt.c32 mboot.c32 menu.c32; do
+        copy_addon_file "${file}" "${syslinux_modules_dir}" addons
+      done
 
-    copy_addon_file memdisk /usr/lib/syslinux addons
+      copy_addon_file memdisk /usr/lib/syslinux addons
+    fi
 
     # copy only files so we can handle bsd4grml on its own
     for file in "${TEMPLATE_DIRECTORY}"/boot/addons/* ; do
@@ -1352,73 +1373,76 @@ else
     done < <(find "${BUILD_OUTPUT}" -name "*%$param%*" -print0)
   done
 
-  # generate addon list
-  rm -f "${BUILD_OUTPUT}/${ADDONS_LIST_FILE}"
-  for name in "${BUILD_OUTPUT}"/boot/isolinux/addon_*.cfg ; do
-    include_name=$(basename "$name")
-    echo "include $include_name"  >> "${BUILD_OUTPUT}/${ADDONS_LIST_FILE}"
-  done
+  if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "i386" ] ; then
+    # generate isolinux addon list
+    ADDONS_LIST_FILE='/boot/isolinux/addons_list.cfg'
+    rm -f "${BUILD_OUTPUT}/${ADDONS_LIST_FILE}"
+    for name in "${BUILD_OUTPUT}"/boot/isolinux/addon_*.cfg ; do
+      include_name=$(basename "$name")
+      echo "include $include_name"  >> "${BUILD_OUTPUT}/${ADDONS_LIST_FILE}"
+    done
 
-  if ! [ -r "${BUILD_OUTPUT}/boot/isolinux/${DISTRI_NAME}.cfg" ] || [ "$DISTRI_NAME" = "grml" ] ; then
-    log "including grmlmain.cfg in ${BUILD_OUTPUT}/boot/isolinux/distri.cfg"
-    echo "include grmlmain.cfg"    >  "${BUILD_OUTPUT}/boot/isolinux/distri.cfg"
+    if ! [ -r "${BUILD_OUTPUT}/boot/isolinux/${DISTRI_NAME}.cfg" ] || [ "$DISTRI_NAME" = "grml" ] ; then
+      log "including grmlmain.cfg in ${BUILD_OUTPUT}/boot/isolinux/distri.cfg"
+      echo "include grmlmain.cfg"    >  "${BUILD_OUTPUT}/boot/isolinux/distri.cfg"
 
-    # Generate grmlmain.cfg
-    {
-      echo "include default.cfg"
-      echo "include menuoptions.cfg"
-      echo "include grml.cfg"
-      for f in "${BUILD_OUTPUT}"/boot/isolinux/submenu*.cfg ; do
-        echo "include $(basename "$f")"
-      done
-      echo "include options.cfg"
-      if [ -z "$NO_ADDONS" ] ; then
-        echo "include addons.cfg"
+      # Generate grmlmain.cfg
+      {
+        echo "include default.cfg"
+        echo "include menuoptions.cfg"
+        echo "include grml.cfg"
+        for f in "${BUILD_OUTPUT}"/boot/isolinux/submenu*.cfg ; do
+          echo "include $(basename "$f")"
+        done
+        echo "include options.cfg"
+        if [ -z "$NO_ADDONS" ] ; then
+          echo "include addons.cfg"
+        fi
+        echo "include isoprompt.cfg"
+        echo "include hd.cfg"
+        echo "include hidden.cfg"
+      } > "${BUILD_OUTPUT}/boot/isolinux/grmlmain.cfg"
+    else # assume we are building a custom distribution:
+      log "File ${BUILD_OUTPUT}/boot/isolinux/${DISTRI_NAME}.cfg found, using it."
+      einfo "File ${BUILD_OUTPUT}/boot/isolinux/${DISTRI_NAME}.cfg found, using it."
+      if grep -q "^include ${DISTRI_NAME}.cfg" "${BUILD_OUTPUT}/boot/isolinux/distri.cfg" ; then
+        log "include for ${DISTRI_NAME}.cfg already present, nothing to do."
+        eindent
+        einfo "include for ${DISTRI_NAME}.cfg already present, nothing to do."
+        eoutdent
+        eend $?
+      else
+        log "including ${DISTRI_NAME}.cfg in ${BUILD_OUTPUT}/boot/isolinux/distri.cfg"
+        echo "include ${DISTRI_NAME}.cfg" > "${BUILD_OUTPUT}/boot/isolinux/distri.cfg"
+        if [ -z "$NO_ADDONS" ] ; then
+          echo "include addons.cfg" >> "${BUILD_OUTPUT}/boot/isolinux/distri.cfg"
+        fi
       fi
-      echo "include isoprompt.cfg"
-      echo "include hd.cfg"
-      echo "include hidden.cfg"
-    } > "${BUILD_OUTPUT}/boot/isolinux/grmlmain.cfg"
-  else # assume we are building a custom distribution:
-    log "File ${BUILD_OUTPUT}/boot/isolinux/${DISTRI_NAME}.cfg found, using it."
-    einfo "File ${BUILD_OUTPUT}/boot/isolinux/${DISTRI_NAME}.cfg found, using it."
-    if grep -q "^include ${DISTRI_NAME}.cfg" "${BUILD_OUTPUT}/boot/isolinux/distri.cfg" ; then
-      log "include for ${DISTRI_NAME}.cfg already present, nothing to do."
-      eindent
-      einfo "include for ${DISTRI_NAME}.cfg already present, nothing to do."
-      eoutdent
-      eend $?
+    fi
+
+    # use old style console based isolinux method only if requested:
+    if [[ "${ISOLINUX_METHOD}" == "console" ]] ; then
+      log "Using console based isolinux method as requested via \$ISOLINUX_METHOD."
+      einfo "Using console based isolinux method as requested via \$ISOLINUX_METHOD."
+      if grep -q '^include console.cfg' "${BUILD_OUTPUT}/boot/isolinux/distri.cfg" ; then
+        einfo "include for console.cfg already found, nothing to do."
+        eend 0
+      else
+        log "including console.cfg in ${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg"
+        einfo "including console.cfg in ${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg"
+        echo "include console.cfg" >> "${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg"
+        eend 0
+      fi
     else
-      log "including ${DISTRI_NAME}.cfg in ${BUILD_OUTPUT}/boot/isolinux/distri.cfg"
-      echo "include ${DISTRI_NAME}.cfg" > "${BUILD_OUTPUT}/boot/isolinux/distri.cfg"
-      if [ -z "$NO_ADDONS" ] ; then
-        echo "include addons.cfg" >> "${BUILD_OUTPUT}/boot/isolinux/distri.cfg"
+      log 'Using graphical boot menu.'
+      if grep -q '^include vesamenu.cfg' "${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg" ; then
+        log "include for vesamenu.cfg already found, nothing to do."
+      else
+        log "including vesamenu.cfg in ${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg"
+        echo "include vesamenu.cfg" >> "${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg"
       fi
     fi
-  fi
-
-  # use old style console based isolinux method only if requested:
-  if [[ "${ISOLINUX_METHOD}" == "console" ]] ; then
-    log "Using console based isolinux method as requested via \$ISOLINUX_METHOD."
-    einfo "Using console based isolinux method as requested via \$ISOLINUX_METHOD."
-    if grep -q '^include console.cfg' "${BUILD_OUTPUT}/boot/isolinux/distri.cfg" ; then
-      einfo "include for console.cfg already found, nothing to do."
-      eend 0
-    else
-      log "including console.cfg in ${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg"
-      einfo "including console.cfg in ${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg"
-      echo "include console.cfg" >> "${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg"
-      eend 0
-    fi
-  else
-    log 'Using graphical boot menu.'
-    if grep -q '^include vesamenu.cfg' "${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg" ; then
-      log "include for vesamenu.cfg already found, nothing to do."
-    else
-      log "including vesamenu.cfg in ${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg"
-      echo "include vesamenu.cfg" >> "${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg"
-    fi
-  fi
+  fi # amd64 or i386
 
   if [ -e "$BUILD_OUTPUT"/boot/addons/bsd4grml/boot.6 ]; then
     sed -i "s/%RELEASE_INFO%/$RELEASE_INFO/" "$BUILD_OUTPUT"/boot/addons/bsd4grml/boot.6
@@ -1601,6 +1625,11 @@ BOOT_ARGS="-no-emul-boot -boot-load-size 4 -boot-info-table -b boot/isolinux/iso
 if [ "$HYBRID_METHOD" = "isohybrid" ] ; then
   EFI_ARGS="-isohybrid-mbr /usr/lib/ISOLINUX/isohdpfx.bin -eltorito-alt-boot -e boot/efi.img -no-emul-boot -isohybrid-gpt-basdat"
 fi
+if [ "$ARCH" = "arm64" ]; then
+  # No isolinux on arm64.
+  BOOT_ARGS=""
+  EFI_ARGS="-eltorito-alt-boot -e boot/efi.img -no-emul-boot -isohybrid-gpt-basdat"
+fi
 
 if [ -f "${ISO_OUTPUT}/${ISO_NAME}" ] && [ -z "$UPDATE" ] && [ -z "$BUILD_ONLY" ] && [ -z "$BUILD_DIRTY" ] && [ "$FORCE_ISO_REBUILD" = "false" ]  ; then
    log   "Skipping stage 'iso build' as $ISO_OUTPUT/${ISO_NAME} exists already."
@@ -1709,22 +1738,6 @@ create_netbootpackage() {
 
   mkdir -p "$NETBOOT"
 
-  # since syslinux v3:6.03~pre1+dfsg-4 the pxelinux.0 has been split into a
-  # separate pxelinux package
-  if [ -d "${CHROOT_OUTPUT}/usr/lib/PXELINUX/" ] ; then
-    local pxelinux_dir=/usr/lib/PXELINUX
-  else
-    local pxelinux_dir=/usr/lib/syslinux
-  fi
-
-  if ! [ -r "${CHROOT_OUTPUT}/${pxelinux_dir}/pxelinux.0" ] ; then
-    ewarn "File ${pxelinux_dir}/pxelinux.0 not found in build chroot." ; eend 0
-    eindent
-    einfo "Install syslinux[-common]/pxelinux package in chroot to get a netboot package."
-    eoutdent
-    return 0
-  fi
-
   local OUTPUTDIR="${NETBOOT}/build_tmp"
   local WORKING_DIR="${OUTPUTDIR}/grml_netboot_package_${GRML_NAME}_${VERSION}/tftpboot/"
 
@@ -1732,58 +1745,91 @@ create_netbootpackage() {
 
   cp "${CHROOT_OUTPUT}"/boot/vmlinuz-*    "$WORKING_DIR"/vmlinuz
   cp "${CHROOT_OUTPUT}"/boot/initrd.img-* "$WORKING_DIR"/initrd.img
-  cp "${CHROOT_OUTPUT}/${pxelinux_dir}/pxelinux.0" "${WORKING_DIR}/pxelinux.0"
 
-  if [ -r "${CHROOT_OUTPUT}"/usr/lib/syslinux/modules/bios/ldlinux.c32 ] ; then
-    cp "${CHROOT_OUTPUT}"/usr/lib/syslinux/modules/bios/ldlinux.c32 "${WORKING_DIR}"/
-  fi
+  if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ] ; then
+    # since syslinux v3:6.03~pre1+dfsg-4 the pxelinux.0 has been split into a
+    # separate pxelinux package
+    if [ -d "${CHROOT_OUTPUT}/usr/lib/PXELINUX/" ] ; then
+      local pxelinux_dir=/usr/lib/PXELINUX
+    else
+      local pxelinux_dir=/usr/lib/syslinux
+    fi
 
-  mkdir -p "${WORKING_DIR}/pxelinux.cfg"
-  if [ -r "${BUILD_OUTPUT}/boot/isolinux/netboot.cfg" ] ; then
-    cp "${BUILD_OUTPUT}/boot/isolinux/netboot.cfg" "${WORKING_DIR}/pxelinux.cfg/default"
-  else
-    log   "File ${BUILD_OUTPUT}/boot/isolinux/netboot.cfg not found."
-    ewarn "File ${BUILD_OUTPUT}/boot/isolinux/netboot.cfg not found."
-    eindent
-    log   "Hint: Are you using custom templates which do not provide netboot.cfg?"
-    ewarn "Hint: Are you using custom templates which do not provide netboot.cfg?" ; eend 0
-    eoutdent
-  fi
+    if ! [ -r "${CHROOT_OUTPUT}/${pxelinux_dir}/pxelinux.0" ] ; then
+      ewarn "File ${pxelinux_dir}/pxelinux.0 not found in build chroot." ; eend 0
+      eindent
+      einfo "Install syslinux[-common]/pxelinux package in chroot to get a netboot package."
+      eoutdent
+      return 0
+    fi
+
+    cp "${CHROOT_OUTPUT}/${pxelinux_dir}/pxelinux.0" "${WORKING_DIR}/pxelinux.0"
+
+    if [ -r "${CHROOT_OUTPUT}"/usr/lib/syslinux/modules/bios/ldlinux.c32 ] ; then
+      cp "${CHROOT_OUTPUT}"/usr/lib/syslinux/modules/bios/ldlinux.c32 "${WORKING_DIR}"/
+    fi
+
+    mkdir -p "${WORKING_DIR}/pxelinux.cfg"
+    if [ -r "${BUILD_OUTPUT}/boot/isolinux/netboot.cfg" ] ; then
+      cp "${BUILD_OUTPUT}/boot/isolinux/netboot.cfg" "${WORKING_DIR}/pxelinux.cfg/default"
+    else
+      log   "File ${BUILD_OUTPUT}/boot/isolinux/netboot.cfg not found."
+      ewarn "File ${BUILD_OUTPUT}/boot/isolinux/netboot.cfg not found."
+      eindent
+      log   "Hint: Are you using custom templates which do not provide netboot.cfg?"
+      ewarn "Hint: Are you using custom templates which do not provide netboot.cfg?" ; eend 0
+      eoutdent
+    fi
+  fi # amd64 or i386
 
   # don't include shim + grubnetx64 + grub files in i386 netboot packages,
   # as those don't make much sense there
-  if [ "$ARCH" = amd64 ] ; then
+  if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "arm64" ] ; then
     if ! [ -r "${BUILD_OUTPUT}/boot/grub/netboot.cfg" ] ; then
       log   "File ${BUILD_OUTPUT}/boot/grub/netboot.cfg not found."
       ewarn "File ${BUILD_OUTPUT}/boot/grub/netboot.cfg not found."
       eindent
-      log   "Hint: Are you using custom templates which do not provide grub.cfg?"
-      ewarn "Hint: Are you using custom templates which do not provide grub.cfg?" ; eend 0
+      log   "Hint: Are you using custom templates which do not provide netboot.cfg?"
+      ewarn "Hint: Are you using custom templates which do not provide netboot.cfg?" ; eend 0
       eoutdent
     else
       cp "${BUILD_OUTPUT}/boot/grub/netboot.cfg" "${WORKING_DIR}/grub.cfg"
       adjust_boot_files "${WORKING_DIR}/grub.cfg"
 
-      if [ -r "${CHROOT_OUTPUT}"/usr/lib/shim/shimx64.efi.signed ] ; then
-        log "Installing ${CHROOT_OUTPUT}/usr/lib/shim/shimx64.efi.signed as shim.efi in netboot package"
-        cp "${CHROOT_OUTPUT}"/usr/lib/shim/shimx64.efi.signed "${WORKING_DIR}"/shim.efi
-      elif [ -r "${CHROOT_OUTPUT}"/usr/lib/shim/shimx64.efi ] ; then
-        log "Installing ${CHROOT_OUTPUT}/usr/lib/shim/shimx64.efi as shim.efi in netboot package"
-        cp "${CHROOT_OUTPUT}"/usr/lib/shim/shimx64.efi "${WORKING_DIR}"/shim.efi
-      else
-        log   "No shimx64.efi for usage with PXE boot found (shim-signed not present?)"
-        ewarn "No shimx64.efi for usage with PXE boot found (shim-signed not present?)" ; eend 0
+      if [ "$ARCH" = "amd64" ] ; then
+        if ! copy_optional_file_logged "${WORKING_DIR}"/shim.efi "${CHROOT_OUTPUT}" \
+          /usr/lib/shim/shimx64.efi.signed \
+          /usr/lib/shim/shimx64.efi
+        then
+          log   "No shimx64.efi for usage with PXE boot found (shim-signed not present?)"
+          ewarn "No shimx64.efi for usage with PXE boot found (shim-signed not present?)" ; eend 0
+        fi
+
+        if ! copy_optional_file_logged "${WORKING_DIR}"/grubx64.efi "${CHROOT_OUTPUT}" \
+          /usr/lib/grub/x86_64-efi-signed/grubnetx64.efi.signed \
+          /usr/lib/grub/x86_64-efi/monolithic/grubnetx64.efi
+        then
+          log   "No grubnetx64.efi for usage with PXE boot found (grub-efi-amd64-signed not present?)"
+          ewarn "No grubnetx64.efi for usage with PXE boot found (grub-efi-amd64-signed not present?)." ; eend 0
+        fi
       fi
 
-      if [ -r "${CHROOT_OUTPUT}"/usr/lib/grub/x86_64-efi-signed/grubnetx64.efi.signed ] ; then
-        log "Installing /usr/lib/grub/x86_64-efi-signed/grubnetx64.efi.signed as grubx64.efi in netboot package"
-        cp "${CHROOT_OUTPUT}"/usr/lib/grub/x86_64-efi-signed/grubnetx64.efi.signed "${WORKING_DIR}"/grubx64.efi
-      elif [ -r "${CHROOT_OUTPUT}"/usr/lib/grub/x86_64-efi/monolithic/grubnetx64.efi ] ; then
-        log "Installing /usr/lib/grub/x86_64-efi/monolithic/grubnetx64.efi as grubx64.efi in netboot package"
-        cp "${CHROOT_OUTPUT}"/usr/lib/grub/x86_64-efi/monolithic/grubnetx64.efi "${WORKING_DIR}"/grubx64.efi
-      else
-        log   "No grubnetx64.efi for usage with PXE boot found (grub-efi-amd64-signed not present?)"
-        ewarn "No grubnetx64.efi for usage with PXE boot found (grub-efi-amd64-signed not present?)." ; eend 0
+      if [ "$ARCH" = "arm64" ] ; then
+        if ! copy_optional_file_logged "${WORKING_DIR}"/shim.efi "${CHROOT_OUTPUT}" \
+          /usr/lib/shim/shimaa64.efi.signed \
+          /usr/lib/shim/shimaa64.efi
+        then
+          log   "No shimaa64.efi for usage with PXE boot found (shim-signed not present?)"
+          ewarn "No shimaa64.efi for usage with PXE boot found (shim-signed not present?)" ; eend 0
+        fi
+
+        if ! copy_optional_file_logged "${WORKING_DIR}"/grubaa64.efi "${CHROOT_OUTPUT}" \
+          /usr/lib/grub/arm64-efi-signed/grubnetaa64.efi.signed \
+          /usr/lib/grub/arm64-efi/monolithic/grubnetaa64.efi
+        then
+          log   "No grubnetaa64.efi for usage with PXE boot found (grub-efi-arm64-signed not present?)"
+          ewarn "No grubnetaa64.efi for usage with PXE boot found (grub-efi-arm64-signed not present?)." ; eend 0
+        fi
       fi
 
       if [ -r "${CHROOT_OUTPUT}"/usr/share/grub/unicode.pf2 ] ; then
@@ -1795,7 +1841,7 @@ create_netbootpackage() {
         ewarn "No unicode.pf2 for usage with PXE boot found (grub-common not present?)" ; eend 0
       fi
     fi
-  fi
+  fi # amd64 or arm64
 
   if tar -C "$OUTPUTDIR" -cf "${OUTPUT_FILE}" "grml_netboot_package_${GRML_NAME}_${VERSION}" ; then
     (

--- a/grml-live
+++ b/grml-live
@@ -1184,10 +1184,6 @@ else
     for file in "${CHROOT_OUTPUT}"/usr/lib/syslinux/modules/bios/*.c32 ; do
       copy_addon_file "$(basename "$file")"  /usr/lib/syslinux/modules/bios/ isolinux
     done
-  else # syslinux versions <= 3:4.05+dfsg-6+deb8u1
-    copy_addon_file isolinux.bin /usr/lib/syslinux isolinux
-    copy_addon_file ifcpu64.c32  /usr/lib/syslinux isolinux
-    copy_addon_file vesamenu.c32 /usr/lib/syslinux isolinux
   fi
 
   # *always* copy files to output directory so the variables

--- a/grml-live
+++ b/grml-live
@@ -499,6 +499,13 @@ if [ -n "$ZERO_LOGFILE" ] ; then
 fi
 # }}}
 
+# Automatically enable NO_ADDONS=1 if addons are not present {{{
+if [ -z "${NO_ADDONS:-}" ] && [ ! -r "$TEMPLATE_DIRECTORY"/boot/addons ] ; then
+  ewarn "Boot addons not found, setting NO_ADDONS=1. (Consider installing package grml-live-addons)" ; eend 0
+  NO_ADDONS=1
+fi
+# }}}
+
 # Show configuration and ask user whether to continue {{{
 echo
 echo "${PN} [${GRML_LIVE_VERSION}] Build Configuration:"
@@ -538,6 +545,7 @@ else
     [ -n "$SKIP_MKSQUASHFS" ]     && echo "  Skipping creation of SQUASHFS file."
     [ -n "$SKIP_NETBOOT" ]        && echo "  Skipping creation of NETBOOT package."
     [ -n "$SKIP_MKISOFS" ]        && echo "  Skipping creation of ISO file."
+    [ -n "$NO_ADDONS" ]           && echo "  Skipping boot addons."
     [ -n "$BUILD_ONLY" ]          && echo "  Executing BUILD_ONLY instead of fresh installation or UPDATE."
     [ -n "$BUILD_DIRTY" ]         && echo "  Executing BUILD_DIRTY to leave chroot untouched."
 fi
@@ -1159,7 +1167,6 @@ if [ "$ARCH" = i386 ] || [ "$ARCH" = amd64 ] || [ "$ARCH" = arm64 ] ; then
       ewarn "No EFI boot files found, skipping." ; eend 0
     fi
 
-    [ -n "$TEMPLATE_DIRECTORY" ] || TEMPLATE_DIRECTORY='/usr/share/grml-live/templates'
     if ! [ -d "${TEMPLATE_DIRECTORY}"/boot ] ; then
       log    "Error: ${TEMPLATE_DIRECTORY}/boot does not exist. Exiting."
       eerror "Error: ${TEMPLATE_DIRECTORY}/boot does not exist. Exiting." ; eend 1
@@ -1187,87 +1194,81 @@ if [ "$ARCH" = i386 ] || [ "$ARCH" = amd64 ] || [ "$ARCH" = arm64 ] ; then
 
     if [ -n "$NO_ADDONS" ] ; then
       rm -f "$BUILD_OUTPUT"/boot/grub/addons.cfg
-      log   "Skipping installation of boot addons as requested via \$NO_ADDONS."
-      einfo "Skipping installation of boot addons as requested via \$NO_ADDONS."; eend 0
+      log   "Skipping installation of boot addons as \$NO_ADDONS=${NO_ADDONS}."
+      einfo "Skipping installation of boot addons as \$NO_ADDONS=${NO_ADDONS}."; eend 0
     else
-      if ! [ -r "$TEMPLATE_DIRECTORY"/boot/addons ] ; then
-        log   "Boot addons not found, skipping therefore. (Consider installing package grml-live-addons)"
-        ewarn "Boot addons not found, skipping therefore. (Consider installing package grml-live-addons)" ; eend 0
-      else
-        log   "Installing boot addons."
-        einfo "Installing boot addons."
+      log   "Installing boot addons."
+      einfo "Installing boot addons."
 
-        # copy addons from system packages or grml-live-addons
-        copy_addon_file ipxe.lkrn /usr/lib/ipxe addons
-        copy_addon_file ipxe.efi /usr/lib/ipxe addons
-        copy_addon_file pci.ids /usr/share/misc addons
+      # copy addons from system packages or grml-live-addons
+      copy_addon_file ipxe.lkrn /usr/lib/ipxe addons
+      copy_addon_file ipxe.efi /usr/lib/ipxe addons
+      copy_addon_file pci.ids /usr/share/misc addons
 
-        # memtest86+ >=6.00-1
+      # memtest86+ >=6.00-1
+      if [[ "$ARCH" == "amd64" ]] ; then
+        copy_addon_file memtest86+x64.efi /boot addons
+      elif [[ "$ARCH" == "i386" ]] ; then
+        copy_addon_file memtest86+ia32.efi /boot addons
+      fi
+
+      # provide memtest86+ >=6.00-1 files as "memtest" file
+      # for BIOS boot in isolinux/syslinux
+      if ! [ -r "${BUILD_OUTPUT}/boot/addons/memtest" ] ; then
         if [[ "$ARCH" == "amd64" ]] ; then
-          copy_addon_file memtest86+x64.efi /boot addons
-        elif [[ "$ARCH" == "i386" ]] ; then
-          copy_addon_file memtest86+ia32.efi /boot addons
-        fi
-
-        # provide memtest86+ >=6.00-1 files as "memtest" file
-        # for BIOS boot in isolinux/syslinux
-        if ! [ -r "${BUILD_OUTPUT}/boot/addons/memtest" ] ; then
-          if [[ "$ARCH" == "amd64" ]] ; then
-            copy_addon_file memtest86+x64.bin /boot addons &&
-            # make memtest filename FAT16/8.3 compatible
-            mv "${BUILD_OUTPUT}/boot/addons/memtest86+x64.bin" \
-               "${BUILD_OUTPUT}/boot/addons/memtest"
-          elif [[ "$ARCH" == "i386" ]] ; then
-            copy_addon_file memtest86+ia32.bin /boot addons &&
-            # make memtest filename FAT16/8.3 compatible
-            mv "${BUILD_OUTPUT}/boot/addons/memtest86+ia32.bin" \
-               "${BUILD_OUTPUT}/boot/addons/memtest"
-          fi
-        fi
-
-        # fallback: if we still don't have /boot/addons/memtest available, we
-        # might have an older memtest86+ version (<=5.01-3.1) which ships
-        # file "memtest86+.bin" instead
-        if ! [ -r "${BUILD_OUTPUT}/boot/addons/memtest" ] ; then
-          copy_addon_file memtest86+.bin /boot addons &&
+          copy_addon_file memtest86+x64.bin /boot addons &&
           # make memtest filename FAT16/8.3 compatible
-          mv "${BUILD_OUTPUT}/boot/addons/memtest86+.bin" \
+          mv "${BUILD_OUTPUT}/boot/addons/memtest86+x64.bin" \
+             "${BUILD_OUTPUT}/boot/addons/memtest"
+        elif [[ "$ARCH" == "i386" ]] ; then
+          copy_addon_file memtest86+ia32.bin /boot addons &&
+          # make memtest filename FAT16/8.3 compatible
+          mv "${BUILD_OUTPUT}/boot/addons/memtest86+ia32.bin" \
              "${BUILD_OUTPUT}/boot/addons/memtest"
         fi
+      fi
 
-        # since syslinux(-common) v3:6.03~pre1+dfsg-4 the files are in a
-        # different directory :(
-        if [ -d "${CHROOT_OUTPUT}/usr/lib/syslinux/modules/bios/" ] ; then
-          syslinux_modules_dir=/usr/lib/syslinux/modules/bios/
+      # fallback: if we still don't have /boot/addons/memtest available, we
+      # might have an older memtest86+ version (<=5.01-3.1) which ships
+      # file "memtest86+.bin" instead
+      if ! [ -r "${BUILD_OUTPUT}/boot/addons/memtest" ] ; then
+        copy_addon_file memtest86+.bin /boot addons &&
+        # make memtest filename FAT16/8.3 compatible
+        mv "${BUILD_OUTPUT}/boot/addons/memtest86+.bin" \
+           "${BUILD_OUTPUT}/boot/addons/memtest"
+      fi
+
+      # since syslinux(-common) v3:6.03~pre1+dfsg-4 the files are in a
+      # different directory :(
+      if [ -d "${CHROOT_OUTPUT}/usr/lib/syslinux/modules/bios/" ] ; then
+        syslinux_modules_dir=/usr/lib/syslinux/modules/bios/
+      else
+        syslinux_modules_dir=/usr/lib/syslinux
+      fi
+      for file in chain.c32 hdt.c32 mboot.c32 menu.c32; do
+        copy_addon_file "${file}" "${syslinux_modules_dir}" addons
+      done
+
+      copy_addon_file memdisk /usr/lib/syslinux addons
+
+      # copy only files so we can handle bsd4grml on its own
+      for file in "${TEMPLATE_DIRECTORY}"/boot/addons/* ; do
+        test -f "$file" && cp "$file" "$BUILD_OUTPUT"/boot/addons/
+      done
+
+      eend 0
+
+      if [ -n "$NO_ADDONS_BSD4GRML" ] ; then
+        log   "Skipping installation of bsd4grml as requested via \$NO_ADDONS_BSD4GRML."
+        einfo "Skipping installation of bsd4grml as requested via \$NO_ADDONS_BSD4GRML."; eend 0
+      else
+        if [ -d "$TEMPLATE_DIRECTORY"/boot/addons/bsd4grml ] ; then
+          cp -a "${TEMPLATE_DIRECTORY}"/boot/addons/bsd4grml "$BUILD_OUTPUT"/boot/addons/
         else
-          syslinux_modules_dir=/usr/lib/syslinux
+          log   "Missing addon file: bsd4grml"
+          ewarn "Missing addon file: bsd4grml" ; eend 0
         fi
-        for file in chain.c32 hdt.c32 mboot.c32 menu.c32; do
-          copy_addon_file "${file}" "${syslinux_modules_dir}" addons
-        done
-
-        copy_addon_file memdisk /usr/lib/syslinux addons
-
-        # copy only files so we can handle bsd4grml on its own
-        for file in "${TEMPLATE_DIRECTORY}"/boot/addons/* ; do
-          test -f "$file" && cp "$file" "$BUILD_OUTPUT"/boot/addons/
-        done
-
-        eend 0
-
-        if [ -n "$NO_ADDONS_BSD4GRML" ] ; then
-          log   "Skipping installation of bsd4grml as requested via \$NO_ADDONS_BSD4GRML."
-          einfo "Skipping installation of bsd4grml as requested via \$NO_ADDONS_BSD4GRML."; eend 0
-        else
-          if [ -d "$TEMPLATE_DIRECTORY"/boot/addons/bsd4grml ] ; then
-            cp -a "${TEMPLATE_DIRECTORY}"/boot/addons/bsd4grml "$BUILD_OUTPUT"/boot/addons/
-          else
-            log   "Missing addon file: bsd4grml"
-            ewarn "Missing addon file: bsd4grml" ; eend 0
-          fi
-        fi
-
-      fi # no "$TEMPLATE_DIRECTORY"/boot/addons
+      fi
     fi # NO_ADDONS
 
     # generate loopback.cfg config file without depending on grub's regexp module

--- a/grml-live
+++ b/grml-live
@@ -473,6 +473,12 @@ specify it on the command line using the -c option."
 [ -n "$OUTPUT" ] || bailout 1 "Error: \$OUTPUT unset, please set it in $LIVE_CONF or
 specify it on the command line using the -o option."
 
+if [ "$ARCH" != "i386" ] && [ "$ARCH" != "amd64" ] && [ "$ARCH" != "arm64" ] ; then
+  eerror 'Error: Unsupported ARCH, sorry. Want to support it? Contribute!'
+  eend 1
+  bailout
+fi
+
 if [[ "$(dpkg --print-architecture)" != "arm64" ]] && [[ "$ARCH" == "arm64" ]] ; then
   eerror "Failure: trying to build for arm64, but not running on arm64."
   eend 1
@@ -1067,384 +1073,378 @@ grub_setup() {
 mkdir -p "$BUILD_OUTPUT" || bailout 6 "Problem with creating $BUILD_OUTPUT for stage ARCH"
 
 # prepare ISO
-if [ "$ARCH" = i386 ] || [ "$ARCH" = amd64 ] || [ "$ARCH" = arm64 ] ; then
-  if [ -n "$BOOTSTRAP_ONLY" ] ; then
-    log   "Skipping stage 'boot' as building with bootstrap only."
-    ewarn "Skipping stage 'boot' as building with bootstrap only." ; eend 0
+if [ -n "$BOOTSTRAP_ONLY" ] ; then
+  log   "Skipping stage 'boot' as building with bootstrap only."
+  ewarn "Skipping stage 'boot' as building with bootstrap only." ; eend 0
+else
+  # booting stuff:
+  mkdir -p "$BUILD_OUTPUT"/boot/isolinux
+  mkdir -p "$BUILD_OUTPUT"/boot/"${SHORT_NAME}"
+
+  # this is a variable we're using for adjusting boot templates, not only in
+  # adjust_boot_files though, so set here
+  RELEASE_INFO="$GRML_NAME $VERSION - Release Codename $RELEASENAME"
+
+  # if we don't have an initrd we a) can't boot and b) there was an error
+  # during build, so check for the file:
+  # shellcheck disable=SC2010 disable=SC2012 # We do not expect fancy characters here.
+  INITRD=$(ls "$CHROOT_OUTPUT"/boot/initrd* 2>/dev/null| grep -v '.bak$' | sort -r | head -1)
+  if [ -n "$INITRD" ] ; then
+    cp "$INITRD" "$BUILD_OUTPUT"/boot/"${SHORT_NAME}"/initrd.img
+    find "$CHROOT_OUTPUT"/boot/ -name initrd\*.bak -exec rm {} \;
   else
-    # booting stuff:
-    mkdir -p "$BUILD_OUTPUT"/boot/isolinux
-    mkdir -p "$BUILD_OUTPUT"/boot/"${SHORT_NAME}"
+    log    "Error: No initrd found inside $CHROOT_OUTPUT/boot/ - Exiting"
+    eerror "Error: No initrd found inside $CHROOT_OUTPUT/boot/ - Exiting" ; eend 1
+    bailout 10
+  fi
 
-    # this is a variable we're using for adjusting boot templates, not only in
-    # adjust_boot_files though, so set here
-    RELEASE_INFO="$GRML_NAME $VERSION - Release Codename $RELEASENAME"
+  # shellcheck disable=SC2010 disable=SC2012 # We do not expect fancy characters here.
+  KERNEL_IMAGE=$(ls "$CHROOT_OUTPUT"/boot/vmlinuz* 2>/dev/null | sort -r | head -1)
+  if [ -n "$KERNEL_IMAGE" ] ; then
+    cp "$KERNEL_IMAGE" "$BUILD_OUTPUT"/boot/"${SHORT_NAME}"/vmlinuz
+  else
+    log    "Error: No kernel found inside $CHROOT_OUTPUT/boot/ - Exiting"
+    eerror "Error: No kernel found inside $CHROOT_OUTPUT/boot/ - Exiting" ; eend 1
+    bailout 11
+  fi
 
-    # if we don't have an initrd we a) can't boot and b) there was an error
-    # during build, so check for the file:
-    # shellcheck disable=SC2010 disable=SC2012 # We do not expect fancy characters here.
-    INITRD=$(ls "$CHROOT_OUTPUT"/boot/initrd* 2>/dev/null| grep -v '.bak$' | sort -r | head -1)
-    if [ -n "$INITRD" ] ; then
-      cp "$INITRD" "$BUILD_OUTPUT"/boot/"${SHORT_NAME}"/initrd.img
-      find "$CHROOT_OUTPUT"/boot/ -name initrd\*.bak -exec rm {} \;
-    else
-      log    "Error: No initrd found inside $CHROOT_OUTPUT/boot/ - Exiting"
-      eerror "Error: No initrd found inside $CHROOT_OUTPUT/boot/ - Exiting" ; eend 1
-      bailout 10
+  # we need to set "$BOOTID" before we invoke adjust_boot_files for the
+  # first time, being inside grub_setup below
+  if [ -n "$NO_BOOTID" ] ; then
+    log   "Skipping bootid feature as requested via \$NO_BOOTID."
+    einfo "Skipping bootid feature as requested via \$NO_BOOTID."
+  else
+    [ -n "$BOOTID" ] || BOOTID=$(echo "${GRML_NAME}${VERSION}" | tr -d ',./;\- ')
+    mkdir -p "$BUILD_OUTPUT"/conf
+    einfo "Generating /conf/bootid.txt with entry ${BOOTID}."
+    log   "Generating /conf/bootid.txt with entry ${BOOTID}."
+    echo "$BOOTID" > "$BUILD_OUTPUT"/conf/bootid.txt
+    eend 0
+  fi
+
+  # every recent Grml ISO ships a /conf/bootid.txt, though GRUB might find
+  # the /conf/bootid.txt of a different (Grml) ISO than the one that's
+  # supposed to be running, so within scripts/GRMLBASE/45-grub-images
+  # we generate a random filename, stored inside /boot/grub/bootfile.txt,
+  # which we place on the resulting ISO here
+  if [ -r "${CHROOT_OUTPUT}"/boot/grub/bootfile.txt ] ; then
+    mkdir -p "${BUILD_OUTPUT}"/conf
+    rm -f "${BUILD_OUTPUT}"/conf/bootfile*  # ensure we don't leave any old(er) files behind
+
+    einfo "Generating ${BUILD_OUTPUT}/conf/bootfile* files"
+    log   "Generating ${BUILD_OUTPUT}/conf/bootfile* files"
+
+    BOOT_FILE="/conf/bootfile_$(cat "${CHROOT_OUTPUT}"/boot/grub/bootfile.txt)"
+    echo "# This file is relevant for GRUB boot with the Grml ISO." > "${BUILD_OUTPUT}/${BOOT_FILE}"
+    # save information about the random filename inside /conf/bootfile.txt
+    echo "${BOOT_FILE}" > "${BUILD_OUTPUT}"/conf/bootfile.txt
+    eend 0
+  fi
+
+  grub_setup
+
+  # EFI boot files
+  if [ -r "${CHROOT_OUTPUT}/boot/efi.img" ] && [ -r "${CHROOT_OUTPUT}/boot/bootaa64.efi" ] ; then
+    einfo "Copying 64-bit EFI boot files (arm64) into ISO path."
+    log   "Copying 64-bit EFI boot files (arm64) into ISO path."
+    RC=0
+    cp "${CHROOT_OUTPUT}/boot/efi.img" "${BUILD_OUTPUT}/boot/" || RC=$?
+    mkdir -p "${BUILD_OUTPUT}/EFI/BOOT/" || RC=$?
+    cp "${CHROOT_OUTPUT}/boot/bootaa64.efi" "${BUILD_OUTPUT}/EFI/BOOT/bootaa64.efi" || RC=$?
+    eend "$RC"
+  elif [ -r "${CHROOT_OUTPUT}/boot/efi.img" ] && [ -r "${CHROOT_OUTPUT}/boot/bootx64.efi" ] ; then
+    einfo "Copying 64-bit EFI boot files (amd64) into ISO path."
+    log   "Copying 64-bit EFI boot files (amd64) into ISO path."
+    RC=0
+    cp "${CHROOT_OUTPUT}/boot/efi.img" "${BUILD_OUTPUT}/boot/" || RC=$?
+    mkdir -p "${BUILD_OUTPUT}/EFI/BOOT/" || RC=$?
+    cp "${CHROOT_OUTPUT}/boot/bootx64.efi" "${BUILD_OUTPUT}/EFI/BOOT/bootx64.efi" || RC=$?
+    eend "$RC"
+  elif [ -r "${CHROOT_OUTPUT}/boot/efi.img" ] && [ -r "${CHROOT_OUTPUT}/boot/bootia32.efi" ] ; then
+    einfo "Copying 32-bit EFI boot files into ISO path."
+    log   "Copying 32-bit EFI boot files into ISO path."
+    RC=0
+    cp "${CHROOT_OUTPUT}/boot/efi.img" "${BUILD_OUTPUT}/boot/" || RC=$?
+    mkdir -p "${BUILD_OUTPUT}/EFI/BOOT/" || RC=$?
+    cp "${CHROOT_OUTPUT}/boot/bootia32.efi" "${BUILD_OUTPUT}/EFI/BOOT/bootia32.efi" || RC=$?
+    eend "$RC"
+  else
+    ewarn "No EFI boot files found, skipping." ; eend 0
+  fi
+
+  if ! [ -d "${TEMPLATE_DIRECTORY}"/boot ] ; then
+    log    "Error: ${TEMPLATE_DIRECTORY}/boot does not exist. Exiting."
+    eerror "Error: ${TEMPLATE_DIRECTORY}/boot does not exist. Exiting." ; eend 1
+    bailout 8
+  fi
+
+  # copy _required_ isolinux files
+  if [ -d "${CHROOT_OUTPUT}/usr/lib/ISOLINUX" ] ; then
+    copy_addon_file isolinux.bin /usr/lib/ISOLINUX isolinux
+    for file in "${CHROOT_OUTPUT}"/usr/lib/syslinux/modules/bios/*.c32 ; do
+      copy_addon_file "$(basename "$file")"  /usr/lib/syslinux/modules/bios/ isolinux
+    done
+  else # syslinux versions <= 3:4.05+dfsg-6+deb8u1
+    copy_addon_file isolinux.bin /usr/lib/syslinux isolinux
+    copy_addon_file ifcpu64.c32  /usr/lib/syslinux isolinux
+    copy_addon_file vesamenu.c32 /usr/lib/syslinux isolinux
+  fi
+
+  # *always* copy files to output directory so the variables
+  # get adjusted according to the build.
+  cp "${TEMPLATE_DIRECTORY}"/boot/isolinux/*  "$BUILD_OUTPUT"/boot/isolinux/
+
+  mkdir -p "${BUILD_OUTPUT}/boot/grub"
+  cp -a "${TEMPLATE_DIRECTORY}"/boot/grub/* "$BUILD_OUTPUT"/boot/grub/
+
+  if [ -n "$NO_ADDONS" ] ; then
+    rm -f "$BUILD_OUTPUT"/boot/grub/addons.cfg
+    log   "Skipping installation of boot addons as \$NO_ADDONS=${NO_ADDONS}."
+    einfo "Skipping installation of boot addons as \$NO_ADDONS=${NO_ADDONS}."; eend 0
+  else
+    log   "Installing boot addons."
+    einfo "Installing boot addons."
+
+    # copy addons from system packages or grml-live-addons
+    copy_addon_file ipxe.lkrn /usr/lib/ipxe addons
+    copy_addon_file ipxe.efi /usr/lib/ipxe addons
+    copy_addon_file pci.ids /usr/share/misc addons
+
+    # memtest86+ >=6.00-1
+    if [[ "$ARCH" == "amd64" ]] ; then
+      copy_addon_file memtest86+x64.efi /boot addons
+    elif [[ "$ARCH" == "i386" ]] ; then
+      copy_addon_file memtest86+ia32.efi /boot addons
     fi
 
-    # shellcheck disable=SC2010 disable=SC2012 # We do not expect fancy characters here.
-    KERNEL_IMAGE=$(ls "$CHROOT_OUTPUT"/boot/vmlinuz* 2>/dev/null | sort -r | head -1)
-    if [ -n "$KERNEL_IMAGE" ] ; then
-      cp "$KERNEL_IMAGE" "$BUILD_OUTPUT"/boot/"${SHORT_NAME}"/vmlinuz
-    else
-      log    "Error: No kernel found inside $CHROOT_OUTPUT/boot/ - Exiting"
-      eerror "Error: No kernel found inside $CHROOT_OUTPUT/boot/ - Exiting" ; eend 1
-      bailout 11
-    fi
-
-    # we need to set "$BOOTID" before we invoke adjust_boot_files for the
-    # first time, being inside grub_setup below
-    if [ -n "$NO_BOOTID" ] ; then
-      log   "Skipping bootid feature as requested via \$NO_BOOTID."
-      einfo "Skipping bootid feature as requested via \$NO_BOOTID."
-    else
-      [ -n "$BOOTID" ] || BOOTID=$(echo "${GRML_NAME}${VERSION}" | tr -d ',./;\- ')
-      mkdir -p "$BUILD_OUTPUT"/conf
-      einfo "Generating /conf/bootid.txt with entry ${BOOTID}."
-      log   "Generating /conf/bootid.txt with entry ${BOOTID}."
-      echo "$BOOTID" > "$BUILD_OUTPUT"/conf/bootid.txt
-      eend 0
-    fi
-
-    # every recent Grml ISO ships a /conf/bootid.txt, though GRUB might find
-    # the /conf/bootid.txt of a different (Grml) ISO than the one that's
-    # supposed to be running, so within scripts/GRMLBASE/45-grub-images
-    # we generate a random filename, stored inside /boot/grub/bootfile.txt,
-    # which we place on the resulting ISO here
-    if [ -r "${CHROOT_OUTPUT}"/boot/grub/bootfile.txt ] ; then
-      mkdir -p "${BUILD_OUTPUT}"/conf
-      rm -f "${BUILD_OUTPUT}"/conf/bootfile*  # ensure we don't leave any old(er) files behind
-
-      einfo "Generating ${BUILD_OUTPUT}/conf/bootfile* files"
-      log   "Generating ${BUILD_OUTPUT}/conf/bootfile* files"
-
-      BOOT_FILE="/conf/bootfile_$(cat "${CHROOT_OUTPUT}"/boot/grub/bootfile.txt)"
-      echo "# This file is relevant for GRUB boot with the Grml ISO." > "${BUILD_OUTPUT}/${BOOT_FILE}"
-      # save information about the random filename inside /conf/bootfile.txt
-      echo "${BOOT_FILE}" > "${BUILD_OUTPUT}"/conf/bootfile.txt
-      eend 0
-    fi
-
-    grub_setup
-
-    # EFI boot files
-    if [ -r "${CHROOT_OUTPUT}/boot/efi.img" ] && [ -r "${CHROOT_OUTPUT}/boot/bootaa64.efi" ] ; then
-      einfo "Copying 64-bit EFI boot files (arm64) into ISO path."
-      log   "Copying 64-bit EFI boot files (arm64) into ISO path."
-      RC=0
-      cp "${CHROOT_OUTPUT}/boot/efi.img" "${BUILD_OUTPUT}/boot/" || RC=$?
-      mkdir -p "${BUILD_OUTPUT}/EFI/BOOT/" || RC=$?
-      cp "${CHROOT_OUTPUT}/boot/bootaa64.efi" "${BUILD_OUTPUT}/EFI/BOOT/bootaa64.efi" || RC=$?
-      eend "$RC"
-    elif [ -r "${CHROOT_OUTPUT}/boot/efi.img" ] && [ -r "${CHROOT_OUTPUT}/boot/bootx64.efi" ] ; then
-      einfo "Copying 64-bit EFI boot files (amd64) into ISO path."
-      log   "Copying 64-bit EFI boot files (amd64) into ISO path."
-      RC=0
-      cp "${CHROOT_OUTPUT}/boot/efi.img" "${BUILD_OUTPUT}/boot/" || RC=$?
-      mkdir -p "${BUILD_OUTPUT}/EFI/BOOT/" || RC=$?
-      cp "${CHROOT_OUTPUT}/boot/bootx64.efi" "${BUILD_OUTPUT}/EFI/BOOT/bootx64.efi" || RC=$?
-      eend "$RC"
-    elif [ -r "${CHROOT_OUTPUT}/boot/efi.img" ] && [ -r "${CHROOT_OUTPUT}/boot/bootia32.efi" ] ; then
-      einfo "Copying 32-bit EFI boot files into ISO path."
-      log   "Copying 32-bit EFI boot files into ISO path."
-      RC=0
-      cp "${CHROOT_OUTPUT}/boot/efi.img" "${BUILD_OUTPUT}/boot/" || RC=$?
-      mkdir -p "${BUILD_OUTPUT}/EFI/BOOT/" || RC=$?
-      cp "${CHROOT_OUTPUT}/boot/bootia32.efi" "${BUILD_OUTPUT}/EFI/BOOT/bootia32.efi" || RC=$?
-      eend "$RC"
-    else
-      ewarn "No EFI boot files found, skipping." ; eend 0
-    fi
-
-    if ! [ -d "${TEMPLATE_DIRECTORY}"/boot ] ; then
-      log    "Error: ${TEMPLATE_DIRECTORY}/boot does not exist. Exiting."
-      eerror "Error: ${TEMPLATE_DIRECTORY}/boot does not exist. Exiting." ; eend 1
-      bailout 8
-    fi
-
-    # copy _required_ isolinux files
-    if [ -d "${CHROOT_OUTPUT}/usr/lib/ISOLINUX" ] ; then
-      copy_addon_file isolinux.bin /usr/lib/ISOLINUX isolinux
-      for file in "${CHROOT_OUTPUT}"/usr/lib/syslinux/modules/bios/*.c32 ; do
-        copy_addon_file "$(basename "$file")"  /usr/lib/syslinux/modules/bios/ isolinux
-      done
-    else # syslinux versions <= 3:4.05+dfsg-6+deb8u1
-      copy_addon_file isolinux.bin /usr/lib/syslinux isolinux
-      copy_addon_file ifcpu64.c32  /usr/lib/syslinux isolinux
-      copy_addon_file vesamenu.c32 /usr/lib/syslinux isolinux
-    fi
-
-    # *always* copy files to output directory so the variables
-    # get adjusted according to the build.
-    cp "${TEMPLATE_DIRECTORY}"/boot/isolinux/*  "$BUILD_OUTPUT"/boot/isolinux/
-
-    mkdir -p "${BUILD_OUTPUT}/boot/grub"
-    cp -a "${TEMPLATE_DIRECTORY}"/boot/grub/* "$BUILD_OUTPUT"/boot/grub/
-
-    if [ -n "$NO_ADDONS" ] ; then
-      rm -f "$BUILD_OUTPUT"/boot/grub/addons.cfg
-      log   "Skipping installation of boot addons as \$NO_ADDONS=${NO_ADDONS}."
-      einfo "Skipping installation of boot addons as \$NO_ADDONS=${NO_ADDONS}."; eend 0
-    else
-      log   "Installing boot addons."
-      einfo "Installing boot addons."
-
-      # copy addons from system packages or grml-live-addons
-      copy_addon_file ipxe.lkrn /usr/lib/ipxe addons
-      copy_addon_file ipxe.efi /usr/lib/ipxe addons
-      copy_addon_file pci.ids /usr/share/misc addons
-
-      # memtest86+ >=6.00-1
+    # provide memtest86+ >=6.00-1 files as "memtest" file
+    # for BIOS boot in isolinux/syslinux
+    if ! [ -r "${BUILD_OUTPUT}/boot/addons/memtest" ] ; then
       if [[ "$ARCH" == "amd64" ]] ; then
-        copy_addon_file memtest86+x64.efi /boot addons
-      elif [[ "$ARCH" == "i386" ]] ; then
-        copy_addon_file memtest86+ia32.efi /boot addons
-      fi
-
-      # provide memtest86+ >=6.00-1 files as "memtest" file
-      # for BIOS boot in isolinux/syslinux
-      if ! [ -r "${BUILD_OUTPUT}/boot/addons/memtest" ] ; then
-        if [[ "$ARCH" == "amd64" ]] ; then
-          copy_addon_file memtest86+x64.bin /boot addons &&
-          # make memtest filename FAT16/8.3 compatible
-          mv "${BUILD_OUTPUT}/boot/addons/memtest86+x64.bin" \
-             "${BUILD_OUTPUT}/boot/addons/memtest"
-        elif [[ "$ARCH" == "i386" ]] ; then
-          copy_addon_file memtest86+ia32.bin /boot addons &&
-          # make memtest filename FAT16/8.3 compatible
-          mv "${BUILD_OUTPUT}/boot/addons/memtest86+ia32.bin" \
-             "${BUILD_OUTPUT}/boot/addons/memtest"
-        fi
-      fi
-
-      # fallback: if we still don't have /boot/addons/memtest available, we
-      # might have an older memtest86+ version (<=5.01-3.1) which ships
-      # file "memtest86+.bin" instead
-      if ! [ -r "${BUILD_OUTPUT}/boot/addons/memtest" ] ; then
-        copy_addon_file memtest86+.bin /boot addons &&
+        copy_addon_file memtest86+x64.bin /boot addons &&
         # make memtest filename FAT16/8.3 compatible
-        mv "${BUILD_OUTPUT}/boot/addons/memtest86+.bin" \
+        mv "${BUILD_OUTPUT}/boot/addons/memtest86+x64.bin" \
+           "${BUILD_OUTPUT}/boot/addons/memtest"
+      elif [[ "$ARCH" == "i386" ]] ; then
+        copy_addon_file memtest86+ia32.bin /boot addons &&
+        # make memtest filename FAT16/8.3 compatible
+        mv "${BUILD_OUTPUT}/boot/addons/memtest86+ia32.bin" \
            "${BUILD_OUTPUT}/boot/addons/memtest"
       fi
-
-      # since syslinux(-common) v3:6.03~pre1+dfsg-4 the files are in a
-      # different directory :(
-      if [ -d "${CHROOT_OUTPUT}/usr/lib/syslinux/modules/bios/" ] ; then
-        syslinux_modules_dir=/usr/lib/syslinux/modules/bios/
-      else
-        syslinux_modules_dir=/usr/lib/syslinux
-      fi
-      for file in chain.c32 hdt.c32 mboot.c32 menu.c32; do
-        copy_addon_file "${file}" "${syslinux_modules_dir}" addons
-      done
-
-      copy_addon_file memdisk /usr/lib/syslinux addons
-
-      # copy only files so we can handle bsd4grml on its own
-      for file in "${TEMPLATE_DIRECTORY}"/boot/addons/* ; do
-        test -f "$file" && cp "$file" "$BUILD_OUTPUT"/boot/addons/
-      done
-
-      eend 0
-
-      if [ -n "$NO_ADDONS_BSD4GRML" ] ; then
-        log   "Skipping installation of bsd4grml as requested via \$NO_ADDONS_BSD4GRML."
-        einfo "Skipping installation of bsd4grml as requested via \$NO_ADDONS_BSD4GRML."; eend 0
-      else
-        if [ -d "$TEMPLATE_DIRECTORY"/boot/addons/bsd4grml ] ; then
-          cp -a "${TEMPLATE_DIRECTORY}"/boot/addons/bsd4grml "$BUILD_OUTPUT"/boot/addons/
-        else
-          log   "Missing addon file: bsd4grml"
-          ewarn "Missing addon file: bsd4grml" ; eend 0
-        fi
-      fi
-    fi # NO_ADDONS
-
-    # generate loopback.cfg config file without depending on grub's regexp module
-    # which isn't available in Debian/squeeze
-    echo "## grub2 loopback configuration" > "${BUILD_OUTPUT}"/boot/grub/loopback.cfg
-    echo "source /boot/grub/header.cfg" >> "${BUILD_OUTPUT}"/boot/grub/loopback.cfg
-    for config in "${BUILD_OUTPUT}"/boot/grub/*_default.cfg "${BUILD_OUTPUT}"/boot/grub/*_options.cfg ; do
-      [ -r "$config" ] || continue
-      echo "source ${config##"$BUILD_OUTPUT"}" >> "${BUILD_OUTPUT}"/boot/grub/loopback.cfg
-    done
-    if [ -z "$NO_ADDONS" ] ; then
-      echo "source /boot/grub/addons.cfg" >> "${BUILD_OUTPUT}"/boot/grub/loopback.cfg
-    fi
-    echo "source /boot/grub/footer.cfg" >> "${BUILD_OUTPUT}"/boot/grub/loopback.cfg
-
-    # copy modules for GRUB
-    if [ "${ARCH}" = "arm64" ] ; then
-      mkdir -p "${BUILD_OUTPUT}"/boot/grub/arm64-efi/
-      cp -a "${CHROOT_OUTPUT}"/usr/lib/grub/arm64-efi/*.mod "${BUILD_OUTPUT}"/boot/grub/arm64-efi/
-      cp -a "${CHROOT_OUTPUT}"/usr/lib/grub/arm64-efi/*.lst "${BUILD_OUTPUT}"/boot/grub/arm64-efi/
-      # NOTE: usage of /boot/grub/core.img + /boot/grub/grub.img unclear yet
-    elif [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "i386" ] ; then
-      # grub-pc-bin
-      mkdir -p "${BUILD_OUTPUT}"/boot/grub/i386-pc/
-      cp -a "${CHROOT_OUTPUT}"/usr/lib/grub/*-pc/*.mod  "${BUILD_OUTPUT}"/boot/grub/i386-pc/
-      cp -a "${CHROOT_OUTPUT}"/usr/lib/grub/*-pc/*.o    "${BUILD_OUTPUT}"/boot/grub/i386-pc/
-      cp -a "${CHROOT_OUTPUT}"/usr/lib/grub/*-pc/*.lst  "${BUILD_OUTPUT}"/boot/grub/i386-pc/
-
-      # grub-efi-amd64-bin
-      mkdir -p "${BUILD_OUTPUT}"/boot/grub/x86_64-efi/
-      cp -a "${CHROOT_OUTPUT}"/usr/lib/grub/x86_64-efi/*.{mod,lst} "${BUILD_OUTPUT}"/boot/grub/x86_64-efi/
-
-      # grub-efi-ia32-bin
-      mkdir -p "${BUILD_OUTPUT}"/boot/grub/i386-efi/
-      cp -a "${CHROOT_OUTPUT}"/usr/lib/grub/i386-efi/*.{mod,lst} "${BUILD_OUTPUT}"/boot/grub/i386-efi/
-
-      cp -a "${CHROOT_OUTPUT}"/boot/grub/core.img       "${BUILD_OUTPUT}"/boot/grub/
-      cp -a "${CHROOT_OUTPUT}"/boot/grub/grub.img       "${BUILD_OUTPUT}"/boot/grub/
     fi
 
-    # arch independent files
-    cp -a "${CHROOT_OUTPUT}"/usr/share/grub/unicode.pf2   "${BUILD_OUTPUT}"/boot/grub/
-
-    if ! [ -d "${TEMPLATE_DIRECTORY}"/GRML ] ; then
-      log    "Error: ${TEMPLATE_DIRECTORY}/GRML does not exist. Exiting."
-      eerror "Error: ${TEMPLATE_DIRECTORY}/GRML does not exist. Exiting." ; eend 1
-      bailout 9
+    # fallback: if we still don't have /boot/addons/memtest available, we
+    # might have an older memtest86+ version (<=5.01-3.1) which ships
+    # file "memtest86+.bin" instead
+    if ! [ -r "${BUILD_OUTPUT}/boot/addons/memtest" ] ; then
+      copy_addon_file memtest86+.bin /boot addons &&
+      # make memtest filename FAT16/8.3 compatible
+      mv "${BUILD_OUTPUT}/boot/addons/memtest86+.bin" \
+         "${BUILD_OUTPUT}/boot/addons/memtest"
     fi
 
-    mkdir -p "$BUILD_OUTPUT"/GRML/"${GRML_NAME}"/
-    cp -a "${TEMPLATE_DIRECTORY}"/GRML/* "$BUILD_OUTPUT"/GRML/"${GRML_NAME}"/
-
-    if [ -r "$BUILD_OUTPUT"/GRML/"${GRML_NAME}"/grml-version ] ; then
-      sed -i "s/%RELEASE_INFO%/$RELEASE_INFO/" "$BUILD_OUTPUT"/GRML/"${GRML_NAME}"/grml-version
-      sed -i "s/%DATE%/$DATE/"                 "$BUILD_OUTPUT"/GRML/"${GRML_NAME}"/grml-version
-    fi
-
-    # make sure the squashfs filename is set accordingly:
-    SQUASHFS_NAME="$GRML_NAME.squashfs"
-    # adjust bootsplash accordingly but make sure the string has the according length
-    fixed_squashfs_name="$(cut_string 20 "$SQUASHFS_NAME")"
-    fixed_squashfs_name="$(extend_string_end 20 "$fixed_squashfs_name")"
-    for file in f4 f5 ; do
-      if [ -r "${BUILD_OUTPUT}/boot/isolinux/${file}" ] ; then
-        sed -i "s/%SQUASHFS_NAME%/${fixed_squashfs_name}/" "${BUILD_OUTPUT}/boot/isolinux/${file}"
-        sed -i "s/%SQUASHFS_NAME%/${fixed_squashfs_name}/" "${BUILD_OUTPUT}/boot/isolinux/${file}"
-      fi
-    done
-
-    # adjust all variables in the templates with the according distribution information
-    adjust_boot_files "${BUILD_OUTPUT}"/boot/isolinux/*.cfg \
-      "${BUILD_OUTPUT}"/boot/isolinux/*.msg \
-      "${BUILD_OUTPUT}"/boot/grub/*
-
-    for param in ARCH DATE DISTRI_INFO DISTRI_NAME DISTRI_SPLASH GRML_NAME SQUASHFS_NAME \
-      RELEASE_INFO SHORT_NAME VERSION ; do
-      while IFS= read -r -d '' file ; do
-        value=$(eval echo '$'"$param")
-        mv "${file}" "${file/\%${param}\%/$value}"
-      done < <(find "${BUILD_OUTPUT}" -name "*%$param%*" -print0)
-    done
-
-    # generate addon list
-    rm -f "${BUILD_OUTPUT}/${ADDONS_LIST_FILE}"
-    for name in "${BUILD_OUTPUT}"/boot/isolinux/addon_*.cfg ; do
-      include_name=$(basename "$name")
-      echo "include $include_name"  >> "${BUILD_OUTPUT}/${ADDONS_LIST_FILE}"
-    done
-
-    if ! [ -r "${BUILD_OUTPUT}/boot/isolinux/${DISTRI_NAME}.cfg" ] || [ "$DISTRI_NAME" = "grml" ] ; then
-      log "including grmlmain.cfg in ${BUILD_OUTPUT}/boot/isolinux/distri.cfg"
-      echo "include grmlmain.cfg"    >  "${BUILD_OUTPUT}/boot/isolinux/distri.cfg"
-
-      # Generate grmlmain.cfg
-      {
-        echo "include default.cfg"
-        echo "include menuoptions.cfg"
-        echo "include grml.cfg"
-        for f in "${BUILD_OUTPUT}"/boot/isolinux/submenu*.cfg ; do
-          echo "include $(basename "$f")"
-        done
-        echo "include options.cfg"
-        if [ -z "$NO_ADDONS" ] ; then
-          echo "include addons.cfg"
-        fi
-        echo "include isoprompt.cfg"
-        echo "include hd.cfg"
-        echo "include hidden.cfg"
-      } > "${BUILD_OUTPUT}/boot/isolinux/grmlmain.cfg"
-    else # assume we are building a custom distribution:
-      log "File ${BUILD_OUTPUT}/boot/isolinux/${DISTRI_NAME}.cfg found, using it."
-      einfo "File ${BUILD_OUTPUT}/boot/isolinux/${DISTRI_NAME}.cfg found, using it."
-      if grep -q "^include ${DISTRI_NAME}.cfg" "${BUILD_OUTPUT}/boot/isolinux/distri.cfg" ; then
-        log "include for ${DISTRI_NAME}.cfg already present, nothing to do."
-        eindent
-        einfo "include for ${DISTRI_NAME}.cfg already present, nothing to do."
-        eoutdent
-        eend $?
-      else
-        log "including ${DISTRI_NAME}.cfg in ${BUILD_OUTPUT}/boot/isolinux/distri.cfg"
-        echo "include ${DISTRI_NAME}.cfg" > "${BUILD_OUTPUT}/boot/isolinux/distri.cfg"
-        if [ -z "$NO_ADDONS" ] ; then
-          echo "include addons.cfg" >> "${BUILD_OUTPUT}/boot/isolinux/distri.cfg"
-        fi
-      fi
-    fi
-
-    # use old style console based isolinux method only if requested:
-    if [[ "${ISOLINUX_METHOD}" == "console" ]] ; then
-      log "Using console based isolinux method as requested via \$ISOLINUX_METHOD."
-      einfo "Using console based isolinux method as requested via \$ISOLINUX_METHOD."
-      if grep -q '^include console.cfg' "${BUILD_OUTPUT}/boot/isolinux/distri.cfg" ; then
-        einfo "include for console.cfg already found, nothing to do."
-        eend 0
-      else
-        log "including console.cfg in ${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg"
-        einfo "including console.cfg in ${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg"
-        echo "include console.cfg" >> "${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg"
-        eend 0
-      fi
+    # since syslinux(-common) v3:6.03~pre1+dfsg-4 the files are in a
+    # different directory :(
+    if [ -d "${CHROOT_OUTPUT}/usr/lib/syslinux/modules/bios/" ] ; then
+      syslinux_modules_dir=/usr/lib/syslinux/modules/bios/
     else
-      log 'Using graphical boot menu.'
-      if grep -q '^include vesamenu.cfg' "${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg" ; then
-        log "include for vesamenu.cfg already found, nothing to do."
+      syslinux_modules_dir=/usr/lib/syslinux
+    fi
+    for file in chain.c32 hdt.c32 mboot.c32 menu.c32; do
+      copy_addon_file "${file}" "${syslinux_modules_dir}" addons
+    done
+
+    copy_addon_file memdisk /usr/lib/syslinux addons
+
+    # copy only files so we can handle bsd4grml on its own
+    for file in "${TEMPLATE_DIRECTORY}"/boot/addons/* ; do
+      test -f "$file" && cp "$file" "$BUILD_OUTPUT"/boot/addons/
+    done
+
+    eend 0
+
+    if [ -n "$NO_ADDONS_BSD4GRML" ] ; then
+      log   "Skipping installation of bsd4grml as requested via \$NO_ADDONS_BSD4GRML."
+      einfo "Skipping installation of bsd4grml as requested via \$NO_ADDONS_BSD4GRML."; eend 0
+    else
+      if [ -d "$TEMPLATE_DIRECTORY"/boot/addons/bsd4grml ] ; then
+        cp -a "${TEMPLATE_DIRECTORY}"/boot/addons/bsd4grml "$BUILD_OUTPUT"/boot/addons/
       else
-        log "including vesamenu.cfg in ${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg"
-        echo "include vesamenu.cfg" >> "${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg"
+        log   "Missing addon file: bsd4grml"
+        ewarn "Missing addon file: bsd4grml" ; eend 0
       fi
     fi
+  fi # NO_ADDONS
 
-    if [ -e "$BUILD_OUTPUT"/boot/addons/bsd4grml/boot.6 ]; then
-      sed -i "s/%RELEASE_INFO%/$RELEASE_INFO/" "$BUILD_OUTPUT"/boot/addons/bsd4grml/boot.6
+  # generate loopback.cfg config file without depending on grub's regexp module
+  # which isn't available in Debian/squeeze
+  echo "## grub2 loopback configuration" > "${BUILD_OUTPUT}"/boot/grub/loopback.cfg
+  echo "source /boot/grub/header.cfg" >> "${BUILD_OUTPUT}"/boot/grub/loopback.cfg
+  for config in "${BUILD_OUTPUT}"/boot/grub/*_default.cfg "${BUILD_OUTPUT}"/boot/grub/*_options.cfg ; do
+    [ -r "$config" ] || continue
+    echo "source ${config##"$BUILD_OUTPUT"}" >> "${BUILD_OUTPUT}"/boot/grub/loopback.cfg
+  done
+  if [ -z "$NO_ADDONS" ] ; then
+    echo "source /boot/grub/addons.cfg" >> "${BUILD_OUTPUT}"/boot/grub/loopback.cfg
+  fi
+  echo "source /boot/grub/footer.cfg" >> "${BUILD_OUTPUT}"/boot/grub/loopback.cfg
+
+  # copy modules for GRUB
+  if [ "${ARCH}" = "arm64" ] ; then
+    mkdir -p "${BUILD_OUTPUT}"/boot/grub/arm64-efi/
+    cp -a "${CHROOT_OUTPUT}"/usr/lib/grub/arm64-efi/*.mod "${BUILD_OUTPUT}"/boot/grub/arm64-efi/
+    cp -a "${CHROOT_OUTPUT}"/usr/lib/grub/arm64-efi/*.lst "${BUILD_OUTPUT}"/boot/grub/arm64-efi/
+    # NOTE: usage of /boot/grub/core.img + /boot/grub/grub.img unclear yet
+  elif [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "i386" ] ; then
+    # grub-pc-bin
+    mkdir -p "${BUILD_OUTPUT}"/boot/grub/i386-pc/
+    cp -a "${CHROOT_OUTPUT}"/usr/lib/grub/*-pc/*.mod  "${BUILD_OUTPUT}"/boot/grub/i386-pc/
+    cp -a "${CHROOT_OUTPUT}"/usr/lib/grub/*-pc/*.o    "${BUILD_OUTPUT}"/boot/grub/i386-pc/
+    cp -a "${CHROOT_OUTPUT}"/usr/lib/grub/*-pc/*.lst  "${BUILD_OUTPUT}"/boot/grub/i386-pc/
+
+    # grub-efi-amd64-bin
+    mkdir -p "${BUILD_OUTPUT}"/boot/grub/x86_64-efi/
+    cp -a "${CHROOT_OUTPUT}"/usr/lib/grub/x86_64-efi/*.{mod,lst} "${BUILD_OUTPUT}"/boot/grub/x86_64-efi/
+
+    # grub-efi-ia32-bin
+    mkdir -p "${BUILD_OUTPUT}"/boot/grub/i386-efi/
+    cp -a "${CHROOT_OUTPUT}"/usr/lib/grub/i386-efi/*.{mod,lst} "${BUILD_OUTPUT}"/boot/grub/i386-efi/
+
+    cp -a "${CHROOT_OUTPUT}"/boot/grub/core.img       "${BUILD_OUTPUT}"/boot/grub/
+    cp -a "${CHROOT_OUTPUT}"/boot/grub/grub.img       "${BUILD_OUTPUT}"/boot/grub/
+  fi
+
+  # arch independent files
+  cp -a "${CHROOT_OUTPUT}"/usr/share/grub/unicode.pf2   "${BUILD_OUTPUT}"/boot/grub/
+
+  if ! [ -d "${TEMPLATE_DIRECTORY}"/GRML ] ; then
+    log    "Error: ${TEMPLATE_DIRECTORY}/GRML does not exist. Exiting."
+    eerror "Error: ${TEMPLATE_DIRECTORY}/GRML does not exist. Exiting." ; eend 1
+    bailout 9
+  fi
+
+  mkdir -p "$BUILD_OUTPUT"/GRML/"${GRML_NAME}"/
+  cp -a "${TEMPLATE_DIRECTORY}"/GRML/* "$BUILD_OUTPUT"/GRML/"${GRML_NAME}"/
+
+  if [ -r "$BUILD_OUTPUT"/GRML/"${GRML_NAME}"/grml-version ] ; then
+    sed -i "s/%RELEASE_INFO%/$RELEASE_INFO/" "$BUILD_OUTPUT"/GRML/"${GRML_NAME}"/grml-version
+    sed -i "s/%DATE%/$DATE/"                 "$BUILD_OUTPUT"/GRML/"${GRML_NAME}"/grml-version
+  fi
+
+  # make sure the squashfs filename is set accordingly:
+  SQUASHFS_NAME="$GRML_NAME.squashfs"
+  # adjust bootsplash accordingly but make sure the string has the according length
+  fixed_squashfs_name="$(cut_string 20 "$SQUASHFS_NAME")"
+  fixed_squashfs_name="$(extend_string_end 20 "$fixed_squashfs_name")"
+  for file in f4 f5 ; do
+    if [ -r "${BUILD_OUTPUT}/boot/isolinux/${file}" ] ; then
+      sed -i "s/%SQUASHFS_NAME%/${fixed_squashfs_name}/" "${BUILD_OUTPUT}/boot/isolinux/${file}"
+      sed -i "s/%SQUASHFS_NAME%/${fixed_squashfs_name}/" "${BUILD_OUTPUT}/boot/isolinux/${file}"
     fi
+  done
 
-    DPKG_LIST="/var/log/fai/$HOSTNAME/last/dpkg.list" # the dpkg --list output of the chroot
-    if ! [ -r "$DPKG_LIST" ] ; then
-      ewarn "$DPKG_LIST could not be read, ignoring to store package information on ISO therefore."
-    else
-      einfo "Storing package list information as /GRML/${GRML_NAME}/packages.txt on ISO."
-      cp "$DPKG_LIST" "${BUILD_OUTPUT}"/GRML/"${GRML_NAME}"/packages.txt
+  # adjust all variables in the templates with the according distribution information
+  adjust_boot_files "${BUILD_OUTPUT}"/boot/isolinux/*.cfg \
+    "${BUILD_OUTPUT}"/boot/isolinux/*.msg \
+    "${BUILD_OUTPUT}"/boot/grub/*
+
+  for param in ARCH DATE DISTRI_INFO DISTRI_NAME DISTRI_SPLASH GRML_NAME SQUASHFS_NAME \
+    RELEASE_INFO SHORT_NAME VERSION ; do
+    while IFS= read -r -d '' file ; do
+      value=$(eval echo '$'"$param")
+      mv "${file}" "${file/\%${param}\%/$value}"
+    done < <(find "${BUILD_OUTPUT}" -name "*%$param%*" -print0)
+  done
+
+  # generate addon list
+  rm -f "${BUILD_OUTPUT}/${ADDONS_LIST_FILE}"
+  for name in "${BUILD_OUTPUT}"/boot/isolinux/addon_*.cfg ; do
+    include_name=$(basename "$name")
+    echo "include $include_name"  >> "${BUILD_OUTPUT}/${ADDONS_LIST_FILE}"
+  done
+
+  if ! [ -r "${BUILD_OUTPUT}/boot/isolinux/${DISTRI_NAME}.cfg" ] || [ "$DISTRI_NAME" = "grml" ] ; then
+    log "including grmlmain.cfg in ${BUILD_OUTPUT}/boot/isolinux/distri.cfg"
+    echo "include grmlmain.cfg"    >  "${BUILD_OUTPUT}/boot/isolinux/distri.cfg"
+
+    # Generate grmlmain.cfg
+    {
+      echo "include default.cfg"
+      echo "include menuoptions.cfg"
+      echo "include grml.cfg"
+      for f in "${BUILD_OUTPUT}"/boot/isolinux/submenu*.cfg ; do
+        echo "include $(basename "$f")"
+      done
+      echo "include options.cfg"
+      if [ -z "$NO_ADDONS" ] ; then
+        echo "include addons.cfg"
+      fi
+      echo "include isoprompt.cfg"
+      echo "include hd.cfg"
+      echo "include hidden.cfg"
+    } > "${BUILD_OUTPUT}/boot/isolinux/grmlmain.cfg"
+  else # assume we are building a custom distribution:
+    log "File ${BUILD_OUTPUT}/boot/isolinux/${DISTRI_NAME}.cfg found, using it."
+    einfo "File ${BUILD_OUTPUT}/boot/isolinux/${DISTRI_NAME}.cfg found, using it."
+    if grep -q "^include ${DISTRI_NAME}.cfg" "${BUILD_OUTPUT}/boot/isolinux/distri.cfg" ; then
+      log "include for ${DISTRI_NAME}.cfg already present, nothing to do."
+      eindent
+      einfo "include for ${DISTRI_NAME}.cfg already present, nothing to do."
+      eoutdent
       eend $?
+    else
+      log "including ${DISTRI_NAME}.cfg in ${BUILD_OUTPUT}/boot/isolinux/distri.cfg"
+      echo "include ${DISTRI_NAME}.cfg" > "${BUILD_OUTPUT}/boot/isolinux/distri.cfg"
+      if [ -z "$NO_ADDONS" ] ; then
+        echo "include addons.cfg" >> "${BUILD_OUTPUT}/boot/isolinux/distri.cfg"
+      fi
     fi
+  fi
 
-    # autostart for Windows:
-    if [ -d "${TEMPLATE_DIRECTORY}/windows/autostart/" ] ; then
-      cp "${TEMPLATE_DIRECTORY}"/windows/autostart/* "$BUILD_OUTPUT"/
+  # use old style console based isolinux method only if requested:
+  if [[ "${ISOLINUX_METHOD}" == "console" ]] ; then
+    log "Using console based isolinux method as requested via \$ISOLINUX_METHOD."
+    einfo "Using console based isolinux method as requested via \$ISOLINUX_METHOD."
+    if grep -q '^include console.cfg' "${BUILD_OUTPUT}/boot/isolinux/distri.cfg" ; then
+      einfo "include for console.cfg already found, nothing to do."
+      eend 0
+    else
+      log "including console.cfg in ${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg"
+      einfo "including console.cfg in ${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg"
+      echo "include console.cfg" >> "${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg"
+      eend 0
     fi
+  else
+    log 'Using graphical boot menu.'
+    if grep -q '^include vesamenu.cfg' "${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg" ; then
+      log "include for vesamenu.cfg already found, nothing to do."
+    else
+      log "including vesamenu.cfg in ${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg"
+      echo "include vesamenu.cfg" >> "${BUILD_OUTPUT}/boot/isolinux/isolinux.cfg"
+    fi
+  fi
 
-    FORCE_ISO_REBUILD=true
-    einfo "Finished execution of stage 'boot'" ; eend 0
-  fi # BOOTSTRAP_ONLY
-else
-  log    'Error: Unsupported ARCH, sorry. Want to support it? Contribute!'
-  eerror 'Error: Unsupported ARCH, sorry. Want to support it? Contribute!' ; eend 1
-  bailout
-fi
+  if [ -e "$BUILD_OUTPUT"/boot/addons/bsd4grml/boot.6 ]; then
+    sed -i "s/%RELEASE_INFO%/$RELEASE_INFO/" "$BUILD_OUTPUT"/boot/addons/bsd4grml/boot.6
+  fi
+
+  DPKG_LIST="/var/log/fai/$HOSTNAME/last/dpkg.list" # the dpkg --list output of the chroot
+  if ! [ -r "$DPKG_LIST" ] ; then
+    ewarn "$DPKG_LIST could not be read, ignoring to store package information on ISO therefore."
+  else
+    einfo "Storing package list information as /GRML/${GRML_NAME}/packages.txt on ISO."
+    cp "$DPKG_LIST" "${BUILD_OUTPUT}"/GRML/"${GRML_NAME}"/packages.txt
+    eend $?
+  fi
+
+  # autostart for Windows:
+  if [ -d "${TEMPLATE_DIRECTORY}/windows/autostart/" ] ; then
+    cp "${TEMPLATE_DIRECTORY}"/windows/autostart/* "$BUILD_OUTPUT"/
+  fi
+
+  FORCE_ISO_REBUILD=true
+  einfo "Finished execution of stage 'boot'" ; eend 0
+fi # BOOTSTRAP_ONLY
 
 # support installation of local files into the chroot/ISO
 if [ -n "$CHROOT_INSTALL" ] ; then

--- a/templates/boot/grub/addons.cfg
+++ b/templates/boot/grub/addons.cfg
@@ -123,13 +123,3 @@ if [ "${grub_platform}" != "efi" ] ; then
     fi # iso_path
 fi # efi mode
 }
-
-if [ "${grub_platform}" == "efi" ] ; then
-menuentry "UEFI Firmware Settings" {
-    fwsetup
-}
-fi # efi mode
-
-menuentry "Boot from next device" {
-    exit
-}

--- a/templates/boot/grub/grub.cfg
+++ b/templates/boot/grub/grub.cfg
@@ -19,5 +19,15 @@ if [ -f /boot/grub/addons.cfg ] ; then
     source "/boot/grub/addons.cfg"
 fi
 
+if [ "${grub_platform}" == "efi" ] ; then
+menuentry "UEFI Firmware Settings" {
+    fwsetup
+}
+fi # efi mode
+
+menuentry "Boot from next device" {
+    exit
+}
+
 source /boot/grub/footer.cfg
 # EOF


### PR DESCRIPTION
Moves non-addon entries out of addons.cfg. With NO_ADDONS=1, addons.cfg is deleted, but those entries should still exist.

Then we set NO_ADDONS=1 early, if the addons directory is missing, instead of just complaining later.

With this, the same code path as for NO_ADDONS=1 is executed, when the addons directory is missing. This causes addons.cfg to be (correctly!) deleted.

Also add NO_ADDONS=1 state to grml-live configuration output, and always show the requested configuration, even if -F is given.

---

Additionally, this removes syslinux/isolinux/pxelinux from the arm64 builds. These tools are x86-only, and as such are only dead weight on arm64. Bonus effect: the resulting ISO is understood by macOS once again.