### PR TITLE
isolinux: Drop bootoption "gmt"

### DIFF
--- a/templates/GRML/grml-cheatcodes.txt
+++ b/templates/GRML/grml-cheatcodes.txt
@@ -39,7 +39,7 @@ Regional settings:
 ------------------
 grml lang=at|de|cn|da|es|fr|it        Specify language ($LANG, $LC_ALL, $LANGUAGE - utf8) + keyboard
 grml lang=nl|pl|ru|sk|tr|tw|us        Specify language ($LANG, $LC_ALL, $LANGUAGE - utf8) + keyboard
-grml localtime                        Hardware Clock is set to local time (default: RTC is in UTC)
+grml localtime                        Assume Hardware Clock (RTC) is set in localtime (default: RTC is in UTC)
 grml tz=Europe/Vienna                 Use specified timezone for TZ, defaults to TZ=UTC
 grml keyboard=us                      Use different keyboard layout
 

--- a/templates/boot/isolinux/f4
+++ b/templates/boot/isolinux/f4
@@ -9,7 +9,8 @@
  grml blacklist=usbcore                                   disable USB drivers  
  grml debnet        search local partitions for file /etc/network/interfaces,  
                 copy /etc/network then to local system and restart networking  
- grml gmt tz=Europe/Vienna   use GMT-based time and specified timezone for TZ  
+ grml localtime                   assume Hardware Clock (RTC) is in localtime  
+ grml tz=Europe/Vienna                         set timezone (default: tz=UTC)  
  grml home=/dev/sda1                   use specified device as home directory  
  grml keyboard=de                                                set keyboard  
  grml lang=[at|ch|da|de|es|fr|it|...|us]              set keyboard + language  
@@ -18,6 +19,5 @@
  grml nodhcp                     disable searching for network setup via DHCP  
  grml noeject noprompt      do not eject CD after halt / do not prompt for it  
  grml nofstab / nolabel   disable generating of /etc/fstab / use of fs-labels  
-                                                                               
                                                                                
 1f


### PR DESCRIPTION
We replaced "gmt" with "utc" some time ago, see: 65ee43c.

In the meanwhile we changed the timezone and localtime handling and dropped support for the bootoption "utc", as it is the default nowadays, see: grml/grml-autoconfig@e96da70 + grml/grml-live@34167e2f.

TZ defaults to UTC and the RTC defaults to be set to UTC.

Related: grml/grml-live#296