### PR TITLE
SW: add iwd to GRMLBASE

### DIFF
--- a/config/package_config/GRMLBASE
+++ b/config/package_config/GRMLBASE
@@ -31,6 +31,7 @@ hwinfo
 ifupdown
 initramfs-tools
 iputils-ping
+iwd
 kbd
 less
 live-boot-grml live-boot-grml-doc
@@ -72,6 +73,7 @@ firmware-qlogic
 firmware-realtek
 firmware-ti-connectivity
 firmware-zd1211
+wireless-regdb
 
 libpam-systemd
 systemd-container


### PR DESCRIPTION
iwd seems to be required for support of wpa-enterprise networks. Given that we consider network connectivity as essential and already ship the wpasupplicant package in GRMLBASE, and iwd only adds 2,717 kB of additional disk space (including its dependency libell0), let's also include it into our base software selection.

Closes: grml/grml#226