### PR TITLE
Switch from ftp.debian.org to deb.debian.org

### DIFF
--- a/debian/grml-live.maintscript
+++ b/debian/grml-live.maintscript
@@ -1,4 +1,5 @@
 rm_conffile /etc/grml/fai/config/files/etc/apt/grml.key/GRMLBASE 0.32.3~
+rm_conffile /etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_ETCH 0.50.2~
 rm_conffile /etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_SID 0.47.10~
 rm_conffile /etc/grml/fai/config/files/etc/inittab/GRMLBASE 0.43.0~
 rm_conffile /etc/grml/fai/config/files/etc/inittab/GRML_SMALL 0.43.0~

--- a/docs/grml-live.txt
+++ b/docs/grml-live.txt
@@ -690,7 +690,7 @@ FAI_DEBOOTSTRAP:
   [...]
   APT_PROXY="http://localhost:3142/"
   [...]
-  FAI_DEBOOTSTRAP="bookworm http://localhost:3142/ftp.debian.org/debian bookworm main contrib non-free"
+  FAI_DEBOOTSTRAP="bookworm http://localhost:3142/deb.debian.org/debian bookworm main contrib non-free"
 
 Make sure apt-cacher-ng is running ('/etc/init.d/apt-cacher-ng restart').
 That's it.  All downloaded files will be cached in /var/cache/apt-cacher-ng then.

--- a/etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_BOOKWORM
+++ b/etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_BOOKWORM
@@ -1,6 +1,6 @@
 # official debian repository:
-  deb     http://ftp.debian.org/debian/ bookworm main contrib non-free-firmware non-free
-  deb-src http://ftp.debian.org/debian/ bookworm main contrib non-free-firmware non-free
+  deb     http://deb.debian.org/debian/ bookworm main contrib non-free-firmware non-free
+  deb-src http://deb.debian.org/debian/ bookworm main contrib non-free-firmware non-free
 
 # security updates:
   deb     http://security.debian.org/debian-security bookworm-security main contrib non-free-firmware non-free

--- a/etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_BULLSEYE
+++ b/etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_BULLSEYE
@@ -1,6 +1,6 @@
 # official debian repository:
-  deb     http://ftp.debian.org/debian/ bullseye main contrib non-free
-  deb-src http://ftp.debian.org/debian/ bullseye main contrib non-free
+  deb     http://deb.debian.org/debian/ bullseye main contrib non-free
+  deb-src http://deb.debian.org/debian/ bullseye main contrib non-free
 
 # security updates:
   deb     http://security.debian.org/debian-security bullseye-security main contrib non-free

--- a/etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_ETCH
+++ b/etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_ETCH
@@ -1,3 +1,3 @@
 # official debian repository:
-  deb     http://ftp.debian.org/debian/ etch main contrib non-free
-  deb-src http://ftp.debian.org/debian/ etch main contrib non-free
+  deb     http://deb.debian.org/debian/ etch main contrib non-free
+  deb-src http://deb.debian.org/debian/ etch main contrib non-free

--- a/etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_ETCH
+++ b/etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_ETCH
@@ -1,3 +1,0 @@
-# official debian repository:
-  deb     http://deb.debian.org/debian/ etch main contrib non-free
-  deb-src http://deb.debian.org/debian/ etch main contrib non-free

--- a/etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_STABLE
+++ b/etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_STABLE
@@ -1,11 +1,11 @@
 # official debian repository:
-  deb     http://ftp.debian.org/debian/ stable main contrib non-free-firmware non-free
-  deb-src http://ftp.debian.org/debian/ stable main contrib non-free-firmware non-free
+  deb     http://deb.debian.org/debian/ stable main contrib non-free-firmware non-free
+  deb-src http://deb.debian.org/debian/ stable main contrib non-free-firmware non-free
 
 # security updates:
   deb     http://security.debian.org/debian-security stable-security main contrib non-free-firmware non-free
   deb-src http://security.debian.org/debian-security stable-security main contrib non-free-firmware non-free
 
 # backports:
-  deb     http://ftp.debian.org/debian/ stable-backports main contrib non-free-firmware non-free
-  deb-src http://ftp.debian.org/debian/ stable-backports main contrib non-free-firmware non-free
+  deb     http://deb.debian.org/debian/ stable-backports main contrib non-free-firmware non-free
+  deb-src http://deb.debian.org/debian/ stable-backports main contrib non-free-firmware non-free

--- a/etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_TESTING
+++ b/etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_TESTING
@@ -1,6 +1,6 @@
 # official debian repository:
-  deb     http://ftp.debian.org/debian/ testing main contrib non-free-firmware non-free
-  deb-src http://ftp.debian.org/debian/ testing main contrib non-free-firmware non-free
+  deb     http://deb.debian.org/debian/ testing main contrib non-free-firmware non-free
+  deb-src http://deb.debian.org/debian/ testing main contrib non-free-firmware non-free
 
 # security updates:
   deb     http://security.debian.org/debian-security/ testing-security main contrib non-free-firmware non-free

--- a/etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_TRIXIE
+++ b/etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_TRIXIE
@@ -1,6 +1,6 @@
 # official debian repository:
-  deb     http://ftp.debian.org/debian/ trixie main contrib non-free-firmware non-free
-  deb-src http://ftp.debian.org/debian/ trixie main contrib non-free-firmware non-free
+  deb     http://deb.debian.org/debian/ trixie main contrib non-free-firmware non-free
+  deb-src http://deb.debian.org/debian/ trixie main contrib non-free-firmware non-free
 
 # security updates:
   deb     http://security.debian.org/debian-security trixie-security main contrib non-free-firmware non-free

--- a/etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_UNSTABLE
+++ b/etc/grml/fai/config/files/etc/apt/sources.list.d/debian.list/DEBIAN_UNSTABLE
@@ -1,3 +1,3 @@
 # official debian repository:
-  deb     http://ftp.debian.org/debian/ unstable main contrib non-free-firmware non-free
-  deb-src http://ftp.debian.org/debian/ unstable main contrib non-free-firmware non-free
+  deb     http://deb.debian.org/debian/ unstable main contrib non-free-firmware non-free
+  deb-src http://deb.debian.org/debian/ unstable main contrib non-free-firmware non-free

--- a/etc/grml/fai/config/hooks/updatebase.GRMLBASE
+++ b/etc/grml/fai/config/hooks/updatebase.GRMLBASE
@@ -77,7 +77,7 @@ fcopy -M -i -B -v -r /etc/apt
 if [ -n "${WAYBACK_DATE:-}" ] ; then
   echo "Wayback date '$WAYBACK_DATE' identified, enabling for snapshot.debian.org usage."
 
-  perl -pi -e "s#^(\s+)(deb.* )(.*://ftp.debian.org.*?)\s+([a-z-]+)\s+(.*)\$#\$1\$2 [check-valid-until=no] http://snapshot.debian.org/archive/debian/$WAYBACK_DATE/ \$4 \$5#" \
+  perl -pi -e "s#^(\s+)(deb.* )(.*://deb.debian.org.*?)\s+([a-z-]+)\s+(.*)\$#\$1\$2 [check-valid-until=no] http://snapshot.debian.org/archive/debian/$WAYBACK_DATE/ \$4 \$5#" \
     "${target}/etc/apt/sources.list.d/debian.list"
 
   perl -pi -e "s#^(\s+)(deb.* )(.*://security.debian.org.*?)\s+([a-z-/]+)\s+(.*)\$#\$1\$2 [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/$WAYBACK_DATE/ \$4 \$5#" \

--- a/etc/grml/fai/config/scripts/GRMLBASE/33-aptsetup
+++ b/etc/grml/fai/config/scripts/GRMLBASE/33-aptsetup
@@ -15,7 +15,7 @@ target=${target:?}
 if ifclass RELEASE ; then
   set -u
   current_date=$(date +%Y%m%d)
-  perl -pi -e 'BEGIN { $d="'"$current_date"'"; } s#^(\s+)(deb.* )(.*://ftp.debian.org.*?)\s+([a-z-]+)\s+(.*)$#$1$2http://snapshot.debian.org/archive/debian/$d/ $4 $5#' \
+  perl -pi -e 'BEGIN { $d="'"$current_date"'"; } s#^(\s+)(deb.* )(.*://deb.debian.org.*?)\s+([a-z-]+)\s+(.*)$#$1$2http://snapshot.debian.org/archive/debian/$d/ $4 $5#' \
     "${target}/etc/apt/sources.list.d/debian.list"
 fi
 

--- a/etc/grml/grml-live.conf
+++ b/etc/grml/grml-live.conf
@@ -55,7 +55,7 @@
 
 # Which Debian suite and which mirror do you want to use for debootstrapping?
 # Usage: "<suite> <mirror>"
-# FAI_DEBOOTSTRAP="bookworm http://ftp.debian.org/debian"
+# FAI_DEBOOTSTRAP="bookworm http://deb.debian.org/debian"
 
 # Do you want to use a local mirror (like NFS)?
 # If so specify the directory where debian/ is available:

--- a/grml-live
+++ b/grml-live
@@ -753,7 +753,7 @@ if [ -z "$FAI_DEBOOTSTRAP" ] ; then
   if [ -n "$WAYBACK_DATE" ] ; then
     FAI_DEBOOTSTRAP="$SUITE http://snapshot.debian.org/archive/debian/$WAYBACK_DATE/"
   else
-    FAI_DEBOOTSTRAP="$SUITE http://ftp.debian.org/debian"
+    FAI_DEBOOTSTRAP="$SUITE http://deb.debian.org/debian"
   fi
 fi
 


### PR DESCRIPTION
Both point to the same CDN nowadays, but the deb.debian.org name is more popular with automatic caching redirects et al.

While at it, drop the apt sources.list file for `DEBIAN_ETCH`.