### PR TITLE
grml-live: fix build only mode

### DIFF
--- a/grml-live
+++ b/grml-live
@@ -677,8 +677,8 @@ if [ -n "$EXTRACT_ISO_NAME" ]; then
   fi
 
   local squashfs
-  squahsfs=( "${tempdir}"/live/*/*.squashfs )
-  if (( ${#squahsfs[@]} != 0 )) && [ -r "${squashfs[0]}" ]; then
+  squashfs=( "${tempdir}"/live/*/*.squashfs )
+  if (( ${#squashfs[@]} != 0 )) && [ -r "${squashfs[0]}" ]; then
     log "Will unsquashfs ${squashfs[0]}"
     unsquashfs -d "${CHROOT_OUTPUT}" "${squashfs[0]}" ; rc=$?
   else


### PR DESCRIPTION
Fix embarrassing typo causing build-only to fail like this:

```
...
Volume id    : 'grml-small-arm64 d20241209b151'
xorriso : UPDATE :       2 files restored ( 392.3m) in 1 seconds , 296.9xD
xorriso : UPDATE :       3 files restored ( 394.1m) in 1 seconds = 297.0xD
Extracted from ISO image: file '/live'='/tmp/tmp.qcRmTPEtzH/live'
  [!] Error: Could not find any *.squashfs files on the ISO
```