### PR TITLE
Require package repositories to be signed, by default

### DIFF
--- a/config/class/GRMLBASE.var
+++ b/config/class/GRMLBASE.var
@@ -1,7 +1,7 @@
 # default values for installation. You can override them in your *.var files
 
 # allow installation of packages from unsigned repositories
-FAI_ALLOW_UNSIGNED=1
+# FAI_ALLOW_UNSIGNED=1
 
 CONSOLEFONT=
 KEYMAP=us-latin1


### PR DESCRIPTION
Users can still use unsigned repositories, if they understand the security implications. By default, we really want signing.