### PR TITLE
autoconfig: remove brltty start, done by initramfs

### DIFF
--- a/config/files/GRMLBASE/etc/grml/autoconfig
+++ b/config/files/GRMLBASE/etc/grml/autoconfig
@@ -41,7 +41,6 @@ CONFIG_GPM='yes'
 CONFIG_AUTOMOUNT='yes'        # automounting of device labeled GRMLCFG
 CONFIG_BLANKING='yes'         # check for bootoption noblank to disable console blanking
 CONFIG_CONFIG='yes'           # do we want config unpacking to work?
-CONFIG_BRLTTY='yes'           # automatically start brltty if a brltty option is specified in /proc/cmdline
 CONFIG_DEBOOTSTRAP='yes'      # support automatic installation of Debian via grml-deboostrap
 CONFIG_DEBNET='yes'           # search for /etc/network/interfaces on partitions and set up network afterwards
 CONFIG_DEBS='yes'             # check for bootoption debs for installing .debs

--- a/config/files/GRMLBASE/usr/share/grml-autoconfig/autoconfig.functions
+++ b/config/files/GRMLBASE/usr/share/grml-autoconfig/autoconfig.functions
@@ -421,15 +421,6 @@ fi
 }
 # }}}
 
-# {{{ Start brltty
-config_brltty() {
-  if checkbootparam 'brltty' ; then
-    einfo "Starting brltty service as requested on boot commandline."
-    service_wrapper brltty start ; eend $?
-  fi
-}
-# }}}
-
 # {{{ Start creating /etc/fstab with HD partitions and USB SCSI devices now
 config_fstab(){
 

--- a/config/files/GRMLBASE/usr/share/grml-autoconfig/grml-autoconfig
+++ b/config/files/GRMLBASE/usr/share/grml-autoconfig/grml-autoconfig
@@ -47,8 +47,6 @@ checkvalue $CONFIG_LVM && config_lvm
 
 checkvalue $CONFIG_TESTCD && config_testcd
 
-checkvalue $CONFIG_BRLTTY && config_brltty
-
 checkvalue $CONFIG_FSTAB && config_fstab
 
 checkvalue $CONFIG_CPU && config_cpu

--- a/templates/GRML/grml-cheatcodes.txt
+++ b/templates/GRML/grml-cheatcodes.txt
@@ -199,7 +199,7 @@ grml getfile.retries=$NUM             Retry the download of the files specified 
 Accessibility related settings:
 -------------------------------
 grml brltty=type,port,table           Parameters for Braille device (e.g.: brltty=al,/dev/ttyS0,text.de.tbl)
-                                      See http://mielke.cc/brltty/guidelines.html for documentation.
+                                      See https://brltty.app/guidelines.html for documentation.
 
 Hardware related settings:
 --------------------------


### PR DESCRIPTION
The Debian brltty package installs an initramfs hook, which automatically
starts brltty, as long as a brltty.conf is available. Thus on GRML_FULL,
brltty is always started. It's also a lot earlier than grml-autoconfig
could do it.

Remove the grml-autoconfig code for brltty, as it does not add any value.

Supersedes #357.
