### PR TITLE
ssh.service: adapt for trixie

### DIFF
--- a/config/files/GRMLBASE/etc/systemd/system/ssh.service.d/keygen.conf
+++ b/config/files/GRMLBASE/etc/systemd/system/ssh.service.d/keygen.conf
@@ -1,4 +1,6 @@
 # This file was deployed via grml-live.
 
 [Service]
+ExecStartPre=
 ExecStartPre=-/usr/bin/ssh-keygen -A
+ExecStartPre=/usr/sbin/sshd -t


### PR DESCRIPTION
Apparently trixie's ssh.service got an ExecStartPre= line. Our override would apply *after* it, but that is too late.

Closes https://github.com/grml/grml/issues/228