### PR TITLE
build-driver: allow basefiles directory to already exist

### DIFF
--- a/build-driver/build.py
+++ b/build-driver/build.py
@@ -121,7 +121,7 @@ def run_grml_live(
     if not old_iso_path:
         with ci_section("Creating basefile using mmdebstrap"):
             basefiles_path = grml_fai_config / "config" / "basefiles"
-            basefiles_path.mkdir()
+            basefiles_path.mkdir(exist_ok=True)
             basefile = basefiles_path / f"{arch.upper()}.tar.gz"
             run_x(["mmdebstrap", "--format=tar", debian_suite, basefile])
 


### PR DESCRIPTION
Useful for local testing. In CI, this directory never exists, but when running the build scripts locally it is usually left over from a previous run.