### PR TITLE
GRMLBASE: disable systemd-firstboot wizard

### DIFF
--- a/config/files/GRMLBASE/etc/systemd/system-preset/10-grml.preset
+++ b/config/files/GRMLBASE/etc/systemd/system-preset/10-grml.preset
@@ -11,4 +11,7 @@ enable resolvconf.service
 enable avahi-daemon.service
 enable avahi-ssh.service
 
+# don't need the firstboot wizard
+disable systemd-firstboot.service
+
 disable *


### PR DESCRIPTION
From systemd PoV each Grml Live boot is a "first boot". True, because /etc/machine-id is absent.

Disable the firstboot wizard, so it does not pop up any prompts. At some later point we might want to check what the overlap with grml-autoconfig is and so on.

Closes: grml/grml#231