### PR TITLE
Deprecate setting individual *_OUTPUT vars 

### DIFF
--- a/docs/grml-live.8.txt
+++ b/docs/grml-live.8.txt
@@ -150,8 +150,7 @@ Display short usage information and exit.
 
   -i **ISO_NAME**::
 
-Specify name of ISO which will be available inside $OUTPUT_DIRECTORY/grml_isos
-by default.
+Specify name of ISO which will be available inside $OUTPUT_DIRECTORY/grml_isos.
 
   -I **CHROOT_INSTALL**::
 
@@ -480,11 +479,11 @@ please send us a bug report then). Check out <<deploy-on-debian,How do I deploy
 grml-live on a plain Debian installation>> for details how to set up grml-live
 on a plain, original Debian system.
 
-* enough free disk space; at least ~2GB are required for a minimal grml-live
-run (\~1GB for the chroot [$CHROOT_OUTPUT], \~400MB for the build target
-[$BUILD_OUTPUT], \~35MB for the netboot files and \~350MB for the resulting ISO
-[$ISO_OUTPUT] plus some temporary files), if you plan to use GRML_FULL you
-should have at least 4GB of total free disk space
+* enough free disk space. At least 2GB are required for a minimal grml-live
+run (\~1GB for the chroot, \~400MB for the build target, \~35MB for the netboot
+files and \~350MB for the resulting ISO plus some temporary files).
+If you plan to build GRML_FULL you should have at least 4GB of total free disk
+space.
 
 * fast network access for retrieving the Debian packages used for creating the
 chroot (check out "local mirror" to workaround this problem as far as possible)

--- a/etc/grml/grml-live.conf
+++ b/etc/grml/grml-live.conf
@@ -17,15 +17,6 @@
 # You have enough RAM? Use shared memory for fast testing-purposes:
 # OUTPUT="/dev/shm" # mount -o remount,suid,dev,rw /dev/shm
 
-# Where do want to find the chroot of the buildprocess files?
-# CHROOT_OUTPUT="$OUTPUT/grml_chroot"
-# Where do you want to find the compressed chroot, bootstuff,...?
-# BUILD_OUTPUT="$OUTPUT/grml_cd"
-# Where do you want to find the final ISO?
-# ISO_OUTPUT="$OUTPUT/grml_isos"
-# Where do you want to find the netboot package?
-# NETBOOT="${OUTPUT}/netboot/"
-
 # Do you want to preserve the logfile from being cleaned after each execution
 # of grml-live? By default the logfile is cleaned so the log doesn't fill up.
 # PRESERVE_LOGFILE='1'

--- a/grml-live
+++ b/grml-live
@@ -957,7 +957,6 @@ grub_setup() {
 # }}}
 
 # BUILD_OUTPUT - execute arch specific stuff and squashfs {{{
-[ -n "$BUILD_OUTPUT" ] || BUILD_OUTPUT="$OUTPUT/grml_cd"
 mkdir -p "$BUILD_OUTPUT" || bailout 6 "Problem with creating $BUILD_OUTPUT for stage ARCH"
 
 # prepare ISO

--- a/grml-live
+++ b/grml-live
@@ -1501,7 +1501,6 @@ generate_build_info() {
 # }}}
 
 # ISO_OUTPUT - mkisofs {{{
-[ -n "$ISO_OUTPUT" ] || ISO_OUTPUT="$OUTPUT/grml_isos"
 [ -n "$ISO_NAME" ] || ISO_NAME="${GRML_NAME}_${VERSION}.iso"
 
 BOOT_ARGS="-no-emul-boot -boot-load-size 4 -boot-info-table -b boot/isolinux/isolinux.bin -c boot/isolinux/boot.cat -isohybrid-mbr ${CHROOT_OUTPUT}/usr/lib/ISOLINUX/isohdpfx.bin"

--- a/grml-live
+++ b/grml-live
@@ -747,8 +747,6 @@ if [ -n "$BUILD_DIRTY" ]; then
    log   "Skipping stage 'fai' as requested via option -B"
    ewarn "Skipping stage 'fai' as requested via option -B" ; eend 0
 else
-   [ -n "$CHROOT_OUTPUT" ] || CHROOT_OUTPUT="$OUTPUT/grml_chroot"
-
    if [ -n "$BOOTSTRAP_ONLY" ] ; then
       FAI_ACTION=bootstrap
    elif [ -n "$BUILD_ONLY" ] ; then

--- a/grml-live
+++ b/grml-live
@@ -415,7 +415,6 @@ export SOURCE_DATE_EPOCH
 [ -n "$CHROOT_OUTPUT" ]    || CHROOT_OUTPUT="$OUTPUT/grml_chroot"
 [ -n "$ISO_OUTPUT" ]       || ISO_OUTPUT="$OUTPUT/grml_isos"
 [ -n "$LOG_OUTPUT" ]       || LOG_OUTPUT="$OUTPUT/grml_logs"
-[ -n "$REPORTS" ]          || REPORTS="${LOG_OUTPUT}/reports"
 [ -n "$NETBOOT" ]          || NETBOOT="${OUTPUT}/netboot"
 # }}}
 

--- a/grml-live
+++ b/grml-live
@@ -409,12 +409,17 @@ export SOURCE_DATE_EPOCH
 [ -n "$USERNAME" ]                || USERNAME='grml'
 [ -n "$VERSION" ]                 || VERSION='0.0.1'
 
-# output specific stuff, depends on $OUTPUT (iff not set):
+# output specific stuff, depends on $OUTPUT:
 [ -n "$OUTPUT" ]           || OUTPUT="$PWD/grml/"
+[ -n "$BUILD_OUTPUT" ]     && echo "W: setting BUILD_OUTPUT is deprecated, please remove it"
 [ -n "$BUILD_OUTPUT" ]     || BUILD_OUTPUT="$OUTPUT/grml_cd"
+[ -n "$CHROOT_OUTPUT" ]    && echo "W: setting CHROOT_OUTPUT is deprecated, please remove it"
 [ -n "$CHROOT_OUTPUT" ]    || CHROOT_OUTPUT="$OUTPUT/grml_chroot"
+[ -n "$ISO_OUTPUT" ]       && echo "W: setting ISO_OUTPUT is deprecated, please remove it"
 [ -n "$ISO_OUTPUT" ]       || ISO_OUTPUT="$OUTPUT/grml_isos"
+[ -n "$LOG_OUTPUT" ]       && echo "W: setting LOG_OUTPUT is deprecated, please remove it"
 [ -n "$LOG_OUTPUT" ]       || LOG_OUTPUT="$OUTPUT/grml_logs"
+[ -n "$NETBOOT" ]          && echo "W: setting NETBOOT is deprecated, please remove it"
 [ -n "$NETBOOT" ]          || NETBOOT="${OUTPUT}/netboot"
 # }}}
 
@@ -516,11 +521,8 @@ echo
 echo "  FAI classes:       $CLASSES"
 [ -n "$LOCAL_CONFIG" ]        && echo "  Configuration:     $LOCAL_CONFIG"
 [ -n "$GRML_FAI_CONFIG" ]     && echo "  Config directory:  $GRML_FAI_CONFIG"
-echo "  main directory:    $OUTPUT"
+echo "  Output directory:  $OUTPUT"
 [ -n "$EXTRACT_ISO_NAME" ]    && echo "  Extract ISO:       $EXTRACT_ISO_NAME"
-[ -n "$CHROOT_OUTPUT" ]       && echo "  Chroot target:     $CHROOT_OUTPUT"
-[ -n "$BUILD_OUTPUT" ]        && echo "  Build target:      $BUILD_OUTPUT"
-[ -n "$ISO_OUTPUT" ]          && echo "  ISO target:        $ISO_OUTPUT"
 [ -n "$GRML_NAME" ]           && echo "  Grml name:         $GRML_NAME"
 [ -n "$RELEASENAME" ]         && echo "  Release name:      $RELEASENAME"
 [ -n "$DATE" ]                && echo "  Build date:        $DATE"


### PR DESCRIPTION
I intend to make changes later to how and where these variables are setup and passing all of them through to the python tools is annoying.

I can see how it was useful to move individual output directories in the past, but I'm counting on computers being fast and big enough today.

For our own builds, build-driver lets grml-live default the vars and then moves whatever it needs.