### PR TITLE
build: sort debian changes, fix flavor

### DIFF
--- a/build-driver/build.py
+++ b/build-driver/build.py
@@ -335,7 +335,7 @@ def download_old_dpkg_list_last_release(tmp_dir: Path, last_release_version: str
         return None
 
     path = tmp_dir / "dpkg.list.previous_release"
-    url = f"https://ftp-master.grml.org/grml-{last_release_version}-metadata/grml-full-{last_release_version}-{arch}/dpkg.list"
+    url = f"https://ftp-master.grml.org/grml-{last_release_version}-metadata/grml-{flavor}-{last_release_version}-{arch}/dpkg.list"
     with ci_section(f"Downloading old dpkg.list {url} to {path!s}"):
         try:
             download_file(url, path)

--- a/build-driver/generate-changes-list.py
+++ b/build-driver/generate-changes-list.py
@@ -169,9 +169,9 @@ People:
     {}
 ------------------------------------------------------------------------
 """.format(
-        "\n    ".join(debian_changes["added"]).strip(),
-        "\n    ".join(debian_changes["changed"]).strip(),
-        "\n    ".join(debian_changes["removed"]).strip(),
+        "\n    ".join(sorted(debian_changes["added"])).strip(),
+        "\n    ".join(sorted(debian_changes["changed"])).strip(),
+        "\n    ".join(sorted(debian_changes["removed"])).strip(),
     )
 
     output_filename.write_text(changelog)


### PR DESCRIPTION
1) Sort debian package names in `changes-last*.txt`

2) Fix a0e5bbbe5b4f3024323d2c856c25d26e5fefe77a which broke selecting dpkg.list for the correct flavor (currently always the file from `full` is used)
