### PR TITLE
Do not add /dev to squashfs

### DIFF
--- a/etc/grml/fai/config/grml/squashfs-excludes
+++ b/etc/grml/fai/config/grml/squashfs-excludes
@@ -1,3 +1,4 @@
+dev/*
 run/*
 var/run/*
 var/lock/*


### PR DESCRIPTION
The resulting device nodes are problematic when unpacking inside unprivileged podman containers, and the livecd does not need them to work.