### PR TITLE
SW: drop crosshurd from GRML_FULL

### DIFF
--- a/config/package_config/GRML_FULL
+++ b/config/package_config/GRML_FULL
@@ -121,7 +121,6 @@ sqlite3
 whois
 
 # install linux
-crosshurd
 debootstrap
 kexec-tools
 mmdebstrap


### PR DESCRIPTION
This package pulls in debian-ports-archive-keyring, though we aren't aware of any good reasons why we should ship those packages by default.