### PR TITLE
Provide migration script migrate-to-minifai

### DIFF
--- a/scripts/migrate-to-minifai
+++ b/scripts/migrate-to-minifai
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Purpose: migrate config/files from FAI layout to new minifai layout,
+# see https://github.com/grml/grml-live/issues/267
+
+set -euo pipefail
+
+if [ -d ".git" ] ; then
+  echo "Git repository detected, operating with git"
+  git_cmd='git'
+else
+  echo "Not running within git repository, only echo-ing file actions"
+  git_cmd='echo'
+fi
+
+## fcopy files
+# e.g. config/files/etc/hosts/GRMLBASE becomes config/files/GRMLBASE/etc/hosts
+find config/files/ -type f -print0 | while IFS= read -r -d '' file; do
+  orig_filename="${file}"
+  new_filename="$(dirname "${orig_filename#config/files/}")"
+  class_name="$(basename "${orig_filename%/}")"
+  mkdir -p "$(dirname config/files/"${class_name}/${new_filename}")"
+  "$git_cmd" mv "${file}" "config/files/${class_name}/${new_filename}"
+done
+
+## hooks
+# e.g. config/hooks/instsoft.GRMLBASE becomes config/hooks/GRMLBASE/instsoft
+find config/hooks/ -type f -print0 | while IFS= read -r -d '' file; do
+  case "$file" in
+    "config/hooks/savelog.LAST.source")
+      echo "WARN: skipping unsupported file config/hooks/savelog.LAST.source detected, remove or convert manually"
+      continue
+      ;;
+  esac
+  orig_filename="${file}"
+  new_filename="${file##*/}"         # extract "instsoft.GRMLBASE"
+  new_filename="${new_filename%.*}"  # remove class name as last part (".GRMLBASE")
+  class_name="$(basename "${orig_filename##*.}")"
+  mkdir -p "$(dirname config/hooks/"${class_name}/${new_filename}")"
+  "$git_cmd" mv "${file}" "config/hooks/${class_name}/${new_filename}"
+done
+
+## env
+# e.g. config/class/GRMLBASE.var becomes config/env/GRMLBASE
+find config/class/ -type f -print0 | while IFS= read -r -d '' file; do
+  orig_filename="${file}"
+  class_name="$(basename "${orig_filename%/}" .var)"
+  mkdir -p config/env/
+  "$git_cmd" mv "${file}" "config/env/${class_name}"
+done


### PR DESCRIPTION
Executing it converts our existing config/* from FAI layout (e.g. config/files/$FILENAME/$CLASS) into the new minifai layout (e.g. config/files/$CLASS/$FILENAME).

See https://github.com/grml/grml-live/issues/267