### PR TITLE
Generate source package tarball when using SOURCES class

### DIFF
--- a/grml-live
+++ b/grml-live
@@ -1864,6 +1864,38 @@ create_netbootpackage() {
 create_netbootpackage
 # }}}
 
+# {{{
+create_sourcespackages() {
+  if ! hasclass SOURCES ; then
+    log "Skipping source package generation, only enabled with class SOURCES"
+    return 0
+  fi
+
+  local OUTPUT_FILE SOURCES_DIR
+  OUTPUT_FILE="${OUTPUT}/$(basename "${ISO_NAME}" .iso)-sources.tar"
+  SOURCES_DIR="${OUTPUT}/grml_sources/"
+
+  if ! [ -d "${SOURCES_DIR}" ] ; then
+    eerror "Base directory ${SOURCES_DIR} not present, can not generate source package" ; eend 1
+    bailout 22
+  fi
+
+  if tar -C "${OUTPUT}" -cf "${OUTPUT_FILE}" "$(basename "${SOURCES_DIR}")" ; then
+   (
+     # shellcheck disable=SC2164 # We just wrote there. If it disappeared, too bad.
+     cd "$(dirname "${OUTPUT_FILE}")"
+     sha256sum "$(basename "${OUTPUT_FILE}")" > "${OUTPUT_FILE}.sha256"
+   )
+   einfo "Generated source package ${OUTPUT_FILE}" ; eend 0
+ else
+   eerror "Could not generate source package ${OUTPUT_FILE}" ; eend 1
+   bailout 22
+ fi
+}
+
+create_sourcespackages
+# }}}
+
 # finalize {{{
 if [ -n "${start_seconds}" ] ; then
   end_seconds="$(date +%s)"


### PR DESCRIPTION
Even with the smaller grml-small builds we end up with >1k source files inside the grml_sources directory. We don't want this for our daily builds. But also for our release builds we prefer to have one single build artifact which we can pass within our build pipeline.

Example:

```
  # grml-live [...] -c GRMLBASE,GRML_SMALL,AMD64,SOURCES -o /home/mika/build/grml-live-2024-12 -v 2024.12-1
```

Then we generate grml_2024.12-1-sources.tar + grml_2024.12-1-sources.tar.sha256 inside build directory /home/mika/build/grml-live-2024-12/.

Underlying command line for this then being:

```
  tar -C /home/mika/build/grml-live-2024-12 -cf /home/mika/build/grml-live-2024-12/grml_2024.12-1-sources.tar grml_sources
```

FTR: as of commit 87524f9aa1efb2327f45feef9028461b683ffec5 we no longer re-use the source directory with grml-live runs, so we could even remove the grml_sources directory automatically, but we decided to look into this only once we're further reworking the directory layout of our build artifacts.