### PR TITLE
Support UEFI 32bit boot on amd64

### DIFF
--- a/etc/grml/fai/config/package_config/DEBIAN_TESTING
+++ b/etc/grml/fai/config/package_config/DEBIAN_TESTING
@@ -12,3 +12,8 @@ dhcpcd-base
 # Required for ping to work in trixie and newer.
 # https://github.com/grml/grml-live/issues/160
 linux-sysctl-defaults
+
+
+PACKAGES install AMD64
+# UEFI 32bit boot support, available in Debian/trixie and newer
+grub-efi-ia32-unsigned

--- a/etc/grml/fai/config/package_config/DEBIAN_TRIXIE
+++ b/etc/grml/fai/config/package_config/DEBIAN_TRIXIE
@@ -12,3 +12,8 @@ dhcpcd-base
 # Required for ping to work in trixie and newer.
 # https://github.com/grml/grml-live/issues/160
 linux-sysctl-defaults
+
+
+PACKAGES install AMD64
+# UEFI 32bit boot support, available in Debian/trixie and newer
+grub-efi-ia32-unsigned

--- a/etc/grml/fai/config/package_config/DEBIAN_UNSTABLE
+++ b/etc/grml/fai/config/package_config/DEBIAN_UNSTABLE
@@ -12,3 +12,8 @@ dhcpcd-base
 # Required for ping to work in trixie and newer.
 # https://github.com/grml/grml-live/issues/160
 linux-sysctl-defaults
+
+
+PACKAGES install AMD64
+# UEFI 32bit boot support, available in Debian/trixie and newer
+grub-efi-ia32-unsigned

--- a/etc/grml/fai/config/scripts/GRMLBASE/45-grub-images
+++ b/etc/grml/fai/config/scripts/GRMLBASE/45-grub-images
@@ -54,7 +54,8 @@ if ifclass AMD64 ; then
   fi
 fi
 
-if ifclass I386 ; then
+# note: enabled also on AMD64 for UEFI 32bit boot support
+if ifclass I386 || ifclass AMD64 ; then
   if [ -r "${target}"/usr/lib/grub/i386-efi/moddep.lst ] ; then
     ARCHS+=(i386-efi)
     ADDITIONAL_MODULES[i386-efi]="efi_gop efi_uga"

--- a/grml-live
+++ b/grml-live
@@ -973,6 +973,7 @@ grub_setup() {
         ;;
       amd64)
         BOOTX64="/boot/bootx64.efi"
+        BOOTX32="/boot/bootia32.efi"
         ;;
     esac
 
@@ -985,6 +986,15 @@ grub_setup() {
       bailout 50
     fi
 
+    # UEFI 32bit boot support, only supported with Debian trixie and newer,
+    # so make it optional and don't fail hard
+    if [[ "$ARCH" == "amd64" ]] && ! [ -r "${CHROOT_OUTPUT}/${BOOTX32}" ] ; then
+      local uefi_32bit_support
+      uefi_32bit_support=0
+      log   "Cannot access GRUB 32-bit PC EFI image ${CHROOT_OUTPUT}/${BOOTX32}, disabling UEFI 32bit boot support."
+      ewarn "Cannot access GRUB 32-bit PC EFI image ${CHROOT_OUTPUT}/${BOOTX32}, disabling UEFI 32bit boot support" ; eend 0
+    fi
+
     dd if=/dev/zero of="${CHROOT_OUTPUT}/${EFI_IMG}" bs="${efi_size}" count=1 2>/dev/null || bailout 50
     mkfs.vfat -n GRML "${CHROOT_OUTPUT}/${EFI_IMG}" >/dev/null || bailout 51
     mmd -i "${CHROOT_OUTPUT}/${EFI_IMG}" ::EFI || bailout 52
@@ -994,18 +1004,23 @@ grub_setup() {
       log   "Secure Boot is disabled."
       einfo "Secure Boot is disabled." ; eend 0
 
-      # install "$BOOTX64" as ::EFI/BOOT/{bootx64.efi|bootaa64.efi} inside image file "$EFI_IMG":
+      # install "$BOOTX64" as ::EFI/BOOT/{bootx64.efi|bootaa64.efi} inside image file "$EFI_IMG",
+      # and if present also "$BOOTX32" as ::EFI/BOOT/bootia32.efi on amd64 for UEFI 32bit boot support:
       case "$ARCH" in
         arm64)
           mcopy -i "${CHROOT_OUTPUT}/${EFI_IMG}" "${CHROOT_OUTPUT}/${BOOTX64}" ::EFI/BOOT/bootaa64.efi >/dev/null || bailout 53
           ;;
         amd64)
           mcopy -i "${CHROOT_OUTPUT}/${EFI_IMG}" "${CHROOT_OUTPUT}/${BOOTX64}" ::EFI/BOOT/bootx64.efi >/dev/null || bailout 53
+          # UEFI 32bit boot
+          if [ "${uefi_32bit_support:-}" != "0" ] ; then
+            mcopy -i "${CHROOT_OUTPUT}/${EFI_IMG}" "${CHROOT_OUTPUT}/${BOOTX32}" ::EFI/BOOT/bootia32.efi >/dev/null || bailout 53
+          fi
           ;;
       esac
 
-      log   "Created UEFI image $EFI_IMG from $BOOTX64"
-      einfo "Created UEFI image $EFI_IMG from $BOOTX64" ; eend 0
+      log   "Created UEFI image $EFI_IMG from $BOOTX64 ${BOOTX32:-}"
+      einfo "Created UEFI image $EFI_IMG from $BOOTX64 ${BOOTX32:-}" ; eend 0
     else
       case "${SECURE_BOOT}" in
         disable*)
@@ -1811,6 +1826,15 @@ create_netbootpackage() {
         then
           log   "No grubnetx64.efi for usage with PXE boot found (grub-efi-amd64-signed not present?)"
           ewarn "No grubnetx64.efi for usage with PXE boot found (grub-efi-amd64-signed not present?)." ; eend 0
+        fi
+
+        # UEFI 32bit boot
+        if ! copy_optional_file_logged "${WORKING_DIR}"/grubia32.efi "${CHROOT_OUTPUT}" \
+          /usr/lib/grub/i386-efi-signed/grubnetia32.efi.signed \
+          /usr/lib/grub/i386-efi/monolithic/grubnetia32.efi
+        then
+          log   "No grubnetia32.efi for usage with PXE boot found (grub-efi-ia32-unsigned present?)"
+          ewarn "No grubnetia32.efi for usage with PXE boot found (grub-efi-ia32-unsigned present?)." ; eend 0
         fi
       fi
 


### PR DESCRIPTION
We dropped support for i386, though there are 32bit EFI systems with 64bit CPUs out in the wild, so let's support UEFI 32bit boot on amd64.

Verified with `/usr/share/OVMF/OVMF32_CODE_4M.fd` from ovmf-ia32 (v2024.11-2) and qemu, running:

```
% qemu-system-amd64 -m 2048 -M pc -cdrom /path/to/grml_isos/grml_0.42iso -drive if=pflash,format=raw,unit=0,file.filename=/usr/share/OVMF/OVMF32_CODE_4M.fd,file.locking=off,readonly=on
```

Launch boot UEFI interactive shell there and verified that this works:

```
fs0:
cd efi/boot
bootia32.efi
```

This shows the Grml boot menu as expected, whereas executing bootx64.efi fails (as we're running within a 32bit EFI environment), also as expected.

NOTE: We already ship the grub-efi-ia32-bin package on AMD64 already for support within /etc/grml/fai/config/scripts/GRMLBASE/45-grub-images. But for netboot package we need the grubnetia32.efi for usage as grubia32.efi. Though the file /usr/lib/grub/i386-efi-signed/grubnetia32.efi.signed is shipped only via the grub-efi-ia32-signed package, which is available only on i386. Therefore we need to use the file /usr/lib/grub/i386-efi/monolithic/grubnetia32.efi from grub-efi-ia32-unsigned instead, which is available only as of Debian/trixie and newer. But let's still provide the code path in netboot creation, as someone might handle this within a custom script on their own.

See https://github.com/grml/grml/issues/211