### PR TITLE
Ensure files are copied with fcopy into chroot with expected permissions

### DIFF
--- a/etc/grml/fai/config/hooks/updatebase.GRMLBASE
+++ b/etc/grml/fai/config/hooks/updatebase.GRMLBASE
@@ -71,7 +71,7 @@ if ! [ -e "${target}"/etc/udev/kernel-upgrade ] ; then
 fi
 
 # install all apt related files
-fcopy -i -B -v -r /etc/apt
+fcopy -M -i -B -v -r /etc/apt
 
 # install packages from a repository of a specific date
 if [ -n "${WAYBACK_DATE:-}" ] ; then

--- a/etc/grml/fai/config/scripts/GRMLBASE/20-sudo
+++ b/etc/grml/fai/config/scripts/GRMLBASE/20-sudo
@@ -15,7 +15,7 @@ target=${target:?}
 # shellcheck source=/dev/null
 . "$GRML_LIVE_CONFIG"
 
-fcopy -v /etc/sudoers
+fcopy -m root,root,0440 -v /etc/sudoers
 sed -i "s/\$USERNAME/$USERNAME/" "$target"/etc/sudoers
 chmod 440 "$target"/etc/sudoers
 chown 0:0 "$target"/etc/sudoers

--- a/etc/grml/fai/config/scripts/GRMLBASE/25-locales
+++ b/etc/grml/fai/config/scripts/GRMLBASE/25-locales
@@ -14,10 +14,10 @@ target=${target:?}
 
 # set up /etc/locale.gen, GRMLBASE installs a minimal configuration.
 # Only if the LOCALES class is added you get a fuller set of locales.
-fcopy -v /etc/locale.gen
+fcopy -M -v /etc/locale.gen
 
 # set up /etc/locale.conf, to avoid systemd-firstboot prompting for user input
-fcopy -v /etc/locale.conf
+fcopy -M -v /etc/locale.conf
 
 # get rid of locales unless using class LOCALES
 set +u

--- a/etc/grml/fai/config/scripts/GRMLBASE/26-console-setup
+++ b/etc/grml/fai/config/scripts/GRMLBASE/26-console-setup
@@ -9,7 +9,7 @@
 set -u
 set -e
 
-fcopy -v /etc/default/console-setup
+fcopy -M -v /etc/default/console-setup
 
 ## END OF FILE #################################################################
 # vim:ft=sh expandtab ai tw=80 tabstop=4 shiftwidth=2

--- a/etc/grml/fai/config/scripts/GRMLBASE/30-fstab
+++ b/etc/grml/fai/config/scripts/GRMLBASE/30-fstab
@@ -15,7 +15,7 @@ target=${target:?}
 # shellcheck source=/dev/null
 . "$GRML_LIVE_CONFIG"
 
-fcopy -v /etc/fstab
+fcopy -M -v /etc/fstab
 sed -i "s/uid=USERNAME,gid=USERNAME/uid=$USERNAME,gid=$USERNAME/" "$target"/etc/fstab
 
 ## END OF FILE #################################################################

--- a/etc/grml/fai/config/scripts/GRMLBASE/31-motd
+++ b/etc/grml/fai/config/scripts/GRMLBASE/31-motd
@@ -9,7 +9,7 @@
 set -u
 set -e
 
-fcopy -v /etc/motd
+fcopy -M -v /etc/motd
 
 ## END OF FILE #################################################################
 # vim:ft=sh expandtab ai tw=80 tabstop=4 shiftwidth=2

--- a/etc/grml/fai/config/scripts/GRMLBASE/34-hosts
+++ b/etc/grml/fai/config/scripts/GRMLBASE/34-hosts
@@ -15,7 +15,7 @@ target=${target:?}
 # shellcheck source=/dev/null
 . "$GRML_LIVE_CONFIG"
 
-fcopy -v /etc/hosts
+fcopy -M -v /etc/hosts
 
 # replace $HOSTNAME with the real hostname:
 sed -i "s/\$HOSTNAME/$HOSTNAME/" "$target"/etc/hosts

--- a/etc/grml/fai/config/scripts/GRMLBASE/35-network
+++ b/etc/grml/fai/config/scripts/GRMLBASE/35-network
@@ -9,7 +9,7 @@
 set -u
 set -e
 
-fcopy -v /etc/network/interfaces
+fcopy -M -v /etc/network/interfaces
 
 ## END OF FILE #################################################################
 # vim:ft=sh expandtab ai tw=80 tabstop=4 shiftwidth=2

--- a/etc/grml/fai/config/scripts/GRMLBASE/39-modprobe
+++ b/etc/grml/fai/config/scripts/GRMLBASE/39-modprobe
@@ -13,7 +13,7 @@ set -e
 target=${target:?}
 
 # Install all present modprobe.d configuration files
-fcopy -v -i -r /etc/modprobe.d
+fcopy -M -v -i -r /etc/modprobe.d
 
 if [ -f "${target}/lib/modprobe.d/50-nfs.conf" ] ; then  # nfs-kernel-server >=1:2.6.2-1
   echo "Clearing /lib/modprobe.d/50-nfs.conf to avoid automatic kmod/busybox issues"

--- a/etc/grml/fai/config/scripts/GRMLBASE/41-modules
+++ b/etc/grml/fai/config/scripts/GRMLBASE/41-modules
@@ -9,7 +9,7 @@
 set -u
 set -e
 
-fcopy -v /etc/modules
+fcopy -M -v /etc/modules
 
 ## END OF FILE #################################################################
 # vim:ft=sh expandtab ai tw=80 tabstop=4 shiftwidth=2

--- a/etc/grml/fai/config/scripts/GRMLBASE/42-branding
+++ b/etc/grml/fai/config/scripts/GRMLBASE/42-branding
@@ -9,9 +9,9 @@
 set -u
 set -e
 
-fcopy -v /usr/share/initramfs-tools/scripts/init-top/grml
-fcopy -v /usr/share/grml/desktop-bg.png
-fcopy -v /usr/share/doc/grml-docs/startpage.html
+fcopy -m root,root,0755 -v /usr/share/initramfs-tools/scripts/init-top/grml
+fcopy -M -v /usr/share/grml/desktop-bg.png
+fcopy -M -v /usr/share/doc/grml-docs/startpage.html
 
 ## END OF FILE #################################################################
 # vim:ft=sh expandtab ai tw=80 tabstop=4 shiftwidth=2

--- a/etc/grml/fai/config/scripts/GRMLBASE/43-rsyslog
+++ b/etc/grml/fai/config/scripts/GRMLBASE/43-rsyslog
@@ -9,7 +9,7 @@
 set -u
 set -e
 
-fcopy -v /etc/rsyslog.conf
+fcopy -M -v /etc/rsyslog.conf
 
 ## END OF FILE #################################################################
 # vim:ft=sh expandtab ai tw=80 tabstop=4 shiftwidth=2

--- a/etc/grml/fai/config/scripts/GRMLBASE/51-cloud-init
+++ b/etc/grml/fai/config/scripts/GRMLBASE/51-cloud-init
@@ -12,7 +12,7 @@ set -e
 # NOTE: this file is relevant only with cloud-init package installed,
 # though we install it unconditionally via GRMLBASE class to have it
 # available and configured as shipped by Grml ISOs
-fcopy -v /etc/cloud/cloud.cfg.d/42_grml.cfg
+fcopy -M -v /etc/cloud/cloud.cfg.d/42_grml.cfg
 
 ## END OF FILE #################################################################
 # vim:ft=sh expandtab ai tw=80 tabstop=4 shiftwidth=2

--- a/etc/grml/fai/config/scripts/GRMLBASE/80-initramfs
+++ b/etc/grml/fai/config/scripts/GRMLBASE/80-initramfs
@@ -12,9 +12,9 @@ set -e
 # FAI sets $target, but shellcheck does not know that.
 target=${target:?}
 
-fcopy -v /etc/initramfs-tools/hooks/000-udev-shutup
-fcopy -v /etc/initramfs-tools/conf.d/xz-compress
-fcopy -v /etc/initramfs-tools/modules
+fcopy -m root,root,0755 -v /etc/initramfs-tools/hooks/000-udev-shutup
+fcopy -M -v /etc/initramfs-tools/conf.d/xz-compress
+fcopy -M -v /etc/initramfs-tools/modules
 
 if ! [ -f "$target"/usr/share/initramfs-tools/scripts/live ] ; then
   echo "Error: live-boot/-initramfs does not seem to be present, can not create initramfs. Exiting.">&2

--- a/etc/grml/fai/config/scripts/GRML_FULL/01-firefox
+++ b/etc/grml/fai/config/scripts/GRML_FULL/01-firefox
@@ -9,7 +9,7 @@
 set -u
 set -e
 
-fcopy -i -B -v /etc/firefox-esr/firefox-esr.js
+fcopy -M -i -B -v /etc/firefox-esr/firefox-esr.js
 
 ## END OF FILE #################################################################
 # vim:ft=sh expandtab ai tw=80 tabstop=4 shiftwidth=2


### PR DESCRIPTION
When running grml-live from within the git repository that was cloned by a user other than root, the files installed by FAI's fcopy have wrong/unexpected permissions.

For example:

```
| # stat /home/mika/build/grml-live-2024-12/grml_chroot/etc/rsyslog.conf
|   File: /home/mika/build/grml-live-2024-12/grml_chroot/etc/rsyslog.conf
|   Size: 1106            Blocks: 8          IO Block: 4096   regular file
| Device: 253,2   Inode: 4472261     Links: 1
| Access: (0644/-rw-r--r--)  Uid: ( 1000/    mika)   Gid: ( 1000/    mika)
| Access: 2024-12-18 15:39:59.477471695 +0100
| Modify: 2023-08-07 13:32:24.000000000 +0200
| Change: 2024-12-10 17:02:16.177262515 +0100
|  Birth: 2024-12-10 17:02:16.177262515 +0100
```

fcopy provides the following options:

```
| % fcopy -h
| fcopy, copy files using classes.
| [...]
|    -m user,group,mode   Set user, group and mode for copied files.
|    -M                   Same as -m root,root,0644
| [...]
```

Execute all fcopy command lines with `-M`, except for the ones that need execute permission (being /usr/share/initramfs-tools/scripts/init-top/grml and /etc/initramfs-tools/hooks/000-udev-shutup) for which we use the `-m` option accordingly then.