### PR TITLE
minifai: fallback to debian-archive-keyring

### DIFF
--- a/usr/lib/grml-live/minifai
+++ b/usr/lib/grml-live/minifai
@@ -608,6 +608,8 @@ def install_base(conf_dir: Path, chroot_dir: Path, classes, debian_suite: str, m
     for class_name in classes:
         if (keyring_dir / class_name).exists():
             keyring_file = keyring_dir / class_name
+        else:
+            keyring_file = '/usr/share/keyrings/debian-archive-keyring.pgp'
 
     args = [
         "mmdebstrap",


### PR DESCRIPTION
 * if GRML_FAI_CONFIG isn't in the same tree-depth as the original the relative links in buildstrap-keyring (blame debhelper!) will not be resolveable which makes mmdebstrap fail with keyring=None.