### PR TITLE
Enable predictable network device names

### DIFF
--- a/scripts/generate_netboot_package.sh
+++ b/scripts/generate_netboot_package.sh
@@ -43,7 +43,7 @@ cat > "${WORKING_DIR}/pxelinux.cfg/default" << EOF
 default grml
 label grml
   kernel vmlinuz
-  append initrd=initrd.img root=/dev/nfs rw nfsroot=192.168.0.1:/live/image boot=live apm=power-off quiet nomce noprompt noeject vga=791 net.ifnames=0 
+  append initrd=initrd.img root=/dev/nfs rw nfsroot=192.168.0.1:/live/image boot=live apm=power-off quiet nomce noprompt noeject vga=791 
 EOF
 
 if tar -C "$OUTPUTDIR" -acf "${OUTPUT_FILE}" "grml_netboot_package_${GRML_VERSION}" ; then

--- a/templates/boot/grub/%SHORT_NAME%_default.cfg
+++ b/templates/boot/grub/%SHORT_NAME%_default.cfg
@@ -1,7 +1,7 @@
 menuentry "%GRML_NAME% %VERSION%" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux   /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% "${loopback}" ${kernelopts} nomce net.ifnames=0 
+    linux   /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% "${loopback}" ${kernelopts} nomce 
     echo 'Loading initrd...'
     initrd  /boot/%SHORT_NAME%/initrd.img
 }

--- a/templates/boot/grub/%SHORT_NAME%_options.cfg
+++ b/templates/boot/grub/%SHORT_NAME%_options.cfg
@@ -1,16 +1,8 @@
 submenu "  ⇢ Options" --class=submenu {
-menuentry "Enable Predictable Network Interface Names" {
-    set gfxpayload=keep
-    echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} 
-    echo 'Loading initrd...'
-    initrd /boot/%SHORT_NAME%/initrd.img
-}
-
 menuentry "Enable SSH (with random password)" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} ssh 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} ssh 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -18,7 +10,7 @@ menuentry "Enable SSH (with random password)" {
 menuentry "Load Grml to RAM" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} toram=%GRML_NAME%.squashfs 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} toram=%GRML_NAME%.squashfs 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -26,7 +18,7 @@ menuentry "Load Grml to RAM" {
 menuentry "Load whole medium to RAM" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} toram 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} toram 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -34,7 +26,7 @@ menuentry "Load whole medium to RAM" {
 menuentry "Forensic Mode" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} read-only nofstab noraid nolvm noautoconfig noswap raid=noautodetect 
+    linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} read-only nofstab noraid nolvm noautoconfig noswap raid=noautodetect 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -42,7 +34,7 @@ menuentry "Forensic Mode" {
 menuentry "Persistency Mode" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} persistence 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} persistence 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -50,7 +42,7 @@ menuentry "Persistency Mode" {
 menuentry "Load German Keyboard Layout" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} lang=de 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} lang=de 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -58,7 +50,7 @@ menuentry "Load German Keyboard Layout" {
 menuentry "Graphical Mode" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} startx 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} startx 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -66,7 +58,7 @@ menuentry "Graphical Mode" {
 menuentry "Disable Framebuffer" {
     set gfxpayload=text
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -74,7 +66,7 @@ menuentry "Disable Framebuffer" {
 menuentry "Disable Video Kernel Mode Setting" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -82,7 +74,7 @@ menuentry "Disable Video Kernel Mode Setting" {
 menuentry "Debug Mode" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} initcall verbose debug=vc systemd.log_level=debug systemd.log_target=kmsg log_buf_len=1M 
+    linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} initcall verbose debug=vc systemd.log_level=debug systemd.log_target=kmsg log_buf_len=1M 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -90,7 +82,7 @@ menuentry "Debug Mode" {
 menuentry "Serial Console" {
     set gfxpayload=text
     echo 'Loading kernel...'
-    linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 "${loopback}" ${kernelopts} video=vesafb:off console=tty1 console=ttyS0,115200n8 
+    linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} video=vesafb:off console=tty1 console=ttyS0,115200n8 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }

--- a/templates/boot/grub/netboot.cfg
+++ b/templates/boot/grub/netboot.cfg
@@ -16,7 +16,7 @@ set menu_color_highlight=black/yellow
 menuentry "%GRML_NAME% Standard (%VERSION%, %ARCH%)" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux  vmlinuz root=/dev/nfs rw nfsroot=192.168.0.1:/live/image boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off nomce net.ifnames=0 noprompt noeject 
+    linux  vmlinuz root=/dev/nfs rw nfsroot=192.168.0.1:/live/image boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off nomce noprompt noeject 
     echo 'Loading initrd...'
     initrd initrd.img
 }

--- a/templates/boot/isolinux/default.cfg
+++ b/templates/boot/isolinux/default.cfg
@@ -3,7 +3,7 @@ label grml
   menu DEFAULT
   menu label %GRML_NAME% ^Standard (%VERSION%, %ARCH%)
   kernel /boot/%SHORT_NAME%/vmlinuz
-  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce net.ifnames=0 
+  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce 
 
   text help
                                         Grml is a Debian based Linux live

--- a/templates/boot/isolinux/grml.cfg
+++ b/templates/boot/isolinux/grml.cfg
@@ -2,20 +2,10 @@
 
 # generic ones
 
-label pnet
-  menu label Enable Predictable ^Network Interface Names
-  kernel /boot/%SHORT_NAME%/vmlinuz
-  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce 
-
-  text help
-                                        Boot Grml with Predictable Network
-                                        Interface Names.
-  endtext
-
 label ssh
   menu label Enable ^SSH (with random password)
   kernel /boot/%SHORT_NAME%/vmlinuz
-  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce net.ifnames=0 ssh 
+  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce ssh 
 
   text help
                                         Boot Grml and automatically start
@@ -30,7 +20,7 @@ label ssh
 label grml2ram
   menu label Load Grml to ^RAM
   kernel /boot/%SHORT_NAME%/vmlinuz
-  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce net.ifnames=0 toram=%SQUASHFS_NAME% 
+  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce toram=%SQUASHFS_NAME% 
 
   text help
                                         Load Grml into RAM.
@@ -45,7 +35,7 @@ label grml2ram
 label grmlmedium2ram
   menu label Load ^whole medium to RAM
   kernel /boot/%SHORT_NAME%/vmlinuz
-  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce net.ifnames=0 toram 
+  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce toram 
 
   text help
                                         Load whole medium into RAM.
@@ -62,7 +52,7 @@ label grmlmedium2ram
 label forensic
   menu label F^orensic Mode
   kernel /boot/%SHORT_NAME%/vmlinuz
-  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off nomce net.ifnames=0 vga=791 nofstab noraid nolvm noautoconfig noswap raid=noautodetect read-only 
+  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off nomce vga=791 nofstab noraid nolvm noautoconfig noswap raid=noautodetect read-only 
 
   text help
                                         Boot Grml in forensic mode. This
@@ -75,7 +65,7 @@ label forensic
 label persistence
   menu label ^Persistency mode
   kernel /boot/%SHORT_NAME%/vmlinuz
-  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce net.ifnames=0 persistence 
+  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce persistence 
 
   text help
                                         Boot Grml and enable persistency
@@ -87,7 +77,7 @@ label persistence
 label lang-de
   menu label Load ^German Keyboard Layout
   kernel /boot/%SHORT_NAME%/vmlinuz
-  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce net.ifnames=0 lang=de 
+  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce lang=de 
 
   text help
                                         Boot Grml with German keyboard layout.
@@ -96,7 +86,7 @@ label lang-de
 label %GRML_NAME%x
   menu label Graphical ^Mode
   kernel /boot/%SHORT_NAME%/vmlinuz
-  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce net.ifnames=0 startx 
+  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 nomce startx 
 
   text help
                                         Boot Grml and automatically invoke
@@ -106,7 +96,7 @@ label %GRML_NAME%x
 label nofb
   menu label Dis^able Framebuffer
   kernel /boot/%SHORT_NAME%/vmlinuz
-  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=normal radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset nomce net.ifnames=0 
+  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=normal radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset nomce 
 
   text help
                                         Boot Grml without framebuffer.
@@ -115,7 +105,7 @@ label nofb
 label nokms
   menu label Disable Video ^Kernel Mode Setting
   kernel /boot/%SHORT_NAME%/vmlinuz
-  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset nomce net.ifnames=0 vga=791 
+  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset nomce vga=791 
 
   text help
                                         Boot Grml without Kernel Mode Setting
@@ -125,7 +115,7 @@ label nokms
 label debug
   menu label ^Debug Mode
   kernel /boot/%SHORT_NAME%/vmlinuz
-  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 verbose debug=vc initcall nomce net.ifnames=0 systemd.log_level=debug systemd.log_target=kmsg log_buf_len=1M
+  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=791 verbose debug=vc initcall nomce systemd.log_level=debug systemd.log_target=kmsg log_buf_len=1M 
 
   text help
                                         Boot Grml in debug mode, which
@@ -136,7 +126,7 @@ label debug
 label serial
   menu label Serial ^Console
   kernel /boot/%SHORT_NAME%/vmlinuz
-  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=normal video=vesafb:off nomce net.ifnames=0 console=tty1 console=ttyS0,115200n8 
+  append initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off vga=normal video=vesafb:off nomce console=tty1 console=ttyS0,115200n8 
 
 
   text help

--- a/templates/boot/isolinux/hidden.cfg
+++ b/templates/boot/isolinux/hidden.cfg
@@ -1,17 +1,17 @@
 label splash
 menu hide
 kernel /boot/%SHORT_NAME%/vmlinuz
-append apm=power-off vga=791 initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% splash nomce net.ifnames=0 
+append apm=power-off vga=791 initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% splash nomce 
 
 label grmlx
 menu hide
 kernel /boot/%SHORT_NAME%/vmlinuz
-append apm=power-off startx vga=791 initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 
+append apm=power-off startx vga=791 initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce 
 
 label vmlinuz
 menu hide
 kernel /boot/%SHORT_NAME%/vmlinuz
-append apm=power-off vga=791 initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 
+append apm=power-off vga=791 initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce 
 
 label memtest
 menu hide
@@ -21,17 +21,17 @@ append BOOT_IMAGE=memtest
 label fb1280x1024
 menu hide
 kernel /boot/%SHORT_NAME%/vmlinuz
-append apm=power-off vga=794 initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 
+append apm=power-off vga=794 initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce 
 
 label fb1024x768
 menu hide
 kernel /boot/%SHORT_NAME%/vmlinuz
-append apm=power-off vga=791 initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 
+append apm=power-off vga=791 initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce 
 
 label fb800x600
 menu hide
 kernel /boot/%SHORT_NAME%/vmlinuz
-append apm=power-off vga=788 initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce net.ifnames=0 
+append apm=power-off vga=788 initrd=/boot/%SHORT_NAME%/initrd.img boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce 
 
 label userdef
 menu hide

--- a/templates/boot/isolinux/netboot.cfg
+++ b/templates/boot/isolinux/netboot.cfg
@@ -3,7 +3,7 @@ label grml
   menu DEFAULT
   menu label %GRML_NAME% ^Standard (%VERSION%, %ARCH%)
   kernel vmlinuz
-  append initrd=initrd.img root=/dev/nfs rw nfsroot=192.168.0.1:/live/image boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off nomce net.ifnames=0 noprompt noeject vga=791 
+  append initrd=initrd.img root=/dev/nfs rw nfsroot=192.168.0.1:/live/image boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% apm=power-off nomce noprompt noeject vga=791 
 
   text help
                                         Grml is a Debian based Linux live


### PR DESCRIPTION
We have not managed to complete this task since 2019. Enable it now, and when something breaks, people can tell us.

Closes: grml/grml#127