### PR TITLE
grub: retitle grml boot menu entries

### DIFF
--- a/grml-live
+++ b/grml-live
@@ -1306,8 +1306,7 @@ if [ "$ARCH" = i386 ] || [ "$ARCH" = amd64 ] || [ "$ARCH" = arm64 ] ; then
     fi
 
     # arch independent files
-    cp -a "${CHROOT_OUTPUT}"/usr/share/grub/ascii.pf2     "${BUILD_OUTPUT}"/boot/grub/
-    cp -a "${CHROOT_OUTPUT}"/usr/share/grub/unicode.pf2   "${BUILD_OUTPUT}"/boot/grub/  # clarify
+    cp -a "${CHROOT_OUTPUT}"/usr/share/grub/unicode.pf2   "${BUILD_OUTPUT}"/boot/grub/
 
     if ! [ -d "${TEMPLATE_DIRECTORY}"/GRML ] ; then
       log    "Error: ${TEMPLATE_DIRECTORY}/GRML does not exist. Exiting."

--- a/templates/boot/grub/%SHORT_NAME%_default.cfg
+++ b/templates/boot/grub/%SHORT_NAME%_default.cfg
@@ -1,4 +1,4 @@
-menuentry "%GRML_NAME% - release %VERSION% (default)" {
+menuentry "%GRML_NAME% %VERSION%" {
     set gfxpayload=keep
     echo 'Loading kernel...'
     linux   /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% "${loopback}" ${kernelopts} nomce net.ifnames=0 

--- a/templates/boot/grub/%SHORT_NAME%_options.cfg
+++ b/templates/boot/grub/%SHORT_NAME%_options.cfg
@@ -1,4 +1,4 @@
-submenu "%GRML_NAME% - advanced options  ->" --class=submenu {
+submenu "  ⇢ Options" --class=submenu {
 menuentry "Enable Predictable Network Interface Names" {
     set gfxpayload=keep
     echo 'Loading kernel...'

--- a/templates/boot/grub/addons.cfg
+++ b/templates/boot/grub/addons.cfg
@@ -1,4 +1,4 @@
-submenu "Addons ->" --class=submenu {
+submenu "Addons ⇢" --class=submenu {
 
 # EFI:
 if [ "${grub_platform}" == "efi" ] ; then

--- a/templates/boot/grub/grub.cfg
+++ b/templates/boot/grub/grub.cfg
@@ -3,10 +3,20 @@ source /boot/grub/header.cfg
 
 insmod regexp
 
-for config in /boot/grub/*_default.cfg ; do source "$config" ; done
-for config in /boot/grub/*_options.cfg ; do source "$config" ; done
+for config in /boot/grub/*_default.cfg ; do
+    source "$config"
+    regexp --set 1:config "(/boot/grub/.+)_default.cfg" "$config"
+    set config="${config}_options.cfg"
+    source "$config"
+done
+
+# separator entry, no action
+menuentry "" {
+    true
+}
+
 if [ -f /boot/grub/addons.cfg ] ; then
-  source "/boot/grub/addons.cfg"
+    source "/boot/grub/addons.cfg"
 fi
 
 source /boot/grub/footer.cfg

--- a/templates/boot/grub/header.cfg
+++ b/templates/boot/grub/header.cfg
@@ -1,7 +1,7 @@
 set default=0
 set timeout=20
 
-if loadfont /boot/grub/ascii.pf2 ; then
+if loadfont /boot/grub/unicode.pf2 ; then
    insmod png
    set gfxmode=auto
    insmod gfxterm


### PR DESCRIPTION
The default menu entry now just reads "<grml-name> <version>", so for example "grml-small-arm64 2024.12". The additional options are in a menu entry just titled " -> Options".

To allow for removing the name/version for the options menu, grub.cfg now sorts the %SHORTNAME%_options.cfg always directly after the %SHORTNAME%_default.cfg.

Use unicode.pf2 to allow for Unicode characters in the Options and Addons menu entries.

Will need a trivial rebase after #181 is merged.

Closes #175.
