### PR TITLE
Drop support for bsd4grml / NO_ADDONS_BSD4GRML

### DIFF
--- a/etc/grml/grml-live.conf
+++ b/etc/grml/grml-live.conf
@@ -129,9 +129,6 @@
 # Do you want to skip adding /boot/addons/ (from the template directory)?
 # NO_ADDONS='1'
 
-# Do you want to skip adding /boot/addons/bsd4grml/ (from the template directory)?
-# NO_ADDONS_BSD4GRML='1'
-
 # By default the ISO is created for hybrid boot, so you can either
 # boot the CD using normal el torito mode or copy it to USB device
 # *without* having to run grml2usb (like: 'dd if=grml.iso of=/dev/sdX')

--- a/grml-live
+++ b/grml-live
@@ -1272,7 +1272,7 @@ else
       copy_addon_file memdisk /usr/lib/syslinux addons
     fi
 
-    # copy only files so we can handle bsd4grml on its own
+    # copy only files and report which ones are installed
     if [ -d "${TEMPLATE_DIRECTORY}/arch/${ARCH}/boot/addons" ] ; then
       for file in "${TEMPLATE_DIRECTORY}/arch/${ARCH}/boot/addons/"* ; do
         if [ -f "$file" ] ; then
@@ -1292,17 +1292,6 @@ else
     fi
     eend 0
 
-    if [ -n "$NO_ADDONS_BSD4GRML" ] ; then
-      log   "Skipping installation of bsd4grml as requested via \$NO_ADDONS_BSD4GRML."
-      einfo "Skipping installation of bsd4grml as requested via \$NO_ADDONS_BSD4GRML."; eend 0
-    else
-      if [ -d "$TEMPLATE_DIRECTORY"/boot/addons/bsd4grml ] ; then
-        cp -a "${TEMPLATE_DIRECTORY}"/boot/addons/bsd4grml "$BUILD_OUTPUT"/boot/addons/
-      else
-        log   "Missing addon file: bsd4grml"
-        ewarn "Missing addon file: bsd4grml" ; eend 0
-      fi
-    fi
   fi # NO_ADDONS
 
   # generate loopback.cfg config file without depending on grub's regexp module
@@ -1455,10 +1444,6 @@ else
       fi
     fi
   fi # amd64 or i386
-
-  if [ -e "$BUILD_OUTPUT"/boot/addons/bsd4grml/boot.6 ]; then
-    sed -i "s/%RELEASE_INFO%/$RELEASE_INFO/" "$BUILD_OUTPUT"/boot/addons/bsd4grml/boot.6
-  fi
 
   DPKG_LIST="/var/log/fai/$HOSTNAME/last/dpkg.list" # the dpkg --list output of the chroot
   if ! [ -r "$DPKG_LIST" ] ; then

--- a/templates/boot/grub/addons.cfg
+++ b/templates/boot/grub/addons.cfg
@@ -88,38 +88,5 @@ if [ "${grub_platform}" != "efi" ] ; then
         linux16  /boot/addons/memdisk
         initrd16 /boot/addons/balder10.imz
     }
-
-    if [ ${iso_path} ] ; then
-        # assume loopback.cfg boot
-        menuentry "MirOS bsd4grml (via loopback)" {
-            multiboot   /boot/addons/bsd4grml/ldbsd.com
-            module      /boot/addons/bsd4grml/bsd.rd bsd
-            module      /boot/addons/bsd4grml/loopback.0 boot.cfg
-            module      /boot/addons/bsd4grml/loopback.1 boot.1
-            module      /boot/addons/bsd4grml/loopback.2 boot.2
-            module      /boot/addons/bsd4grml/loopback.3 boot.3
-            module      /boot/addons/bsd4grml/loopback.4 boot.4
-            module      /boot/addons/bsd4grml/loopback.5 boot.5
-            module      /boot/addons/bsd4grml/loopback.6 boot.6
-        }
-    else
-        # assume grub.cfg boot
-        menuentry "MirOS bsd4grml (regular method)" {
-            multiboot   /boot/addons/bsd4grml/ldbsd.com
-        }
-
-        menuentry "MirOS bsd4grml (fallback method)" {
-            multiboot   /boot/addons/bsd4grml/ldbsd.com
-            module      /boot/addons/bsd4grml/bsd.rd bsd.rd
-            module      /boot/addons/bsd4grml/boot.1 boot.1
-            module      /boot/addons/bsd4grml/boot.2 boot.2
-            module      /boot/addons/bsd4grml/boot.3 boot.3
-            module      /boot/addons/bsd4grml/boot.4 boot.4
-            module      /boot/addons/bsd4grml/boot.5 boot.5
-            module      /boot/addons/bsd4grml/boot.6 boot.6
-            module      /boot/addons/bsd4grml/boot.cfg boot.cfg
-            module      /boot/grub/grub.img grub.img
-        }
-    fi # iso_path
 fi # efi mode
 }


### PR DESCRIPTION
We no longer ship bsd4grml via grml-live-grml (see https://github.com/grml/grml-live-grml/pull/11), and bsd4grml is so well hidden inside Grml boot, that 2 out of 3 core devs didn't even find it. 8-)

(FTR: in BIOS boot with isolinux/syslinux, one needs to select the "Run Bootloader Grub2" addon sub menu entry, and then under Addons -> "MirOS bsd4grml (via loopback)" needs to be selected, related see commit 438804cfdd3a4c29dd9e9ffd9cedeb35f15bc6c6).

As this boot option was supported on legacy boot (as in BIOS / Non-UEFI boot) only anyway, let's stop supporting it.

See https://github.com/grml/grml/issues/211