### PR TITLE
grml-live: strip xattrs in squashfs

### DIFF
--- a/grml-live
+++ b/grml-live
@@ -1514,6 +1514,11 @@ else
      fi
    fi
 
+   # Ignore all extended attributes. This avoids:
+   # 1) leaking containerization supplied selinux attributes into the squashfs,
+   # 2) prevents unpacking errors in a later build-only step in containers not supporting xattrs.
+   SQUASHFS_OPTIONS="$SQUASHFS_OPTIONS -no-xattrs"
+
    # support exclusion of files via exclude-file:
    if [ -n "$SQUASHFS_EXCLUDES_FILE" ] && [ "$SQUASHFS_EXCLUDES_FILE" ] ; then
       SQUASHFS_OPTIONS="$SQUASHFS_OPTIONS -ef $SQUASHFS_EXCLUDES_FILE -wildcards"


### PR DESCRIPTION
Ignore all extended attributes from files in chroot when adding them to the squashfs.

This avoids:

1) leaking containerization supplied selinux attributes into the squashfs, which can be seen when building in podman, and in docker.

2) prevents unpacking errors in a later build-only step in containers not supporting xattrs. Can also be seen in podman.

On a normal machine and also on a normal (booted) Grml system, the only things having xattrs are:

```
file: var/log/journal
system.posix_acl_access
system.posix_acl_default

file: var/log/journal/1e77092b16004314a93d779757d513ac
system.posix_acl_access
system.posix_acl_default
```

Both of these are apparently applied by systemd/journald during boot, even if the filesystem does not have them.