### PR TITLE
console-setup: create setupcon cache

### DIFF
--- a/etc/grml/fai/config/scripts/GRMLBASE/26-console-setup
+++ b/etc/grml/fai/config/scripts/GRMLBASE/26-console-setup
@@ -11,5 +11,10 @@ set -e
 
 fcopy -M -v /etc/default/console-setup
 
+# Have setupcon write its cache into /etc/console-setup, to avoid doing
+# this on each live boot.
+rm -f "${target}"/etc/console-setup/cached*
+$ROOTCMD setupcon --save-only
+
 ## END OF FILE #################################################################
 # vim:ft=sh expandtab ai tw=80 tabstop=4 shiftwidth=2


### PR DESCRIPTION
Previously console-setup would on startup find and copy the keymap and console font into /etc/console-setup.

This moves this caching step to grml-live execution time, and thus out of the (first) boot.

Files affected:

* /etc/console-setup/cached_UTF-8_del.kmap.gz
* /etc/console-setup/cached_Uni3-Terminus16.psf.gz
* /etc/console-setup/cached_setup_font.sh
* /etc/console-setup/cached_setup_keyboard.sh
* /etc/console-setup/cached_setup_terminal.sh