### PR TITLE
SW: replace dhcpcd with dhcpcd-base in DEBIAN_*

### DIFF
--- a/etc/grml/fai/config/package_config/DEBIAN_TESTING
+++ b/etc/grml/fai/config/package_config/DEBIAN_TESTING
@@ -7,4 +7,4 @@ PACKAGES install
 # towards dhcpcd only for Debian trixie/testing and newer. Also see
 # https://bugs.debian.org/1051421 and
 # https://github.com/grml/grml-live/issues/138
-dhcpcd
+dhcpcd-base

--- a/etc/grml/fai/config/package_config/DEBIAN_TRIXIE
+++ b/etc/grml/fai/config/package_config/DEBIAN_TRIXIE
@@ -7,4 +7,4 @@ PACKAGES install
 # towards dhcpcd only for Debian trixie/testing and newer. Also see
 # https://bugs.debian.org/1051421 and
 # https://github.com/grml/grml-live/issues/138
-dhcpcd
+dhcpcd-base

--- a/etc/grml/fai/config/package_config/DEBIAN_UNSTABLE
+++ b/etc/grml/fai/config/package_config/DEBIAN_UNSTABLE
@@ -7,4 +7,4 @@ PACKAGES install
 # towards dhcpcd only for Debian trixie/testing and newer. Also see
 # https://bugs.debian.org/1051421 and
 # https://github.com/grml/grml-live/issues/138
-dhcpcd
+dhcpcd-base


### PR DESCRIPTION
The dhcpcd package provides the files /etc/init.d/dhcpcd, /usr/lib/systemd/system/dhcpcd.service +
/usr/lib/systemd/system/dhcpcd@.service, neither of which we depend on. We also don't start any of those services with our Grml live systems via systemd presets.

Also cloud-init only depends on dhcpcd-base, so let's depend on dhcpcd-base with Debian trixie and newer.

Thanks to @jkirk for raising this.

Closes: grml/grml-live#187