### PR TITLE
Document kernel option dis_ucode_ldr

### DIFF
--- a/templates/GRML/grml-cheatcodes.txt
+++ b/templates/GRML/grml-cheatcodes.txt
@@ -230,6 +230,7 @@ grml libata.force=[ID:]VAL            Force configurations for libata.
                                       to force pio4 mode on device "ata1:00:"
 grml libata.dma=0                     Disable DMA on PATA and SATA devices
 grml libata.ignore_hpa=1              Disable host protected area (which should enable the whole disk)
+grml dis_ucode_ldr                    Disable loading of CPU microcode
 grml vga=normal                       No-framebuffer mode (does not influence X)
 grml vga=ask                          Display menu for framebuffer mode
 grml radeon.modeset=0  nomodeset      Disable Kernel Mode Setting (KMS) for Radeon driver.


### PR DESCRIPTION
Booting a live system probably shouldn't trigger any microcode updates. The dis_ucode_ldr kernel parameter disables the microcode loader, see https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html and
https://wiki.debian.org/Microcode#Working_around_boot_problems_caused_by_microcode_updates