### PR TITLE
SW: Install openssh-client-ssh1 for DSA-keyed servers

### DIFF
--- a/etc/grml/fai/config/package_config/GRML_FULL
+++ b/etc/grml/fai/config/package_config/GRML_FULL
@@ -178,6 +178,7 @@ netcat-openbsd
 nethogs
 netsniff-ng
 nmap
+openssh-client-ssh1
 radvd
 rdnssd
 rfkill
@@ -186,7 +187,6 @@ sipcalc
 snmp
 socat
 speedtest-cli
-ssh
 ssmping
 tcpdump
 tcptraceroute

--- a/etc/grml/fai/config/package_config/GRML_SMALL
+++ b/etc/grml/fai/config/package_config/GRML_SMALL
@@ -89,6 +89,7 @@ ndisc6
 net-tools
 netbase
 netcat-openbsd
+openssh-client-ssh1
 rdnssd
 rfkill
 ser2net


### PR DESCRIPTION
The current OpenSSH version has dropped support for DSA keys. Users might find them in a situation where they still need DSA keys when they're running our Live CD, so lets provide openssh-client-ssh1 too. At least for a while, until either openssh-client-ssh1 becomes unsupportable or enough time has passed.

Also drop "ssh" from GRML_FULL, as GRMLBASE already has openssh-client and openssh-server.

Adds about 1.5MB installed size.