### PR TITLE
Redefine minifai actions

### DIFF
--- a/config/hooks/GRMLBASE/instsoft
+++ b/config/hooks/GRMLBASE/instsoft
@@ -15,15 +15,6 @@ set -e
 # FAI sets ${target}, but shellcheck does not know that.
 target=${target:?}
 
-# if hooks/updatebase.GRMLBASE fails for whatever reason
-# and can't skip instsoft.GRMLBASE we have to make sure
-# we exit here as well
-if [ -n "$BUILD_ONLY" ] ; then
-   echo "Exiting hooks/instsoft.GRMLBASE as BUILD_ONLY environment is set."
-   echo "W: This place was reached because updatebase.GRMLBASE failed."
-   exit 0
-fi
-
 echo "hooks/instsoft.GRMLBASE running for action ${FAI_ACTION}"
 
 # work around /etc/kernel/postinst.d/zz-update-grub failing
@@ -60,21 +51,7 @@ if [ "$FAI_ACTION" = "softupdate" ] ; then
    rm -f "${target}"/etc/resolv.conf
    cat /etc/resolv.conf >> "${target}"/etc/resolv.conf
 
-   # Update package lists (so they exist at all), so we can install
-   # software; if /var/lib/dpkg/available is empty, it was probably
-   # cleaned by GRMLBASE/98-clean-chroot, so we need to rebuild it
-   # anyway
-   $ROOTCMD /usr/lib/dpkg/methods/apt/update /var/lib/dpkg/ apt apt
-
    if ! $ROOTCMD test -x /usr/bin/aptitude ; then
-     # the apt-get update might return an error if there's for example
-     # a hashsum mismatch on Debian mirror sources, we might want to continue
-     # but should warn the user
-     if ! $ROOTCMD apt-get update ; then
-       echo "Warning: there was an error executing apt-get update, continuing anyway."
-       echo "Warning: there was an error executing apt-get update, continuing anyway." >&2
-     fi
-
      $ROOTCMD apt-get -y install aptitude
    fi
 

--- a/config/hooks/GRMLBASE/updatebase
+++ b/config/hooks/GRMLBASE/updatebase
@@ -26,24 +26,6 @@ Acquire::http { Proxy "$APT_PROXY"; };
 EOF
 fi
 
-if [ "$FAI_ACTION" = "softupdate" ] ; then
-   echo "Action $FAI_ACTION of FAI (hooks/updatebase.GRMLBASE) via grml-live running"
-
-   # otherwise we're running 'aptitude update' even on with -b option
-   skiptask updatebase
-
-   # skip the task if we want to build a new ISO only,
-   # this means we do NOT update any packages
-   if [ -n "$BUILD_ONLY" ] ; then
-      skiptask instsoft
-   fi
-fi
-
-if [ -n "$BOOTSTRAP_ONLY" ] ; then
-  echo "Skipping task configure in hooks/updatebase.GRMLBASE as BOOTSTRAP_ONLY environment is set."
-  skiptask configure
-fi
-
 # install all apt related files
 fcopy -M -i -B -v -r /etc/apt
 fcopy -M -i -B -v -r /usr/share/keyrings

--- a/grml-live
+++ b/grml-live
@@ -688,7 +688,11 @@ if [ -n "$BUILD_DIRTY" ]; then
 else
    [ -n "$CHROOT_OUTPUT" ] || CHROOT_OUTPUT="$OUTPUT/grml_chroot"
 
-   if [ -n "$UPDATE" ] || [ -n "$BUILD_ONLY" ] ; then
+   if [ -n "$BOOTSTRAP_ONLY" ] ; then
+      FAI_ACTION=bootstrap
+   elif [ -n "$BUILD_ONLY" ] ; then
+      FAI_ACTION=reconfigure
+   elif [ -n "$UPDATE" ] ; then
       FAI_ACTION=softupdate
    else
       FAI_ACTION=dirinstall

--- a/usr/lib/grml-live/minifai
+++ b/usr/lib/grml-live/minifai
@@ -383,6 +383,8 @@ def do_fcopy(conf_dir: Path, chroot_dir: Path, classes: list[str], fcopy_args: l
 
 
 def do_skiptask(dynamic_state: DynamicState, skiptask_args: list[str]) -> int:
+    if not skiptask_args:
+        return 0
     print(f"I: Requesting skipping of tasks: {' '.join(skiptask_args)}")
     dynamic_state.skip_tasks.update(skiptask_args)
     return 0
@@ -639,9 +641,11 @@ def task_updatebase(chroot_dir: Path, dynamic_state: DynamicState):
     run_chrooted(chroot_dir, ["apt-get", "update", "-q"])
 
 
-def _run_tasks(conf_dir: Path, chroot_dir: Path, classes: list[str], grml_live_config: Path, fai_action: str) -> int:
+def _run_tasks(conf_dir: Path, chroot_dir: Path, classes: list[str], grml_live_config: Path, fai_action: str, skip_tasks: list[str]) -> int:
     dynamic_state = DynamicState()
     logdir = create_logdir(chroot_dir)
+
+    do_skiptask(dynamic_state, skip_tasks)
 
     env = {
         "GRML_LIVE_CONFIG": str(grml_live_config),
@@ -672,7 +676,7 @@ def create_argparser() -> argparse.ArgumentParser:
     # path to fai classes, scripts, ...
     parser.add_argument("config", type=Path)
     parser.add_argument("classes")
-    parser.add_argument("action", choices=["dirinstall", "softupdate"])
+    parser.add_argument("action", choices=["dirinstall", "softupdate", "reconfigure"])
     parser.add_argument("chroot_dir", type=Path)
     parser.add_argument("grml_live_config", type=Path)
     parser.add_argument("debian_suite", type=str)
@@ -697,11 +701,16 @@ def main(program_name: str, argv: list[str]) -> int:
         raise ValueError(f"Chroot directory {chroot_dir} does not exist")
 
     try:
-        if args.action == "dirinstall":
+        if args.action == "bootstrap":
             install_base(conf_dir, chroot_dir, classes, args.debian_suite, args.mirror_url)
-            rc = _run_tasks(conf_dir, chroot_dir, classes, args.grml_live_config, args.action)
+            rc = _run_tasks(conf_dir, chroot_dir, classes, args.grml_live_config, args.action, ["configure"])
+        elif args.action == "dirinstall":
+            install_base(conf_dir, chroot_dir, classes, args.debian_suite, args.mirror_url)
+            rc = _run_tasks(conf_dir, chroot_dir, classes, args.grml_live_config, args.action, [])
         elif args.action == "softupdate":
-            rc = _run_tasks(conf_dir, chroot_dir, classes, args.grml_live_config, args.action)
+            rc = _run_tasks(conf_dir, chroot_dir, classes, args.grml_live_config, args.action, [])
+        elif args.action == "reconfigure":
+            rc = _run_tasks(conf_dir, chroot_dir, classes, args.grml_live_config, args.action, ["updatebase", "instsoft"])
         else:
             print(f"E: minifai: Unknown fai action: {args.action!r}")
             rc = 1


### PR DESCRIPTION
Instead of the traditional dirinstall and softupdate FAI_ACTIONs, minifai now provides four:

* bootstrap: create chroot and install packages ("updatebase", "instsoft")
* dirinstall: everything: create chroot, install packages and run configure scripts
* softupdate: everything except creating the chroot
* reconfigure: only run configure scripts

Instead of distributing the logic of what to run when in grml-live, FAI and instsoft/updatebase hooks, grml-live now makes a decision and calls minifai with the correct action.

Notably, except for "reconfigure", the "updatebase" task now gets to always run, ensuring APT package lists are available. minifai's updatebase was already minimal and only runs `apt-get update`, which is what grml-live needs.