### PR TITLE
SW: re-add lrzsz to GRML_FULL

### DIFF
--- a/config/package_config/GRML_FULL
+++ b/config/package_config/GRML_FULL
@@ -169,6 +169,7 @@ ipxe
 iw
 libnss-mdns
 libteam-utils
+lrzsz
 mosh
 mtr-tiny
 ndisc6


### PR DESCRIPTION
This partially reverts commit 0c8f310f591e52127aee634e02181d47fa624cc8. Do not re-add it to GRML_SMALL, as we do not have minicom on small either.