### PR TITLE
minifai: always install ca-certificates to allow https:// sources

### DIFF
--- a/config/package_config/GRML_FULL
+++ b/config/package_config/GRML_FULL
@@ -200,7 +200,6 @@ wireguard
 wireless-regdb
 
 # network transfers
-ca-certificates
 fuse3
 lftp
 nfs-kernel-server

--- a/config/scripts/GRMLBASE/98-clean-chroot
+++ b/config/scripts/GRMLBASE/98-clean-chroot
@@ -126,12 +126,8 @@ zero "$target"/var/account/pacct \
      "$target"/var/log       \
      "$target"/var/mail/grml
 
-if ! [ -x "$target"/usr/sbin/update-ca-certificates ] ; then
-  echo "Warning: update-ca-certificates not installed"
-else
-  echo "Updating ca-certificates"
-  $ROOTCMD update-ca-certificates
-fi
+echo "Updating ca-certificates"
+$ROOTCMD update-ca-certificates
 
 # regenerate ls.so.cache
 if ! [ -x "$target"/sbin/ldconfig ] ; then

--- a/usr/lib/grml-live/minifai
+++ b/usr/lib/grml-live/minifai
@@ -598,9 +598,9 @@ def install_base(conf_dir: Path, chroot_dir: Path, classes, debian_suite: str, m
     # Work around APT bug: http://bugs.debian.org/1092164
     included_packages = ["netbase"]
 
-    # Allow using https:// mirror, if given.
-    if mirror_url.startswith("https"):
-        included_packages.append("ca-certificates")
+    # Allow using https:// sources. Do this unconditionally, so sources added with
+    # fcopy /etc/apt just work.
+    included_packages.append("ca-certificates")
 
     # Find keyring to use for mmdebstrap
     keyring_dir = conf_dir / "bootstrap-keyring"


### PR DESCRIPTION
Closes: grml/grml-live#333