### PR TITLE
ttys: set WorkingDirectory to $HOME

### DIFF
--- a/etc/grml/fai/config/files/etc/systemd/system/getty@tty1.service.d/override.conf/GRMLBASE
+++ b/etc/grml/fai/config/files/etc/systemd/system/getty@tty1.service.d/override.conf/GRMLBASE
@@ -7,6 +7,7 @@ StandardInput=tty
 StandardOutput=tty
 TTYPath=/dev/tty1
 TTYVTDisallocate=no
+WorkingDirectory=~
 ExecStart=
 ExecStart=-/usr/share/grml-scripts/run-welcome
 

--- a/etc/grml/fai/config/files/etc/systemd/system/getty@tty2.service.d/override.conf/GRMLBASE
+++ b/etc/grml/fai/config/files/etc/systemd/system/getty@tty2.service.d/override.conf/GRMLBASE
@@ -6,6 +6,7 @@ Restart=always
 StandardInput=tty
 StandardOutput=tty
 TTYPath=/dev/tty2
+WorkingDirectory=~
 ExecStart=
 ExecStart=-/usr/share/grml-scripts/run-screen
 

--- a/etc/grml/fai/config/files/etc/systemd/system/getty@tty3.service.d/override.conf/GRMLBASE
+++ b/etc/grml/fai/config/files/etc/systemd/system/getty@tty3.service.d/override.conf/GRMLBASE
@@ -6,6 +6,7 @@ Restart=always
 StandardInput=tty
 StandardOutput=tty
 TTYPath=/dev/tty3
+WorkingDirectory=~
 ExecStart=
 ExecStart=-/usr/share/grml-scripts/run-screen
 

--- a/etc/grml/fai/config/files/etc/systemd/system/getty@tty4.service.d/override.conf/GRMLBASE
+++ b/etc/grml/fai/config/files/etc/systemd/system/getty@tty4.service.d/override.conf/GRMLBASE
@@ -7,6 +7,7 @@ StandardInput=tty
 StandardOutput=tty
 TTYPath=/dev/tty4
 User=$USERNAME
+WorkingDirectory=~
 ExecStart=
 ExecStart=-/usr/share/grml-scripts/run-screen
 


### PR DESCRIPTION
Let systemd set the current working directory for tty1-tty4 to the users (either root or $USERNAME) home directory. Then we can remove hacks in zshenv/zshrc.