### PR TITLE
GRMLBASE/45-grub-images: fix moddep.lst name in message

### DIFF
--- a/etc/grml/fai/config/scripts/GRMLBASE/45-grub-images
+++ b/etc/grml/fai/config/scripts/GRMLBASE/45-grub-images
@@ -39,7 +39,7 @@ if ifclass ARM64 ; then
     # NOTE: efi_uga (EFI Universal Graphics Adapter) is deprecated + unavailable on arm64
     ADDITIONAL_MODULES[arm64-efi]="efi_gop"  # no efi_uga available
   else
-    echo "/usr/lib/grub/arm64-efi/moddep.lst.lst could not be found, skipping."
+    echo "/usr/lib/grub/arm64-efi/moddep.lst could not be found, skipping."
     echo "NOTE: grub-efi-arm64-bin not installed?"
   fi
 fi


### PR DESCRIPTION
Trivial issue, introduced in e1a55042bafe00328b59bd9e080b443de7a40097