### PR TITLE
GRMLBASE/15-initsetup: mask ldconfig.service

### DIFF
--- a/etc/grml/fai/config/scripts/GRMLBASE/15-initsetup
+++ b/etc/grml/fai/config/scripts/GRMLBASE/15-initsetup
@@ -26,6 +26,11 @@ systemd_setup() {
 
   $ROOTCMD systemctl preset-all
   $ROOTCMD systemctl set-default grml-boot.target
+
+  # ldconfig.service updates the dynamic linker cache. This is not really
+  # useful on a live OS image, where the installed packages do not change
+  # on startup. As this is quite costly, disable it.
+  $ROOTCMD systemctl mask ldconfig.service
 }
 
 systemd_setup


### PR DESCRIPTION
ldconfig.service is mostly useful if the OS image can change its composition during boot. This is not the case for us.

As ldconfig.service can be quite slow, lets mask it.

Closes: grml/grml-live#200