### PR TITLE
Fix missing isolinux files

### DIFF
--- a/grml-live
+++ b/grml-live
@@ -1193,7 +1193,7 @@ else
          [ "$file_basename" != "lua.c32" ] && \
          [ "$file_basename" != "liblua.c32" ] && \
          [[ "$file_basename" != *test.c32 ]] ; then
-        copy_file_logged "${BUILD_OUTPUT}"/boot/isolinux/"$file_basename" "${CHROOT_OUTPUT}" "$file"
+        copy_file_logged "${BUILD_OUTPUT}"/boot/isolinux/"$file_basename" "${CHROOT_OUTPUT}" /usr/lib/syslinux/modules/bios/"$file_basename"
       fi
     done
 


### PR DESCRIPTION
Fixes: 81efbabe7211084b9b75803c7040b929c15fbcce dbfb6371f64363805a1a96b628d626e34372839b

All `*.c32` files went missing in the ISO because the path calculation is wrong.