### PR TITLE
Fix timezone and RTC setup

### DIFF
--- a/config/class/GRMLBASE.var
+++ b/config/class/GRMLBASE.var
@@ -3,6 +3,4 @@
 # allow installation of packages from unsigned repositories
 # FAI_ALLOW_UNSIGNED=1
 
-# Set UTC=yes if your system clock is set to UTC (GMT) and UTC=no if not.
-UTC=no
-TIMEZONE=UTC
+TIMEZONE=Etc/UTC

--- a/config/scripts/GRMLBASE/18-timesetup
+++ b/config/scripts/GRMLBASE/18-timesetup
@@ -12,13 +12,6 @@ set -e
 # FAI sets $target, but shellcheck does not know that.
 target=${target:?}
 
-# tell if hwclock is running in UTC or local time
-# by default it's set to UTC=no
-if [ -n "$UTC" ] && [ "$UTC" = "yes" ] ; then
-   echo "UTC is set to 'yes', setting hwclock parameter UTC"
-   [ -e "${target}/etc/adjtime" ] && sed -i "s/^LOCAL/UTC/" "${target}/etc/adjtime"
-fi
-
 # default timezone settings
 if [ -n "$TIMEZONE" ] ; then
    echo "Setting default timezone to $TIMEZONE"
@@ -32,8 +25,7 @@ if [ -n "$TIMEZONE" ] ; then
       # only for tzdata before 2024b-6 (Debian trixie).
       echo "$TIMEZONE" > "$target"/etc/timezone
    fi
-   rm -f "$target"/etc/localtime
-   cp -f "$target"/usr/share/zoneinfo/"$TIMEZONE" "$target"/etc/localtime
+   chroot "$target" ln -sf /usr/share/zoneinfo/"$TIMEZONE" /etc/localtime
 fi
 
 ## END OF FILE ################################################################

--- a/templates/GRML/grml-cheatcodes.txt
+++ b/templates/GRML/grml-cheatcodes.txt
@@ -39,8 +39,7 @@ Regional settings:
 ------------------
 grml lang=at|de|cn|da|es|fr|it        Specify language ($LANG, $LC_ALL, $LANGUAGE - utf8) + keyboard
 grml lang=nl|pl|ru|sk|tr|tw|us        Specify language ($LANG, $LC_ALL, $LANGUAGE - utf8) + keyboard
-grml utc                              Hardware Clock is set to Coordinated Universal Time (UTC)
-grml localtime                        Hardware Clock is set to local time (LOCAL), this is the default
+grml localtime                        Hardware Clock is set to local time (default: RTC is in UTC)
 grml tz=Europe/Vienna                 Use specified timezone for TZ, defaults to TZ=UTC
 grml keyboard=us                      Use different keyboard layout
 


### PR DESCRIPTION
Correctly create /etc/localtime as a symlink. Also stop dealing with /etc/adjtime, which does not exist anymore. Instead document RTC=UTC as default.

Remove GRMLBASE.var "UTC", and default TIMEZONE to Etc/UTC, to get the debconf variables correctly set.

Corresponding grml-autoconfig change: https://github.com/grml/grml-autoconfig/pull/30