### PR TITLE
GHA CI: add arm64 matrix variant for build-iso job

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -49,41 +49,50 @@ jobs:
         extra_classes:
           - ""
           - "GRML_GHACI_CLOUD"
+        arch:
+          - amd64
+          - arm64
         exclude:
           - host_release: bookworm
             extra_classes: "GRML_GHACI_CLOUD"
+          - arch: arm64
+            host_release: bookworm
+          - arch: arm64
+            extra_classes: "GRML_GHACI_CLOUD"
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
 
       - run: ./test/gha-build-iso.sh initial
-        name: "Build ISO on ${{matrix.host_release}}${{matrix.extra_classes && format(' with {0}', matrix.extra_classes) || ''}}"
+        name: "Build ISO on ${{matrix.host_release}} ${{matrix.arch}}${{matrix.extra_classes && format(' with {0}', matrix.extra_classes) || ''}}"
         env:
           HOST_RELEASE: ${{matrix.host_release}}
           EXTRA_CLASSES: ${{matrix.extra_classes}}
+          ARCH: ${{matrix.arch}}
 
       - name: Archive built ISO
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: grml-live-build-result-initial-${{matrix.host_release}}${{matrix.extra_classes && format('-{0}', matrix.extra_classes) || ''}}
+          name: grml-live-build-result-initial-${{matrix.host_release}}-${{matrix.arch}}${{matrix.extra_classes && format('-{0}', matrix.extra_classes) || ''}}
           if-no-files-found: error
           retention-days: 15
           path: |
             results-initial/*
 
       - run: ./test/gha-build-iso.sh build-only-twice
-        name: "Repack ISO twice on ${{matrix.host_release}}${{matrix.extra_classes && format(' with {0}', matrix.extra_classes) || ''}}"
+        name: "Repack ISO twice on ${{matrix.host_release}} ${{matrix.arch}}${{matrix.extra_classes && format(' with {0}', matrix.extra_classes) || ''}}"
         env:
           HOST_RELEASE: ${{matrix.host_release}}
           EXTRA_CLASSES: ${{matrix.extra_classes}}
+          ARCH: ${{matrix.arch}}
 
       - name: Archive repacked ISO
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: grml-live-build-result-repack-${{matrix.host_release}}${{matrix.extra_classes && format('-{0}', matrix.extra_classes) || ''}}
+          name: grml-live-build-result-repack-${{matrix.host_release}}-${{matrix.arch}}${{matrix.extra_classes && format('-{0}', matrix.extra_classes) || ''}}
           if-no-files-found: error
           retention-days: 15
           path: |

--- a/test/gha-build-iso.sh
+++ b/test/gha-build-iso.sh
@@ -8,6 +8,11 @@ set -euxo pipefail
 
 MODE=$1
 
+if [ -z "${ARCH:-}" ]; then
+    echo "E: ARCH environment variable must be set"
+    exit 1
+fi
+
 cat >build-gha-ci-test-config-initial <<EOT
 ---
 last_release: "2024.12"
@@ -25,7 +30,7 @@ run_build() {
         bash -c \
         "apt-get update -qq && apt-get satisfy -q -y --no-install-recommends 'git, ca-certificates' \
         && git config --global --add safe.directory /source \
-        && /source/build-driver/build /source ${build_mode} /source/${config_filename} ghaci amd64 testing"
+        && /source/build-driver/build /source ${build_mode} /source/${config_filename} ghaci $ARCH testing"
 
     sudo chmod -R a+rX results
     sudo mv results "${results_directory}"
@@ -49,7 +54,7 @@ release_version: "ci-bo-first"
 release_name: CI1
 base_iso:
     ghaci:
-        amd64: "file:///source/$INPUT_ISO"
+        $ARCH: "file:///source/$INPUT_ISO"
 EOT
 
     run_build build-gha-ci-test-config-build-only-first release results-build-only-first
@@ -63,7 +68,7 @@ release_version: "ci-bo-second"
 release_name: CI2
 base_iso:
     ghaci:
-        amd64: "file:///source/$INPUT_ISO"
+        $ARCH: "file:///source/$INPUT_ISO"
 EOT
 
     run_build build-gha-ci-test-config-build-only-second release results-build-only-second


### PR DESCRIPTION
Add arm64 architecture to the build-iso matrix, excluding bookworm and GHACI_CLOUD variants.

🤖 Generated with [Claude Code](https://claude.ai/code)