### PR TITLE
minifai: debug fcopy failure

### DIFF
--- a/usr/lib/grml-live/minifai
+++ b/usr/lib/grml-live/minifai
@@ -5,18 +5,18 @@
 # Please beware that this implementation is an interim step, and we may or may not continue
 # with the FAI API.
 #
-from pathlib import Path
 import argparse
 import contextlib
-import subprocess
 import datetime
 import os
 import shutil
+import subprocess
 import socket
-import traceback
 import sys
 import tempfile
+import traceback
 from dataclasses import dataclass
+from pathlib import Path
 from threading import Event, Thread
 
 

--- a/usr/lib/grml-live/minifai
+++ b/usr/lib/grml-live/minifai
@@ -635,8 +635,6 @@ def _run_tasks(conf_dir: Path, chroot_dir: Path, classes: list[str], grml_live_c
             for class_name in classes:
                 run_class_scripts(conf_dir, chroot_dir, class_name, helper_tools_path, env)
 
-        run_chrooted(chroot_dir, ["ls", "-laR", "/dev/"])
-
     return 0
 
 

--- a/usr/lib/grml-live/minifai
+++ b/usr/lib/grml-live/minifai
@@ -9,6 +9,7 @@ from pathlib import Path
 import argparse
 import contextlib
 import subprocess
+import datetime
 import os
 import shutil
 import socket
@@ -56,6 +57,10 @@ class PackageList(dict):
         for arch, packages in other.items():
             self.setdefault(arch, [])
             self[arch] = list(set(self[arch] + packages))
+
+
+def now_for_log() -> str:
+    return datetime.datetime.now().isoformat()
 
 
 def parse_class_packages(conf_dir: Path, class_name: str) -> PackageList:
@@ -372,24 +377,30 @@ def helper_socket_thread(
         except TimeoutError:
             continue
 
-        request_socket.settimeout(5 * 60)  # 5 minutes
-        orig_req = request_socket.recv(4096).decode()
-        req = orig_req.split("\n")
-        rc = 120
-        if len(req) != 2 and req[1] != "":
-            print("W: socket thread: got message:", repr(orig_req))
-            print("W: socket thread: no newline, message truncated?")
-        else:
-            req = req[0].split(" ")
-            if req[0] == "fcopy":
-                rc = do_fcopy(conf_dir, chroot_dir, classes, req[1:])
-            elif req[0] == "skiptask":
-                rc = do_skiptask(dynamic_state, req[1:])
+        try:
+            request_socket.settimeout(5 * 60)  # 5 minutes
+            orig_req = request_socket.recv(4096).decode()
+            req = orig_req.split("\n")
+            rc = 120
+            if len(req) != 2 and req[1] != "":
+                print("W: socket thread: got message:", repr(orig_req))
+                print("W: socket thread: no newline, message truncated?")
             else:
-                print("W: socket thread: request not understood:", repr(orig_req))
+                req = req[0].split(" ")
+                if req[0] == "fcopy":
+                    rc = do_fcopy(conf_dir, chroot_dir, classes, req[1:])
+                elif req[0] == "skiptask":
+                    rc = do_skiptask(dynamic_state, req[1:])
+                else:
+                    print("W: socket thread: request not understood:", repr(orig_req))
 
-        request_socket.send(f"{rc!s}\n".encode())
-        request_socket.close()
+            request_socket.send(f"{rc!s}\n".encode())
+            request_socket.close()
+
+        except Exception:
+            print(f"E: {now_for_log()} helper_socket_thread caught fatal exception", flush=True)
+            traceback.print_exc()
+            break
 
     listen_socket.close()
 
@@ -408,9 +419,10 @@ def helper_tools(conf_dir: Path, chroot_dir: Path, classes: list[str], dynamic_s
         tempdir,
         "fcopy",
         f"""#!/bin/sh
+echo "D: minifai fcopy: $(date +%FT%T) requesting $@"
 RC=$(echo fcopy "$@" | socat - UNIX-CONNECT:{tempdir}/sock,forever)
 if [ -z "$RC" ]; then
-  echo "E: minifai fcopy: got no reply from server"
+  echo "E: minifai fcopy: $(date +%FT%T) got no reply from server"
   exit 119
 elif [ "$RC" != "0" ]; then
   echo "E: minifai fcopy: server sent error code $RC"
@@ -424,9 +436,10 @@ exit 0
         tempdir,
         "skiptask",
         f"""#!/bin/sh
+echo "D: minifai skiptask: $(date +%FT%T) requesting $@"
 RC=$(echo skiptask "$@" | socat - UNIX-CONNECT:{tempdir}/sock,forever)
 if [ -z "$RC" ]; then
-  echo "E: minifai skiptask: got no reply from server"
+  echo "E: minifai skiptask: $(date +%FT%T) got no reply from server"
   exit 119
 elif [ "$RC" != "0" ]; then
   echo "E: minifai skiptask: server sent error code $RC"
@@ -669,7 +682,7 @@ def main(program_name: str, argv: list[str]) -> int:
         # assume exception site already printed relevant info
         rc = 3
     except Exception:
-        print("E: Caught fatal exception")
+        print(f"E: {now_for_log()} minifai main caught fatal exception")
         traceback.print_exc()
         rc = 2
 

--- a/usr/lib/grml-live/minifai
+++ b/usr/lib/grml-live/minifai
@@ -372,6 +372,7 @@ def helper_socket_thread(
         except TimeoutError:
             continue
 
+        request_socket.settimeout(5 * 60)  # 5 minutes
         orig_req = request_socket.recv(4096).decode()
         req = orig_req.split("\n")
         rc = 120


### PR DESCRIPTION
In a daily build we saw this failure:


```
D: Running "/builds/grml/build-daily/grml-live/config/scripts/GRMLBASE/15-initsetup"
E: minifai fcopy: got no reply from server
Exception in thread Thread-1 (helper_socket_thread):
Traceback (most recent call last):
  File "/usr/lib/python3.11/threading.py", line 1038, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.11/threading.py", line 975, in run
    self._target(*self._args, **self._kwargs)
  File "/builds/grml/build-daily/grml-live/usr/lib/grml-live/minifai", line 390, in helper_socket_thread
    request_socket.send(f"{rc!s}\n".encode())
BrokenPipeError: [Errno 32] Broken pipe
D: fcopy recursive=True ignore_missing=True user='root' group='root' mode=420 paths=['etc/systemd']
E: Script /builds/grml/build-daily/grml-live/config/scripts/GRMLBASE/15-initsetup failed with exitcode 119 - aborting.
I: fcopy: Installing /builds/grml/build-daily/grml-live/config/files/etc/systemd/system-preset/10-grml.preset/GRMLBASE as /tmp/tmp_anfmiv4/grml_chroot/etc/systemd/system-preset/10-grml.preset.
I: fcopy: Installing /builds/grml/build-daily/grml-live/config/files/etc/systemd/logind.conf.d/grml.conf/GRMLBASE as /tmp/tmp_anfmiv4/grml_chroot/etc/systemd/logind.conf.d/grml.conf.
I: fcopy: Installing /builds/grml/build-daily/grml-live/config/files/etc/systemd/system/grml-boot.target/GRMLBASE as /tmp/tmp_anfmiv4/grml_chroot/etc/systemd/system/grml-boot.target.
I: fcopy: Installing /builds/grml/build-daily/grml-live/config/files/etc/systemd/system/getty@tty5.service.d/override.conf/GRMLBASE as /tmp/tmp_anfmiv4/grml_chroot/etc/systemd/system/getty@tty5.service.d/override.conf.
I: fcopy: Installing /builds/grml/build-daily/grml-live/config/files/etc/systemd/system/getty@tty10.service.d/override.conf/GRMLBASE as /tmp/tmp_anfmiv4/grml_chroot/etc/systemd/system/getty@tty10.service.d/override.conf.
I: fcopy: Installing /builds/grml/build-daily/grml-live/config/files/etc/systemd/system/getty@tty11.service.d/override.conf/GRMLBASE as /tmp/tmp_anfmiv4/grml_chroot/etc/systemd/system/getty@tty11.service.d/override.conf.
I: fcopy: Installing /builds/grml/build-daily/grml-live/config/files/etc/systemd/system/getty@tty4.service.d/override.conf/GRMLBASE as /tmp/tmp_anfmiv4/grml_chroot/etc/systemd/system/getty@tty4.service.d/override.conf.
I: fcopy: Installing /builds/grml/build-daily/grml-live/config/files/etc/systemd/system/getty@tty7.service.d/override.conf/GRMLBASE as /tmp/tmp_anfmiv4/grml_chroot/etc/systemd/system/getty@tty7.service.d/override.conf.
I: fcopy: Installing /builds/grml/build-daily/grml-live/config/files/etc/systemd/system/getty@tty1.service.d/override.conf/GRMLBASE as /tmp/tmp_anfmiv4/grml_chroot/etc/systemd/system/getty@tty1.service.d/override.conf.
I: fcopy: Installing /builds/grml/build-daily/grml-live/config/files/etc/systemd/system/getty@tty2.service.d/override.conf/GRMLBASE as /tmp/tmp_anfmiv4/grml_chroot/etc/systemd/system/getty@tty2.service.d/override.conf.
I: fcopy: Installing /builds/grml/build-daily/grml-live/config/files/etc/systemd/system/getty@tty12.service.d/override.conf/GRMLBASE as /tmp/tmp_anfmiv4/grml_chroot/etc/systemd/system/getty@tty12.service.d/override.conf.
I: fcopy: Installing /builds/grml/build-daily/grml-live/config/files/etc/systemd/system/getty@tty3.service.d/override.conf/GRMLBASE as /tmp/tmp_anfmiv4/grml_chroot/etc/systemd/system/getty@tty3.service.d/override.conf.
I: fcopy: Installing /builds/grml/build-daily/grml-live/config/files/etc/systemd/system/ssh.service.d/keygen.conf/GRMLBASE as /tmp/tmp_anfmiv4/grml_chroot/etc/systemd/system/ssh.service.d/keygen.conf.
I: fcopy: Installing /builds/grml/build-daily/grml-live/config/files/etc/systemd/system/getty@tty6.service.d/override.conf/GRMLBASE as /tmp/tmp_anfmiv4/grml_chroot/etc/systemd/system/getty@tty6.service.d/override.conf.
I: fcopy: Installing /builds/grml/build-daily/grml-live/config/files/etc/systemd/system/serial-getty@.service.d/override.conf/GRMLBASE as /tmp/tmp_anfmiv4/grml_chroot/etc/systemd/system/serial-getty@.service.d/override.conf.
I: minifai exiting with exit code 3
```

Lets see if additional logs will help us find this issue.
