### PR TITLE
Drop IGNORE class

### DIFF
--- a/build-driver/build.py
+++ b/build-driver/build.py
@@ -224,7 +224,6 @@ def get_grml_live_classes(arch: str, flavor: str, classes_for_mode: list[str], s
         f"GRML_{flavor.upper()}",
         "RELEASE",
         arch.upper(),
-        "IGNORE",
     ]
 
     # Add extra classes from environment variable

--- a/config/package_config/IGNORE
+++ b/config/package_config/IGNORE
@@ -1,2 +1,0 @@
-PACKAGES install
-


### PR DESCRIPTION
Was useful only in the old Jenkins CI setup for grml.org builds. We no longer use that, so the class has outlived its usefulness.