### PR TITLE
Announce SSH service with Avahi

### DIFF
--- a/config/files/GRMLBASE/etc/systemd/system-preset/10-grml.preset
+++ b/config/files/GRMLBASE/etc/systemd/system-preset/10-grml.preset
@@ -8,5 +8,7 @@ enable gpm.service
 enable grml-autoconfig.service
 enable debug-shell.service
 enable resolvconf.service
+enable avahi-daemon.service
+enable avahi-ssh.service
 
 disable *

--- a/config/files/GRMLBASE/etc/systemd/system/avahi-ssh.service
+++ b/config/files/GRMLBASE/etc/systemd/system/avahi-ssh.service
@@ -1,0 +1,15 @@
+# This file was deployed via grml-live.
+
+[Unit]
+Description=Deploy SSH service config for Avahi
+ConditionPathExists=/usr/share/doc/avahi-daemon/examples/ssh.service
+ConditionPathExists=/etc/avahi/services
+PartOf=ssh.service
+After=ssh.service
+
+[Service]
+Type=oneshot
+ExecStart=cp /usr/share/doc/avahi-daemon/examples/ssh.service /etc/avahi/services/
+
+[Install]
+WantedBy=ssh.service

--- a/config/files/GRML_FULL/etc/systemd/system/avahi-daemon.service.d/override.conf
+++ b/config/files/GRML_FULL/etc/systemd/system/avahi-daemon.service.d/override.conf
@@ -1,0 +1,4 @@
+# This file was deployed via grml-live.
+
+[Install]
+WantedBy=grml-boot.target


### PR DESCRIPTION
We want to announce the SSH service with Avahi.

The avahi-daemon is shipped in GRML_FULL but needs be enabled and a Avahi ssh service configuration file needs to be deployed.

The avahi-ssh.service deploys the SSH service config for Avahi when the SSH service is started. The service avahi-ssh.service needs to be enabled too.

To discover the SSH service in the local network the following command can be used:

```
  avahi-browse -d local _ssh._tcp --resolve -t
```

Issue: grml/grml-live#73