### PR TITLE
Update Grml cheatcodes + clean up isolinux bootprompt options

### DIFF
--- a/templates/GRML/grml-cheatcodes.txt
+++ b/templates/GRML/grml-cheatcodes.txt
@@ -15,9 +15,10 @@ fb1280x1024                           Use fixed framebuffer graphics (1)
 fb1024x768                            Use fixed framebuffer graphics (2) [notice: Grml's default]
 fb800x600                             Use fixed framebuffer graphics (3)
 nofb                                  Disable framebuffer
-floppy                                Boot from floppydisk
-hd / hd1 / hd2 / hd3                  Boot from (local) primary / secondary /... harddisk
-debug                                 Get shells during process of booting for debugging
+floppy                                Boot from primary floppy drive
+hd / hd1 /hd2 / hd3                   Boot from first .. fourth primary partition of (local) harddisk
+hd0 / fd0                             Chainload MBR from first harddisk / floppy drive
+debug                                 Be verbose during the process of booting for debugging
 forensic                              Do not touch any harddisks during hardware recognition
 serial                                Activate ttyS0 and start a getty
 grub                                  Boot Grub bootloader
@@ -27,6 +28,8 @@ Further documentation regarding the boot process can be found at:
 * https://manpages.debian.org/live-boot-doc/live-boot.7.en.html
 * https://manpages.debian.org/initramfs-tools-core/initramfs-tools.7.en.html
 * https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html
+* https://wiki.syslinux.org/wiki/index.php?title=SYSLINUX
+* https://wiki.syslinux.org/wiki/index.php?title=Doc/chain + https://wiki.syslinux.org/wiki/index.php?title=Comboot/chain.c32
 
 The following boot options can be combined.
 Notice: not all of them are available on all the Grml flavours.
@@ -149,14 +152,9 @@ grml ignore_bootid                    Disable bootid verification.
 
 Debugging related settings:
 ---------------------------
-grml debug                            Get shells during process of booting, using GNU screen, be verbose
-grml debug=1                          Get shells during process of booting, using GNU screen, be verbose and
-                                      display shell code being executed in initramfs.
-grml debug=noscreen                   Get shells during process of booting, verbose, but without using GNU screen
 grml nocolor                          Disable colorized output while booting
                                       Also set SYSTEMD_COLORS=0 to disable colors in systemd output
 grml log                              Log error messages while booting to /tmp/grml.log.`date +%Y%m%d`"
-                                      and /var/log/boot
 grml testcd                           Check CD data integrity and md5sums
 
 Security / login related settings:

--- a/templates/boot/grub/%SHORT_NAME%_options.cfg
+++ b/templates/boot/grub/%SHORT_NAME%_options.cfg
@@ -66,7 +66,7 @@ menuentry "Graphical Mode" {
 menuentry "Disable Framebuffer" {
     set gfxpayload=text
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} video=ofonly radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }

--- a/templates/boot/isolinux/hidden.cfg
+++ b/templates/boot/isolinux/hidden.cfg
@@ -3,25 +3,10 @@ menu hide
 kernel /boot/%SHORT_NAME%/vmlinuz
 append apm=power-off vga=791 initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% splash nomce net.ifnames=0 
 
-label debug
-menu hide
-kernel /boot/%SHORT_NAME%/vmlinuz
-append apm=power-off vga=791 verbose debug=vc initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% initcall_debug nomce net.ifnames=0 
-
 label grmlx
 menu hide
 kernel /boot/%SHORT_NAME%/vmlinuz
 append apm=power-off startx vga=791 initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 
-
-label nofb
-menu hide
-kernel /boot/%SHORT_NAME%/vmlinuz
-append apm=power-off vga=normal video=ofonly initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset 
-
-label nokms
-menu hide
-kernel /boot/%SHORT_NAME%/vmlinuz
-append apm=power-off initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset nomce net.ifnames=0 vga=791 
 
 label vmlinuz
 menu hide
@@ -47,11 +32,6 @@ label fb800x600
 menu hide
 kernel /boot/%SHORT_NAME%/vmlinuz
 append apm=power-off vga=788 initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 
-
-label serial
-menu hide
-kernel /boot/%SHORT_NAME%/vmlinuz
-append apm=power-off vga=normal video=vesafb:off initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 console=tty1 console=ttyS0,115200n8 
 
 label userdef
 menu hide


### PR DESCRIPTION
- updated description of the Isolinux bootprompt options to match actual behavior:

  - floppy uses syslinux' `localboot 0x0` command
  - hd .. hd3 use syslinux' `localboot 0x80` to `localboot 0x83` command
  - hd0 / fd0 use syslinux' chain.c32 COM module to chainload the according MBR
  - debug does not provide any shells during the boot process.

- add links to syslinux documentation (esp. for localboot + chain.c32)
- grml debug [...] was dropped as it was not working under systemd as intended, see: grml/grml#3 + grml/grml-autoconfig@f9648a3
- debug, nofb, nokms + serial were defined in hidden.cfg + grml.cfg but grml.cfg takes precedence.
- removed `video=ofonly` from all boot parameters as it does nothing. Quoting: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1377878/comments/39

  > Where this came from has been lost by the sands of time, but it doesn't | relate to any PowerPC mac these days and hasn't been good advice since, | well 10.04, and possibly before that.  Now that framebuffers are modules |  (that are blacklisted), the boot parameter video=ofonly in fact does | nothing.  IT HAS TO BE CHANGED as it is just wasting people's time.

Closes: grml/grml#9