### PR TITLE
build-driver: handle sources before upload_daily

### DIFF
--- a/build-driver/build.py
+++ b/build-driver/build.py
@@ -254,7 +254,6 @@ def build(
     old_dpkg_list_last_release: Path | None,
     job_properties: JobProperties,
     grml_live_path: Path,
-    upload_to_daily: bool,
     old_iso_path: Path | None,
 ):
     run_grml_live(
@@ -287,9 +286,6 @@ def build(
             job_properties.job_name,
             job_properties.version,
         )
-
-    if upload_to_daily:
-        upload_daily(job_properties.job_name, build_dir, job_properties.job_timestamp)
 
 
 def load_config(build_config_file: str) -> dict:
@@ -514,9 +510,11 @@ def main(program_name: str, argv: list[str]) -> int:
             old_dpkg_list_last_release,
             job_properties,
             grml_live_path,
-            upload_to_daily,
             old_iso_path,
         )
+
+        if upload_to_daily:
+            upload_daily(job_properties.job_name, build_dir, job_properties.job_timestamp)
 
         # Copy dpkg.list into cache for next iteration.
         new_dpkg_list = get_dpkg_list_path_for_build(build_dir)

--- a/build-driver/build.py
+++ b/build-driver/build.py
@@ -513,6 +513,15 @@ def main(program_name: str, argv: list[str]) -> int:
             old_iso_path,
         )
 
+        # Remove the sources *directory*, to not have the sources twice in the CI artifacts.
+        grml_sources_directory = build_dir / "grml_sources"
+        if grml_sources_directory.exists():
+            print(f"I: Removing {grml_sources_directory}")
+            shutil.rmtree(grml_sources_directory, ignore_errors=True)
+
+        if old_sources_path:
+            old_sources_path.rename(build_dir / job_properties.sources_name)
+
         if upload_to_daily:
             upload_daily(job_properties.job_name, build_dir, job_properties.job_timestamp)
 
@@ -520,15 +529,6 @@ def main(program_name: str, argv: list[str]) -> int:
         new_dpkg_list = get_dpkg_list_path_for_build(build_dir)
         old_dpkg_list_previous_build.parent.mkdir(exist_ok=True)
         shutil.copyfile(new_dpkg_list, old_dpkg_list_previous_build)
-
-        if old_sources_path:
-            old_sources_path.rename(build_dir / job_properties.sources_name)
-
-        # Remove the sources *directory*, to not have the sources twice in the CI artifacts.
-        grml_sources_directory = build_dir / "grml_sources"
-        if grml_sources_directory.exists():
-            print(f"I: Removing {grml_sources_directory}")
-            shutil.rmtree(grml_sources_directory, ignore_errors=True)
 
     print("I: Success.")
 


### PR DESCRIPTION
Most importantly this deletes `grml_sources` before uploading to the daily host.
Saves us disk space and upload time.

The build driver is slightly more internally consistent now, too.