### PR TITLE
grub: remove nonfunctional memtest86 bios-mode selection

### DIFF
--- a/templates/boot/grub/addons.cfg
+++ b/templates/boot/grub/addons.cfg
@@ -25,31 +25,11 @@ fi
 
 # BIOS/non-EFI:
 if [ "${grub_platform}" != "efi" ] ; then
-  # try to detect amd64 by checking whether CPU supports 64-bit (long) mode
-  if cpuid -l ; then
-    if test -e /boot/addons/memtest86+x64.bin ; then
-      menuentry "Memory test (memtest86+x64.bin)" {
-        insmod linux16
-        linux16 /boot/addons/memtest86+x64.bin
-      }
-    elif test -e /boot/addons/memtest ; then # fallback to old memtest
-      menuentry "Memory test (memtest86+)" {
-        insmod linux16
-        linux16 /boot/addons/memtest
-      }
-    fi
-  else  # assume i386
-    if test -e /boot/addons/memtest86+ia32.bin ; then
-      menuentry "Memory test (memtest86+ia32.bin)" {
-        insmod linux16
-        linux16 /boot/addons/memtest86+ia32.bin
-      }
-    elif test -e /boot/addons/memtest ; then # fallback to old memtest
-      menuentry "Memory test (memtest86+)" {
-        insmod linux16
-        linux16 /boot/addons/memtest
-      }
-    fi
+  if test -e /boot/addons/memtest ; then
+    menuentry "Memory test (memtest86+)" {
+      insmod linux16
+      linux16 /boot/addons/memtest
+    }
   fi
 fi
 


### PR DESCRIPTION
Because we do not have any cpu selection logic in the isolinux boot path, grml-live *always* installs the BIOS-mode memtest86+ binaries as /boot/addons/memtest.

Thus, the check for /boot/addons/memtest86+x64.bin and /boot/addons/memtest86+ia32.bin can never have worked. Drop it.

On `grml-small-daily20241223build179testing-amd64.iso`, only `Memory test (memtest86+)` is visible in BIOS-grub.