### PR TITLE
grml-live: stop passing env vars to fai, make fai overridable

### DIFF
--- a/config/hooks/instsoft.GRMLBASE
+++ b/config/hooks/instsoft.GRMLBASE
@@ -9,6 +9,9 @@
 set -u
 set -e
 
+# shellcheck source=/dev/null
+. "$GRML_LIVE_CONFIG"
+
 # FAI sets ${target}, but shellcheck does not know that.
 target=${target:?}
 

--- a/config/hooks/updatebase.GRMLBASE
+++ b/config/hooks/updatebase.GRMLBASE
@@ -8,6 +8,7 @@
 
 set -u
 set -e
+
 # shellcheck source=/dev/null
 . "$GRML_LIVE_CONFIG"
 

--- a/config/scripts/GRMLBASE/45-grub-images
+++ b/config/scripts/GRMLBASE/45-grub-images
@@ -9,6 +9,9 @@
 set -e
 set -u
 
+# shellcheck source=/dev/null
+. "$GRML_LIVE_CONFIG"
+
 # FAI sets $target, but shellcheck does not know that.
 target=${target:?}
 

--- a/grml-live
+++ b/grml-live
@@ -613,10 +613,10 @@ log "$CMDLINE"
 einfo "Logging actions to logfile $LOGFILE"
 # }}}
 
-# dump config variables into file, for script access {{{
+# dump config variables into file, for hooks/scripts access {{{
 CONFIGDUMP=$(mktemp)
 set | grep -E \
-  '^(GRML_NAME|RELEASENAME|DATE|VERSION|SUITE|ARCH|DISTRI_NAME|TEMPLATE_DIRECTORY|USERNAME|HOSTNAME|APT_PROXY)=' \
+  '^(GRML_NAME|RELEASENAME|DATE|VERSION|SUITE|ARCH|DISTRI_NAME|TEMPLATE_DIRECTORY|USERNAME|HOSTNAME|APT_PROXY|BUILD_ONLY|BOOTSTRAP_ONLY|WAYBACK_DATE)=' \
   > "${CONFIGDUMP}"
 # }}}
 
@@ -775,9 +775,9 @@ else
       mv "${OUTPUT}"/grml_sources "${CHROOT_OUTPUT}"/grml-live/
 
       log "Executed FAI command line:"
-      log "BUILD_ONLY=$BUILD_ONLY BOOTSTRAP_ONLY=$BOOTSTRAP_ONLY GRML_LIVE_CONFIG=$CONFIGDUMP WAYBACK_DATE=$WAYBACK_DATE fai $VERBOSE -C $FAI_CONF_DIR -s file:///$GRML_FAI_CONFIG -c$CLASSES -u $HOSTNAME $FAI_ACTION $CHROOT_OUTPUT $FAI_ARGS"
+      log "GRML_LIVE_CONFIG=$CONFIGDUMP fai $VERBOSE -C $FAI_CONF_DIR -s file:///$GRML_FAI_CONFIG -c$CLASSES -u $HOSTNAME $FAI_ACTION $CHROOT_OUTPUT $FAI_ARGS"
       # shellcheck disable=SC2086 # $FAI_ARGS needs splitting
-      BUILD_ONLY="$BUILD_ONLY" BOOTSTRAP_ONLY="$BOOTSTRAP_ONLY" GRML_LIVE_CONFIG="$CONFIGDUMP" fai $VERBOSE \
+      GRML_LIVE_CONFIG="$CONFIGDUMP" fai $VERBOSE \
                   -C "$FAI_CONF_DIR" -s "file:///$GRML_FAI_CONFIG" -c"$CLASSES" \
                   -u "$HOSTNAME" "$FAI_ACTION" "$CHROOT_OUTPUT" $FAI_ARGS | tee -a "$LOGFILE"
       RC="${PIPESTATUS[0]}" # notice: bash-only

--- a/grml-live
+++ b/grml-live
@@ -128,6 +128,7 @@ HOSTNAME=''
 USERNAME=''
 CONFIGDUMP=''
 FAI_CONF_DIR=''
+FAI_PROGRAM='fai'
 
 # don't use colors/escape sequences
 if [ -r /lib/lsb/init-functions ] ; then
@@ -775,9 +776,9 @@ else
       mv "${OUTPUT}"/grml_sources "${CHROOT_OUTPUT}"/grml-live/
 
       log "Executed FAI command line:"
-      log "GRML_LIVE_CONFIG=$CONFIGDUMP fai $VERBOSE -C $FAI_CONF_DIR -s file:///$GRML_FAI_CONFIG -c$CLASSES -u $HOSTNAME $FAI_ACTION $CHROOT_OUTPUT $FAI_ARGS"
+      log "GRML_LIVE_CONFIG=$CONFIGDUMP $FAI_PROGRAM $VERBOSE -C $FAI_CONF_DIR -s file:///$GRML_FAI_CONFIG -c$CLASSES -u $HOSTNAME $FAI_ACTION $CHROOT_OUTPUT $FAI_ARGS"
       # shellcheck disable=SC2086 # $FAI_ARGS needs splitting
-      GRML_LIVE_CONFIG="$CONFIGDUMP" fai $VERBOSE \
+      GRML_LIVE_CONFIG="$CONFIGDUMP" "$FAI_PROGRAM" $VERBOSE \
                   -C "$FAI_CONF_DIR" -s "file:///$GRML_FAI_CONFIG" -c"$CLASSES" \
                   -u "$HOSTNAME" "$FAI_ACTION" "$CHROOT_OUTPUT" $FAI_ARGS | tee -a "$LOGFILE"
       RC="${PIPESTATUS[0]}" # notice: bash-only


### PR DESCRIPTION
No immediate benefit except a bit of cleanup.

Will become necessary on something I'm working on 😊 