### PR TITLE
build-driver improvements

### DIFF
--- a/build-driver/build.py
+++ b/build-driver/build.py
@@ -116,7 +116,16 @@ def run_grml_live(
             basefiles_path = grml_fai_config / "basefiles"
             basefiles_path.mkdir(exist_ok=True)
             basefile = basefiles_path / f"{arch.upper()}.tar.gz"
-            run_x(["mmdebstrap", "--format=tar", "--variant=required", "--verbose", debian_suite, basefile])
+            args = [
+                "mmdebstrap",
+                "--format=tar",
+                "--variant=required",
+                "--verbose",
+                "--include=netbase",
+                debian_suite,
+                basefile,
+            ]
+            run_x(args)
 
     grml_live_cmd = [
         grml_live_path / "grml-live",

--- a/build-driver/build.py
+++ b/build-driver/build.py
@@ -116,7 +116,7 @@ def run_grml_live(
             basefiles_path = grml_fai_config / "basefiles"
             basefiles_path.mkdir(exist_ok=True)
             basefile = basefiles_path / f"{arch.upper()}.tar.gz"
-            run_x(["mmdebstrap", "--format=tar", "--variant=required", debian_suite, basefile])
+            run_x(["mmdebstrap", "--format=tar", "--variant=required", "--verbose", debian_suite, basefile])
 
     grml_live_cmd = [
         grml_live_path / "grml-live",


### PR DESCRIPTION
Make mmdebstrap more verbose, and install netbase so apt can resolve SRV records for the large package download phase. This works around this apt bug: http://bugs.debian.org/1092164
