### PR TITLE
Workaround /sbin/init vanishing, Debian bug #1056151

### DIFF
--- a/config/hooks/instsoft.GRMLBASE
+++ b/config/hooks/instsoft.GRMLBASE
@@ -146,5 +146,8 @@ if [ -L "${target}"/usr/sbin/invoke-rc.d ] ; then
    $ROOTCMD dpkg-divert --package fai --rename --remove /usr/sbin/invoke-rc.d
 fi
 
+echo "[instsoft] Removing FAI diversion of /sbin/init to avoid Debian bug #1056151 for fai < 6.2.3"
+fai-divert -r /sbin/init || true
+
 ## END OF FILE #################################################################
 # vim:ft=sh expandtab ai tw=80 tabstop=4 shiftwidth=2


### PR DESCRIPTION
FAI before 6.2.3 diverts /sbin/init. Previously we got away with this by having systemd-sysv installed into the basefiles and then never upgrading it. But since c84d711d215eb62c1e4712f5280630000804a544 systemd-sysv gets installed in instsoft, triggering the broken behaviour.

Fixes: c84d711d215eb62c1e4712f5280630000804a544