### PR TITLE
SW: add gnupg to GRML_FULL

### DIFF
--- a/config/package_config/GRML_FULL
+++ b/config/package_config/GRML_FULL
@@ -222,6 +222,7 @@ apg
 pwgen
 
 # privacy tools
+gnupg
 scdaemon
 
 # popular VCS to pull config from


### PR DESCRIPTION
Now that we dropped gnupg as dependencty from the grml-keyring package, we need to make sure to have it available at least on GRML_FULL.

We might consider migrating to sq instead in the future, feedback welcome.