### PR TITLE
DEBIAN_TESTING: correct security.debian.org URL

### DIFF
--- a/etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_TESTING
+++ b/etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_TESTING
@@ -3,5 +3,5 @@
   deb-src http://ftp.debian.org/debian/ testing main contrib non-free-firmware non-free
 
 # security updates:
-  deb     http://security.debian.org/ testing-security main contrib non-free-firmware non-free
-  deb-src http://security.debian.org/ testing-security main contrib non-free-firmware non-free
+  deb     http://security.debian.org/debian-security/ testing-security main contrib non-free-firmware non-free
+  deb-src http://security.debian.org/debian-security/ testing-security main contrib non-free-firmware non-free


### PR DESCRIPTION
Both work, but the new URL is easier cacheable, and works with apt-cacher-ng.