### PR TITLE
Move automatic classes from build-driver to grml-live 

### DIFF
--- a/build-driver/build.py
+++ b/build-driver/build.py
@@ -217,21 +217,14 @@ def skip_sources_requested(build_config: dict, env: dict) -> bool:
     return False
 
 
-def get_grml_live_classes(arch: str, flavor: str, classes_for_mode: list[str], skip_sources: bool) -> list[str]:
-    base_classes = [
-        "GRMLBASE",
-        f"GRML_{flavor.upper()}",
-        "RELEASE",
-        arch.upper(),
-    ]
+def get_grml_live_classes(flavor: str, classes_for_mode: list[str], skip_sources: bool) -> list[str]:
+    base_classes = [f"GRML_{flavor.upper()}"]
 
     # Add extra classes from environment variable
     extra_classes = os.getenv("EXTRA_CLASSES", "").strip()
     if extra_classes:
         extra_class_list = [cls.strip() for cls in extra_classes.split(",") if cls.strip()]
-        # Insert extra classes before "RELEASE"
-        release_index = base_classes.index("RELEASE")
-        base_classes[release_index:release_index] = extra_class_list
+        base_classes += extra_class_list
         print(f"I: Adding extra classes: {extra_class_list}")
 
     if skip_sources:
@@ -399,7 +392,7 @@ def main(program_name: str, argv: list[str]) -> int:
     # possibly mismatching the versions. Also we do not prepare a working DNS,
     # so it would just fail. In the future, grml-live should support reusing
     # the sources tarball and fetching just the necessary differences.
-    classes = get_grml_live_classes(arch, flavor, classes_for_mode, skip_sources or build_mode == "release")
+    classes = get_grml_live_classes(flavor, classes_for_mode, skip_sources or build_mode == "release")
 
     build_grml_name = f"grml-{flavor}-{arch}"
     last_release_version = build_config["last_release"]

--- a/debian/NEWS
+++ b/debian/NEWS
@@ -1,3 +1,22 @@
+grml-live (0.53.2) unstable; urgency=medium
+
+  Class (option -c) handling has changed:
+
+  - GRMLBASE and architecture-specific classes are now enabled by
+    default and should be removed from your grml-live invocation.
+
+  - The RELEASE class (which cleans up /root and /home/grml) is also
+    automatically enabled and can be disabled using the new "-R"
+    option.
+
+  These changes simplify the build process by reducing the need for
+  manual class specification in most common use cases.
+
+  You should still specify GRML_SMALL or GRML_FULL and/or your custom
+  classes.
+
+ -- Chris Hofstaedtler <ch@grml.org>  Tue, 01 Jul 2025 00:42:50 +0200
+
 grml-live (0.52.0) unstable; urgency=medium
 
   We replaced FAI with our own implementation minifai.  It should be

--- a/docs/grml-live.8.txt
+++ b/docs/grml-live.8.txt
@@ -13,7 +13,7 @@ grml-live [-a <architecture>] [-c <classe[s]>] [-C <configfile>] [
 -e <extract_iso_name>] [-g <grml_name>] [-i <iso_name>] [
 -o <output_directory>] [-r <release_name>] [-s <suite>] [
 -t <template_directory>] [-v <version_number>] [-U <username>] [
--w <date>] [-AbBFnNqQuVz]
+-w <date>] [-AbBFnNqQRuVz]
 
 Description
 -----------
@@ -77,16 +77,19 @@ that you do not want to update the chroot.
   -c **CLASSES**::
 
 Specify the CLASSES to be used for building the ISO.  By default only
-the classes GRMLBASE, GRML_FULL and I386/AMD64/ARM64 (depending on system
-architecture) are assumed.  Additionally you can specify a class providing a
+the class GRML_FULL is assumed.  Additionally you can specify a class providing a
 (grml-)kernel (see <<classes,the 'CLASSES' section in this document>> for
 details about available classes). So instead of GRML_FULL you can also use e.g.
 GRML_SMALL.
 
+The classes GRMLBASE, RELEASE, and AMD64/ARM64 (depending on system
+architecture) are automatically added, and shall not be given on the
+command line.
+
 [IMPORTANT]
 All class names should be written in uppercase letters. Do not use a dash, use
-an underscore. So do not use "amd64" but "AMD64", do not use "FOO BAR" but
-"FOO_BAR".
+an underscore. So do not use "grml_small" but "GRML_SMALL", do not use "FOO BAR"
+but "FOO_BAR".
 
 
   -C **CONFIGURATION_FILE**::
@@ -193,6 +196,11 @@ Build the ISO without generating a netboot package.
   -r **RELEASENAME**::
 
 Specify name of the release.
+
+  -R::
+
+After building the chroot, do not clean up for a release ISO. This skips applying
+the class "RELEASE".
 
   -s **SUITE**::
 

--- a/grml-live
+++ b/grml-live
@@ -44,7 +44,7 @@ Usage: $PN [options, see as follows]
    -a <architecture>       architecture; available values: i386, amd64 + arm64
    -A                      clean build directories before and after running
    -b                      build the ISO without updating the chroot
-   -B                      build the ISO without touching the chroot (skips cleanup)
+   -B                      build the ISO without touching the chroot (do not clean up)
    -c <class[es]>          classes to be used for building the ISO
    -C <configfile>         configuration file for grml-live
    -d <date>               use specified date instead of build time as date of release
@@ -62,6 +62,7 @@ Usage: $PN [options, see as follows]
    -q                      skip mksquashfs
    -Q                      skip netboot package build
    -r <release_name>       release name
+   -R                      skip applying RELEASE clean up
    -s <suite>              Debian suite/release, like: stable, testing, unstable
    -S <script_directory>   place of scripts (defaults to /usr/share/grml-live/scripts)
    -t <template_directory> place of the templates
@@ -308,12 +309,12 @@ adjust_boot_files() {
 # }}}
 
 # command line parsing {{{
-while getopts "a:C:c:d:D:e:g:i:I:o:r:s:S:t:U:v:w:AbBFhnNqQuVz" opt; do
+while getopts "a:C:c:d:D:e:g:i:I:o:r:s:S:t:U:v:w:AbBFhnNqQRuVz" opt; do
   case "$opt" in
     a) ARCH="$OPTARG" ;;
     A) CLEAN_ARTIFACTS=1 ;;
     b) BUILD_ONLY=1 ;;
-    B) BUILD_DIRTY=1 ;;
+    B) BUILD_DIRTY=1; SKIP_RELEASE=1 ;;
     c) CLASSES="$OPTARG" ;;
     C) LOCAL_CONFIG="$(readlink -f "$OPTARG")" ;;
     d) DATE="$OPTARG" ;;
@@ -329,6 +330,7 @@ while getopts "a:C:c:d:D:e:g:i:I:o:r:s:S:t:U:v:w:AbBFhnNqQuVz" opt; do
     q) SKIP_MKSQUASHFS=1 ;;
     Q) SKIP_NETBOOT=1 ;;
     r) RELEASENAME="$OPTARG" ;;
+    R) SKIP_RELEASE=1 ;;
     s) SUITE="$OPTARG" ;;
     S) SCRIPTS_DIRECTORY="$OPTARG";;
     t) TEMPLATE_DIRECTORY="$OPTARG";;
@@ -388,7 +390,7 @@ export SOURCE_DATE_EPOCH
 
 # assume sane defaults (if not set already) {{{
 [ -n "$ARCH" ]                    || ARCH="$(dpkg --print-architecture)"
-[ -n "$CLASSES" ]                 || CLASSES="GRMLBASE,GRML_FULL,$(echo "${ARCH}" | tr '[:lower:]' '[:upper:]')"
+[ -n "$CLASSES" ]                 || CLASSES="GRML_FULL,$(echo "${ARCH}" | tr '[:lower:]' '[:upper:]')"
 [ -n "$DATE" ]                    || DATE="$(date --utc -d "@${SOURCE_DATE_EPOCH}" +%Y-%m-%d)"
 [ -n "$DISTRI_INFO" ]             || DISTRI_INFO='Grml - Live Linux for system administrators'
 [ -n "$DISTRI_NAME" ]             || DISTRI_NAME="grml"
@@ -475,6 +477,33 @@ fi
 [ -n "$GRML_NAME" ] && SHORT_NAME="$(echo "$GRML_NAME" | tr -d ',./;\- ')"
 # }}}
 
+# automatic classes {{{
+if hasclass GRMLBASE ; then
+  ewarn "Class GRMLBASE explicitly requested. This is now automatic, please remove it."; eend 1
+else
+  CLASSES="GRMLBASE,${CLASSES}"
+fi
+if hasclass RELEASE ; then
+  ewarn "Class RELEASE explicitly requested. This is now automatic, please remove it."; eend 1
+  if [[ "$SKIP_RELEASE" == "1" ]]; then
+    eerror "Class RELEASE explicitly requested, while conflicting option -R is also given. Please remove either."
+    bailout 1
+  fi
+elif [[ -z "$SKIP_RELEASE" ]]; then
+  CLASSES="${CLASSES},RELEASE"
+fi
+if hasclass AMD64 ; then
+  ewarn "Class AMD64 explicitly requested. This is now automatic, please remove it."; eend 1
+elif [[ "$ARCH" == "amd64" ]]; then
+  CLASSES="${CLASSES},AMD64"
+fi
+if hasclass ARM64 ; then
+  ewarn "Class ARM64 explicitly requested. This is now automatic, please remove it."; eend 1
+elif [[ "$ARCH" == "arm64" ]]; then
+  CLASSES="${CLASSES},ARM64"
+fi
+# }}}
+
 # Warn user if addons from grml-live-addons are absent {{{
 if [ -z "${NO_ADDONS:-}" ] && [ ! -r "$TEMPLATE_DIRECTORY"/arch ] ; then
   ewarn "Boot addons not found (Consider installing package grml-live-addons)" ; eend 0
@@ -523,6 +552,7 @@ else
     [ -n "$BUILD_ONLY" ]          && echo "  Executing BUILD_ONLY instead of fresh installation or UPDATE."
     [ -n "$BUILD_DIRTY" ]         && echo "  Executing BUILD_DIRTY to leave chroot untouched."
 fi
+[ -n "$SKIP_RELEASE" ]        && echo "  Skipping RELEASE clean up."
 echo
 if [ -z "$FORCE" ] ; then
    echo "Check the configuration above, or use -F to force execution."


### PR DESCRIPTION
IMO grml-live should know by itself which classes are needed to get a working build.

Introduces a new option -R to skip class RELEASE.

Deprecated option -V.
