### PR TITLE
Remove obsolete touch /etc/grml_fai_release

### DIFF
--- a/config/scripts/RELEASE/98-clean-chroot
+++ b/config/scripts/RELEASE/98-clean-chroot
@@ -29,10 +29,6 @@ rm -f "$target"/var/lib/apt/lists/*Packages \
 echo "Removing /var/lib/aptitude/pkgstates.old"
 rm -f "$target"/var/lib/aptitude/pkgstates.old
 
-# Remove all FAI logs from chroot via grml-live later then
-echo "Setting up /etc/grml_fai_release for grml-live"
-touch "$target"/etc/grml_fai_release
-
 echo "Removing all files inside /root"
 rm -rf "$target"/root
 mkdir -m 0755 "$target"/root


### PR DESCRIPTION
This was introduced in 0c469a66c1d77ef2aff158145bb3ccec02dc361a together with code in grml-live.  In 4152229391fd4af0ab4b88408a3efff2e7f52f37 I removed the check for the touch-file.

Clean this up.