### PR TITLE
etc/cruft/filters/grml-live: filter /etc/grml/*.local

### DIFF
--- a/debian/grml-live.install
+++ b/debian/grml-live.install
@@ -1,6 +1,7 @@
 config                      usr/share/grml-live/
 docs/grml-live-remaster.8   usr/share/man/man8/
 docs/grml-live.8            usr/share/man/man8/
+etc/cruft/filters/grml-live etc/cruft/filters
 etc/grml                    etc
 examples                    usr/share/doc/grml-live/
 grml-live                   usr/sbin/

--- a/etc/cruft/filters/grml-live
+++ b/etc/cruft/filters/grml-live
@@ -1,0 +1,1 @@
+/etc/grml/*.local


### PR DESCRIPTION
this could only be /etc/grml/grml-live.local but i don't think that i'm the only person who keeps more configurations in there.
```
cb@obelix ~crpb/grml-live (git)-[cruft] % ls -1 /etc/grml/*local
/etc/grml/grml-bookworm-full.local
/etc/grml/grml-bookworm-small.local
/etc/grml/grml-sid-full.local
/etc/grml/grml-sid-small.local
/etc/grml/grml-trixie-full.local
/etc/grml/grml-trixie-small.local
/etc/grml/test-bookworm-small.local
/etc/grml/test-sid-small.local
/etc/grml/test-templ.local
/etc/grml/test-trixie-small.local
```