### PR TITLE
GRMLBASE: drop grml-scripts-core

### DIFF
--- a/config/package_config/GRMLBASE
+++ b/config/package_config/GRMLBASE
@@ -22,7 +22,6 @@ grml-keyring
 grml-network
 grml-quickconfig
 grml-scripts
-grml-scripts-core
 grml-tips
 hdparm
 hwinfo


### PR DESCRIPTION
Got merged into grml-etc-core, in https://github.com/grml/grml-etc-core/pull/215