### PR TITLE
GRMLBASE/21-usersetup: remove grep of group file

### DIFF
--- a/config/scripts/GRMLBASE/21-usersetup
+++ b/config/scripts/GRMLBASE/21-usersetup
@@ -31,7 +31,7 @@ fi
 add_user_to_group() {
    [ -n "$1" ] || return 1
    if grep -q "$1" "$target"/etc/group ; then
-      grep "$1:x:.*$USERNAME" "$target"/etc/group || $ROOTCMD adduser "$USERNAME" "$1"
+      $ROOTCMD adduser --quiet "$USERNAME" "$1"
    fi
 }
 


### PR DESCRIPTION
adduser is supposed to be idempotent; with -q it also does not log a warning when the user is already in the given group.