### PR TITLE
45-grub-images: fix quoting

### DIFF
--- a/etc/grml/fai/config/scripts/GRMLBASE/45-grub-images
+++ b/etc/grml/fai/config/scripts/GRMLBASE/45-grub-images
@@ -73,10 +73,11 @@ for arch in "${ARCHS[@]}" ; do
     arm64-efi)  filename=/boot/bootaa64.efi  ;;
   esac
 
+  read -r -a modules <<< "${ADDITIONAL_MODULES[$arch]}"
   $ROOTCMD grub-mkimage -O "$arch" -o "$filename" --prefix=/boot/grub/ --config="$TMP_CONFIG" \
     echo iso9660 part_msdos search_fs_file test \
     fat ext2 reiserfs xfs btrfs squash4 part_gpt lvm \
-    "${ADDITIONAL_MODULES[$arch]}"
+    "${modules[@]}"
 done
 
 rm -f "${target}/${TMP_CONFIG}"


### PR DESCRIPTION
Fixes: 5eb2286046098c77cf43d45d18e023eda2aa4c9c

Error:

```
=====   shell: GRMLBASE/45-grub-images   =====
grub-mkimage: error: cannot open `/usr/lib/grub/x86_64-efi/efi_gop efi_uga.mod': No such file or directory.
GRMLBASE/45-grub-images FAILED with exit code 1.
```
