### PR TITLE
Fix logic around grml_sources handling no longer being bind-mounted

### DIFF
--- a/grml-live
+++ b/grml-live
@@ -801,7 +801,8 @@ else
          mount --bind "${MIRROR_DIRECTORY}" "${CHROOT_OUTPUT}/${MIRROR_DIRECTORY}"
       fi
 
-      mkdir -p "${CHROOT_OUTPUT}/grml-live/grml_sources/"
+      mkdir -p "${OUTPUT}"/grml_sources "${CHROOT_OUTPUT}"/grml-live/
+      mv "${OUTPUT}"/grml_sources "${CHROOT_OUTPUT}"/grml-live/
 
       log "Executed FAI command line:"
       log "BUILD_ONLY=$BUILD_ONLY BOOTSTRAP_ONLY=$BOOTSTRAP_ONLY GRML_LIVE_CONFIG=$CONFIGDUMP WAYBACK_DATE=$WAYBACK_DATE fai $VERBOSE -C $GRML_FAI_CONFIG -s file:///$GRML_FAI_CONFIG/config -c$CLASSES -u $HOSTNAME $FAI_ACTION $CHROOT_OUTPUT $FAI_ARGS"
@@ -818,8 +819,8 @@ else
         bailout 1
       fi
 
-      mv "${CHROOT_OUTPUT}/grml-live/grml_sources/" "${OUTPUT}/"
-      rmdir "${CHROOT_OUTPUT}/grml-live"
+      mv "${CHROOT_OUTPUT}"/grml-live/grml_sources/ "${OUTPUT}"
+      rmdir "${CHROOT_OUTPUT}"/grml-live
 
       # provide inform fai about the ISO we build, needs to be provided
       # *after* FAI stage, otherwise FAI skips the debootstrap stage if


### PR DESCRIPTION
In commit 87524f9aa1efb2327f45feef9028461b683ffec5 we adjusted the grml_sources handling, as bind mounts are not allowed in (unprivileged) docker.

Now when running grml-live with SOURCES class enabled multiple times in a row (e.g. via grml-live's `-b` or `-u` options), one ends up with the $OUTPUT/grml_sources *and* $OUTPUT/grml_chroot/grml-live/grml_sources directories. grml-live then complains:

```
  mv: cannot overwrite '$OUTPUT/grml_sources': Directory not empty
  rmdir: failed to remove '$OUTPUT/grml_chroot/grml-live': Directory not empty
```

As of commit 8b0a6fafc1003d1bac28c6c26c95bd1869d5d74d we generate a source package tarball when using the SOURCES class, so one might want to remove the "${OUTPUT}/grml_sources" directory anyway (similar to what we're doing in commit 6486c8438f1bc0b508eaa9842ba1de5ffa3094fb in our CI runs). But let's also fix the underlying logic and move grml_sources around as expected.