### PR TITLE
Add Debug::Acquire::http=true to apt if GRML_LIVE_DEBUG_APT is set

### DIFF
--- a/config/scripts/GRMLBASE/03-get-sources
+++ b/config/scripts/GRMLBASE/03-get-sources
@@ -29,10 +29,15 @@ mkdir -p "${target}${SOURCES_PATH}"
 
 $ROOTCMD apt-get update
 
+apt_debug_option=""
+if [ -n "${GRML_LIVE_DEBUG_APT:-}" ]; then
+    apt_debug_option="-oDebug::Acquire::http=true"
+fi
+
 # Collect *source* package names
 # shellcheck disable=SC2016 # Embedded $ is correct.
 $ROOTCMD dpkg-query -W -f='${Source} ${Package}\n' | sed -e 's/^ //' | awk '{ print $1 }' | sort -u | \
-  chroot "${target}" /bin/bash -c "cd \"${SOURCES_PATH}\" && xargs --max-args=32 --max-procs=12 apt-get --download-only source" 2> "${ERRORS_LOG}"
+  chroot "${target}" /bin/bash -c "cd \"${SOURCES_PATH}\" && xargs --max-args=32 --max-procs=12 apt-get $apt_debug_option --download-only source" 2> "${ERRORS_LOG}"
 
 if grep -q '^E:' "${ERRORS_LOG}" ; then
   echo "Errors noticed while retrieving sources:" >&2

--- a/usr/lib/grml-live/minifai
+++ b/usr/lib/grml-live/minifai
@@ -151,9 +151,13 @@ def chrooted_apt_install(chroot_dir: Path, install_list: list[str]):
     env = {
         "DEBIAN_FRONTEND": "noninteractive",
     }
+    command = ["apt", "install", "-q", "-y", "--no-install-recommends"]
+    if os.environ.get("GRML_LIVE_DEBUG_APT", "") != "":
+        command.insert(1, "-oDebug::Acquire::http=true")
+    command += install_list
     run_chrooted(
         chroot_dir,
-        ["apt", "install", "-q", "-y", "--no-install-recommends"] + install_list,
+        command,
         env=env,
         stdin=subprocess.DEVNULL,
     )


### PR DESCRIPTION
For testing deb.debian.org issues.

https://gitlab.grml.org/grml/build-daily/-/commit/eb5fdd1a183f8ef404c49f8d7b2fe11ba0c89767 is too fiddly.

/cc @pkern
