### PR TITLE
Annotate scripts assuming they can use host tools/files

### DIFF
--- a/config/scripts/GRMLBASE/01-packages
+++ b/config/scripts/GRMLBASE/01-packages
@@ -12,6 +12,7 @@ set -e
 # FAI sets $target, but shellcheck does not know that.
 target=${target:?}
 
+# OUTSIDE: This fragment assumes it runs outside the chroot.
 echo -n > "${LOGDIR}"/package_errors.log  # ensure we start with an empty file
 
 if ! [ -e "${LOGDIR}"/software.log ] ; then

--- a/config/scripts/GRMLBASE/47-update-wallpaper
+++ b/config/scripts/GRMLBASE/47-update-wallpaper
@@ -36,6 +36,7 @@ if [ ! -f "$FONTFILE" ]; then
     exit 0
 fi
 
+# OUTSIDE: This fragment assumes it runs outside the chroot.
 convert "$GRML_BG" -gravity center \
     -fill white -font "$FONTFILE" \
     -pointsize "$TITLE_FONTSIZE" \

--- a/config/scripts/GRMLBASE/95-package-information
+++ b/config/scripts/GRMLBASE/95-package-information
@@ -16,10 +16,12 @@ if ! [ -w "${LOGDIR}" ] ; then
   exit 1
 fi
 
+# OUTSIDE: This fragment assumes it runs outside the chroot.
 # store package list:
 COLUMNS=200 $ROOTCMD dpkg --list > "${LOGDIR}"/dpkg.list
 COLUMNS=200 $ROOTCMD dpkg --get-selections > "${LOGDIR}"/dpkg.selections
 
+# OUTSIDE: This fragment assumes it runs outside the chroot.
 # store list of packages sorted by size:
 if [ -x "$target"/usr/bin/dpkg-query ] ; then
   # shellcheck disable=SC2016 # Embedded $ is correct.
@@ -27,6 +29,7 @@ if [ -x "$target"/usr/bin/dpkg-query ] ; then
     "${LOGDIR}"/packages.size
 fi
 
+# OUTSIDE: This fragment assumes it runs outside the chroot.
 # store a list of non-free packages and their licenses
 echo "The following packages from the Debian non-free section are included in this release" \
    > "${LOGDIR}"/nonfree-licenses.txt
@@ -35,6 +38,7 @@ echo >> "${LOGDIR}"/nonfree-licenses.txt
 # copyright information for non-free packages
 non_free_pkgs=$($ROOTCMD apt-cache show '~i' | awk '/^Package: / {pkg=$2} /^Section: non-free/ {print pkg}')
 
+# OUTSIDE: This fragment assumes it runs outside the chroot.
 for pkg in ${non_free_pkgs:-} ; do
   echo "Package: ${pkg}" >> "${LOGDIR}"/nonfree-licenses.txt
   echo "========================================================================" \

--- a/config/scripts/RELEASE/99-update-wallpaper
+++ b/config/scripts/RELEASE/99-update-wallpaper
@@ -35,6 +35,7 @@ if [ ! -f "$FONTFILE" ]; then
     exit 0
 fi
 
+# OUTSIDE: This fragment assumes it runs outside the chroot.
 convert "$GRML_BG" -gravity center \
     -fill white -font "$FONTFILE" \
     -pointsize "$TITLE_FONTSIZE" \


### PR DESCRIPTION
Annotate script fragments that use tools or files from the host (so outside of the chroot) with an "OUTSIDE:" marker.
This will become important later, when we split scripts between "on the inside" and "on the outside" scripts.