### PR TITLE
grml-live: remove GRML_SMALL exclude of vmlinuz, initrd.img

### DIFF
--- a/grml-live
+++ b/grml-live
@@ -1519,11 +1519,6 @@ else
       SQUASHFS_OPTIONS="$SQUASHFS_OPTIONS -ef $SQUASHFS_EXCLUDES_FILE -wildcards"
    fi
 
-   # get rid of unnecessary files when building grml-small for final release:
-   if hasclass GRML_SMALL ; then
-      SQUASHFS_OPTIONS="$SQUASHFS_OPTIONS -e initrd.img* vmlinuz*"
-   fi
-
    # log stuff
    SQUASHFS_STDERR="$(mktemp -t grml-live.XXXXXX)"
 


### PR DESCRIPTION
The exclusion does not work today. /boot/ inside the squashfs always has vmlinuz* and initrd.img* files. IMO if the exclude would work, it would break build-only mode later.

A resulting grml-small build-only ISO does not change in size.