### PR TITLE
GHA: test build-only/release mode

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -50,15 +50,30 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - run: ./test/gha-build-iso.sh
+      - run: ./test/gha-build-iso.sh initial
         name: "Build ISO on ${{matrix.host_release}}"
         env:
           HOST_RELEASE: ${{matrix.host_release}}
 
       - name: Archive built ISO
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: grml-live-build-result-${{matrix.host_release}}
+          name: grml-live-build-result-initial-${{matrix.host_release}}
           if-no-files-found: error
           path: |
-            results/*
+            results-initial/*
+
+      - run: ./test/gha-build-iso.sh build-only-twice
+        name: "Repack ISO twice on ${{matrix.host_release}}"
+        env:
+          HOST_RELEASE: ${{matrix.host_release}}
+
+      - name: Archive repacked ISO
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: grml-live-build-result-repack-${{matrix.host_release}}
+          if-no-files-found: error
+          path: |
+            results-build-only-second/*

--- a/test/gha-build-iso.sh
+++ b/test/gha-build-iso.sh
@@ -6,10 +6,7 @@
 
 set -euxo pipefail
 
-cat >build-gha-ci-test-config <<EOT
----
-last_release: "2024.02"
-EOT
+MODE=$1
 
 # Install as little Debian packages as possible,
 # we do not want to test *Debian*.
@@ -21,10 +18,67 @@ PACKAGES install ARM64
 linux-image-arm64
 EOT
 
-# Note: file ownership inside docker is "wrong", and then git will fail.
-# As a workaround we set safe.directory to ignore the ownership issues.
+cat >build-gha-ci-test-config-initial <<EOT
+---
+last_release: "2024.02"
+EOT
 
-docker run -i --rm --volume "${PWD}:/source" -e SKIP_SOURCES=1 -e DO_DAILY_UPLOAD=0 -w /source debian:"$HOST_RELEASE" bash -c \
-    "apt-get update -qq && apt-get satisfy -q -y --no-install-recommends 'git, ca-certificates' && git config --global --add safe.directory /source && /source/build-driver/build /source daily /source/build-gha-ci-test-config ghaci amd64 testing"
+run_build() {
+    local config_filename
+    config_filename=$1
+    local build_mode
+    build_mode=$2
+    local results_directory
+    results_directory=$3
 
-sudo chmod -R a+rX results
+    docker run -i --rm --volume "${PWD}:/source" -e SKIP_SOURCES=1 -e DO_DAILY_UPLOAD=0 -w /source debian:"$HOST_RELEASE" \
+        bash -c \
+        "apt-get update -qq && apt-get satisfy -q -y --no-install-recommends 'git, ca-certificates' \
+        && git config --global --add safe.directory /source \
+        && /source/build-driver/build /source ${build_mode} /source/${config_filename} ghaci amd64 testing"
+
+    sudo chmod -R a+rX results
+    sudo mv results "${results_directory}"
+}
+
+
+if [ "$MODE" = "initial" ]; then
+
+    # Note: file ownership inside docker is "wrong", and then git will fail.
+    # As a workaround we set safe.directory to ignore the ownership issues.
+
+    run_build build-gha-ci-test-config-initial daily results-initial
+
+elif [ "$MODE" = "build-only-twice" ]; then
+    INPUT_ISO=$(ls results-initial/grml_isos/grml*iso)
+    cat >build-gha-ci-test-config-build-only-first <<EOT
+---
+last_release: "2024.02"
+debian_suite: testing
+release_version: "ci-bo-first"
+release_name: CI1
+base_iso:
+    ghaci:
+        amd64: "file:///source/$INPUT_ISO"
+EOT
+
+    run_build build-gha-ci-test-config-build-only-first release results-build-only-first
+
+    INPUT_ISO=$(ls results-build-only-first/grml_isos/grml*iso)
+    cat >build-gha-ci-test-config-build-only-second <<EOT
+---
+last_release: "2024.02"
+debian_suite: testing
+release_version: "ci-bo-second"
+release_name: CI2
+base_iso:
+    ghaci:
+        amd64: "file:///source/$INPUT_ISO"
+EOT
+
+    run_build build-gha-ci-test-config-build-only-second release results-build-only-second
+
+else
+    echo "E: unsupported \$MODE $MODE"
+    exit 1
+fi


### PR DESCRIPTION
Extend test-build GitHub Actions workflow to run release mode build after creating a daily ISO. The release mode build is done twice, to ensure a) it can work from a daily ISO and b) it can work from a release (candidate) ISO.
