### PR TITLE
ZFS: derive linux package names from primary Debian architecture

### DIFF
--- a/config/hooks/instsoft.ZFS
+++ b/config/hooks/instsoft.ZFS
@@ -26,6 +26,8 @@ target=${target:?}
 # TODO: support other architectures grml and grml-live supports (PRs
 # welcome, I'm sure).
 
+arch=$($ROOTCMD dpkg --print-architecture)
+
 echo "$0: Installing latest kernel and its headers, as well as build-essential."
 # For some reason, apt's autoremove function doesn't pick up some of the
 # extra packages we install here, e.g. gcc-11, so work around that by
@@ -34,9 +36,9 @@ echo "$0: Installing latest kernel and its headers, as well as build-essential."
 # larger. I hope this kludge can go away eventually.
 mapfile -t extra_packages < <($ROOTCMD \
     apt-get --assume-no --download-only --mark-auto -u install \
-	build-essential linux-image-amd64 linux-headers-amd64 \
+	build-essential linux-image-${arch} linux-headers-${arch} \
 	| sed -e '0,/The following NEW packages will be installed/d;/^[^ ]/,$d' -e 's/\s/\n/g' | sed '/^$/d')
-$ROOTCMD apt-get --yes --mark-auto -u install build-essential linux-image-amd64 linux-headers-amd64
+$ROOTCMD apt-get --yes --mark-auto -u install build-essential linux-image-${arch} linux-headers-${arch}
 
 # Remove all but the latest kernel (TODO: support passing in the desired
 # kernel version by configuration variable instead of using the latest):


### PR DESCRIPTION
Necessary for building for arm64.