### PR TITLE
Remove workaround for lighty issue from 15years ago

### DIFF
--- a/config/files/etc/apt/apt.conf.d/15grml-live/GRMLBASE
+++ b/config/files/etc/apt/apt.conf.d/15grml-live/GRMLBASE
@@ -1,8 +1,5 @@
 // Installed via ${GRML_FAI_CONFIG}/files/etc/apt/apt.conf.d/15grml-live/GRMLBASE
 
-// work around http://trac.lighttpd.net/trac/ticket/657
-Acquire::http::Pipeline-Depth 0; // added by grml-live
-
 // Recommends just pull in way tooooo much packages, so disable it:
 APT::Install-Recommends false;   // added by grml-live
 


### PR DESCRIPTION
http://trac.lighttpd.net/trac/ticket/657 was apparently fixed 15 years ago.