### PR TITLE
Divert update-initramfs for performance 

### DIFF
--- a/config/hooks/GRMLBASE/instsoft
+++ b/config/hooks/GRMLBASE/instsoft
@@ -28,14 +28,14 @@ echo "hooks/instsoft.GRMLBASE running for action ${FAI_ACTION}"
 
 # work around /etc/kernel/postinst.d/zz-update-grub failing
 # inside openvz environment, see #597084
-if ! $ROOTCMD dpkg-divert --list | grep -q '/usr/sbin/update-grub' ; then
+if [ '/usr/sbin/update-grub' = "$($ROOTCMD dpkg-divert --truename '/usr/sbin/update-grub')" ]; then
   echo "Diverting update-grub executable"
   $ROOTCMD dpkg-divert --rename --add /usr/sbin/update-grub
   $ROOTCMD ln -s /bin/true /usr/sbin/update-grub
 fi
 
 # work around a bug which causes openvz to freeze when grub-probe is invoked
-if ! $ROOTCMD dpkg-divert --list | grep -q '/usr/sbin/grub-probe' ; then
+if [ '/usr/sbin/grub-probe' = "$($ROOTCMD dpkg-divert --truename '/usr/sbin/grub-probe')" ]; then
   echo "Diverting grub-probe executable"
   $ROOTCMD dpkg-divert --rename --add /usr/sbin/grub-probe
   $ROOTCMD ln -s /bin/true /usr/sbin/grub-probe

--- a/config/hooks/GRMLBASE/instsoft
+++ b/config/hooks/GRMLBASE/instsoft
@@ -41,6 +41,13 @@ if [ '/usr/sbin/grub-probe' = "$($ROOTCMD dpkg-divert --truename '/usr/sbin/grub
   $ROOTCMD ln -s /bin/true /usr/sbin/grub-probe
 fi
 
+# Divert update-initramfs for performance.
+if [ '/usr/sbin/update-initramfs' = "$($ROOTCMD dpkg-divert --truename '/usr/sbin/update-initramfs')" ]; then
+  echo "Diverting update-initramfs executable"
+  $ROOTCMD dpkg-divert --rename --add /usr/sbin/update-initramfs
+  $ROOTCMD ln -s /bin/true /usr/sbin/update-initramfs
+fi
+
 # Do not fail running softupdate for reported bugs.
 [ -d "${target}"/etc/apt/apt.conf.d ] || mkdir "${target}"/etc/apt/apt.conf.d
 if [ -e "${target}"/etc/apt/apt.conf.d/10apt-listbugs ]; then

--- a/config/scripts/GRMLBASE/80-initramfs
+++ b/config/scripts/GRMLBASE/80-initramfs
@@ -21,6 +21,13 @@ fi
 
 echo "Rebuilding initramfs"
 
+# Undo divert done in instsoft.
+if [ '/usr/sbin/update-initramfs' != "$($ROOTCMD dpkg-divert --truename '/usr/sbin/update-initramfs')" ]; then
+  echo "Undoing dpkg-divert of update-initramfs executable"
+  $ROOTCMD rm -f /usr/sbin/update-initramfs
+  $ROOTCMD dpkg-divert --rename --remove /usr/sbin/update-initramfs
+fi
+
 for initrd in $(basename "$target"/boot/vmlinuz-*) ; do
     if ! $ROOTCMD update-initramfs -k "${initrd##vmlinuz-}" -c ; then
         echo "Creating fresh initramfs did not work, trying update instead:"

--- a/config/scripts/GRMLBASE/98-clean-chroot
+++ b/config/scripts/GRMLBASE/98-clean-chroot
@@ -32,7 +32,7 @@ fi
 # revert dpkg-divert of hooks/instsoft.GRMLBASE, which is
 # used to work around /etc/kernel/postinst.d/zz-update-grub failing
 # inside openvz environment, see #597084
-if $ROOTCMD dpkg-divert --list | grep -q '/usr/sbin/update-grub' ; then
+if [ '/usr/sbin/update-grub' != "$($ROOTCMD dpkg-divert --truename '/usr/sbin/update-grub')" ]; then
   echo "Undoing dpkg-divert of update-grub executable"
   $ROOTCMD rm -f /usr/sbin/update-grub
   $ROOTCMD dpkg-divert --rename --remove /usr/sbin/update-grub
@@ -40,7 +40,7 @@ fi
 
 # revert dpkg-divert of hooks/instsoft.GRMLBASE, which is
 # used to work around a grub-probe<->openvz bug
-if $ROOTCMD dpkg-divert --list | grep -q '/usr/sbin/grub-probe' ; then
+if [ '/usr/sbin/grub-probe' != "$($ROOTCMD dpkg-divert --truename '/usr/sbin/grub-probe')" ]; then
   echo "Undoing dpkg-divert of grub-probe executable"
   $ROOTCMD rm -f /usr/sbin/grub-probe
   $ROOTCMD dpkg-divert --rename --remove /usr/sbin/grub-probe


### PR DESCRIPTION
A normal build would run update-initramfs three times. This cuts it down to one run.
