### PR TITLE
Reduce size of nonfree-licenses.txt by gzip-compressing it

### DIFF
--- a/etc/grml/fai/config/scripts/GRMLBASE/95-package-information
+++ b/etc/grml/fai/config/scripts/GRMLBASE/95-package-information
@@ -41,6 +41,7 @@ else
          fi
          echo >> "${LOGDIR}"/nonfree-licenses.txt
       done
+      gzip -9 "${LOGDIR}"/nonfree-licenses.txt
    fi
 fi
 


### PR DESCRIPTION
The file grew in size over time, not at about 5MB uncompressed.