### PR TITLE
GHA: run grml-live in test-build workflow

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -38,3 +38,27 @@ jobs:
           if-no-files-found: error
           path: |
             *.deb
+
+  build-iso:
+    strategy:
+      fail-fast: false
+      matrix:
+        host_release:
+          - bookworm
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: ./test/gha-build-iso.sh
+        name: "Build ISO on ${{matrix.host_release}}"
+        env:
+          HOST_RELEASE: ${{matrix.host_release}}
+
+      - name: Archive built ISO
+        uses: actions/upload-artifact@v4
+        with:
+          name: grml-live-build-result-${{matrix.host_release}}
+          if-no-files-found: error
+          path: |
+            results/*

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
   schedule:
-    - cron: '30 3 * * 2'
+    - cron: "30 3 * * 2"
 
 concurrency:
   group: "${{ github.ref }}"
@@ -16,25 +16,25 @@ jobs:
       fail-fast: false
       matrix:
         host_release:
-        - unstable
-        - trixie
-        - bookworm
+          - unstable
+          - trixie
+          - bookworm
 
     # We want a working shell, qemu, python and docker. Specific version should not matter (much).
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - run: ./test/gha-build-deb.sh
-      name: "Build .deb for ${{matrix.host_release}}"
-      env:
-        HOST_RELEASE: ${{matrix.host_release}}
+      - run: ./test/gha-build-deb.sh
+        name: "Build .deb for ${{matrix.host_release}}"
+        env:
+          HOST_RELEASE: ${{matrix.host_release}}
 
-    - name: Archive built .deb
-      uses: actions/upload-artifact@v4
-      with:
-        name: deb-${{matrix.host_release}}
-        if-no-files-found: error
-        path: |
-          *.deb
+      - name: Archive built .deb
+        uses: actions/upload-artifact@v4
+        with:
+          name: deb-${{matrix.host_release}}
+          if-no-files-found: error
+          path: |
+            *.deb

--- a/test/gha-build-iso.sh
+++ b/test/gha-build-iso.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Entrypoint for GitHub Actions to build an ISO with a minimal setup,
+# just to validate grml-live itself.
+
+set -euxo pipefail
+
+cat >build-gha-ci-test-config <<EOT
+---
+last_release: "2024.02"
+EOT
+
+# Install as little Debian packages as possible,
+# we do not want to test *Debian*.
+cat > etc/grml/fai/config/package_config/GRML_GHACI <<EOT
+PACKAGES install AMD64
+linux-image-amd64
+
+PACKAGES install ARM64
+linux-image-arm64
+EOT
+
+# Note: file ownership inside docker is "wrong", and then git will fail.
+# As a workaround we set safe.directory to ignore the ownership issues.
+
+docker run -i --rm --volume "${PWD}:/source" -e SKIP_SOURCES=1 -e DO_DAILY_UPLOAD=0 -w /source debian:"$HOST_RELEASE" bash -c \
+    "apt-get update -qq && apt-get satisfy -q -y --no-install-recommends 'git, ca-certificates' && git config --global --add safe.directory /source && /source/build-driver/build /source daily /source/build-gha-ci-test-config ghaci amd64 testing"
+
+sudo chmod -R a+rX results


### PR DESCRIPTION
Add an invocation of grml-live to the test-build GitHub Actions workflow. The results are collected as artifacts.

I consider this an initial start of having some form of end-to-end test for grml-live.
What I don't want here is to "test" Debian itself. For this reason, the test setup creates a minimal flavour/class. But at least GRMLBASE must work.
