### PR TITLE
Deprecate FAI_DEBOOTSTRAP

### DIFF
--- a/docs/grml-live.8.txt
+++ b/docs/grml-live.8.txt
@@ -562,7 +562,6 @@ Instructions
   # CHROOT_INSTALL="/srv/config/chroot_install"
   ## adjust if necessary (defaults to ./grml/):
   ## OUTPUT="/srv/grml-live"
-  FAI_DEBOOTSTRAP="bookworm http://deb.debian.org/debian/"
   # ARCH="amd64"
   CLASSES="GRMLBASE,GRML_FULL,AMD64"
   EOF
@@ -625,7 +624,7 @@ Can I use my own (local) Debian mirror?
 
 Yes. Set up an according sources.list configuration as class file in
 ${GRML_FAI_CONFIG}/files/${CLASS}/etc/apt/sources.list.d/ and adjust the variable
-FAI_DEBOOTSTRAP in /etc/grml/grml-live.conf[.local]. If you're setting up
+BOOTSTRAP_MIRROR in /etc/grml/grml-live.conf[.local]. If you're setting up
 your own class file make sure to include the class name in the class list
 (grml-live -c ...).
 
@@ -675,13 +674,13 @@ Set up apt-cacher-ng for use with grml-live
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Make sure /etc/grml/grml-live.local provides according APT_PROXY and
-FAI_DEBOOTSTRAP:
+BOOTSTRAP_MIRROR:
 
   # cat /etc/grml/grml-live.local
   [...]
   APT_PROXY="http://localhost:3142/"
   [...]
-  FAI_DEBOOTSTRAP="bookworm http://localhost:3142/deb.debian.org/debian bookworm main contrib non-free"
+  BOOTSTRAP_MIRROR="http://localhost:3142/deb.debian.org/debian"
 
 Make sure apt-cacher-ng is running ('/etc/init.d/apt-cacher-ng restart').
 That's it.  All downloaded files will be cached in /var/cache/apt-cacher-ng then.

--- a/etc/grml/grml-live.conf
+++ b/etc/grml/grml-live.conf
@@ -47,9 +47,8 @@
 # HTTP Proxy to use for APT
 # APT_PROXY="http://localhost:3142/"
 
-# Which Debian suite and which mirror do you want to use for debootstrapping?
-# Usage: "<suite> <mirror>"
-# FAI_DEBOOTSTRAP="bookworm http://deb.debian.org/debian"
+# Which Debian mirror do you want to use for bootstrapping?
+# BOOTSTRAP_MIRROR="http://deb.debian.org/debian"
 
 # Do you want to use a local mirror (like NFS)?
 # If so specify the directory where debian/ is available:

--- a/grml-live
+++ b/grml-live
@@ -448,6 +448,13 @@ if [ -n "$FAI_ARGS" ] ; then
   bailout
 fi
 
+if [ -n "$FAI_DEBOOTSTRAP" ] ; then
+  ewarn "The variable \$FAI_DEBOOTSTRAP is set, but it is deprecated." ; eend 1
+  ewarn "If you want to specify a mirror, please set BOOTSTRAP_MIRROR." ; eend 1
+  ewarn "Current value: \$FAI_DEBOOTSTRAP=${FAI_DEBOOTSTRAP}" ; eend 1
+  BOOTSTRAP_MIRROR="${FAI_DEBOOTSTRAP#* }"
+fi
+
 if [ -n "$FAI_DEBOOTSTRAP_OPTS" ] ; then
   eerror "The variable \$FAI_DEBOOTSTRAP_OPTS is set, but it is unsupported." ; eend 1
   eerror "Current value: \$FAI_DEBOOTSTRAP_OPTS=${FAI_DEBOOTSTRAP_OPTS}" ; eend 1
@@ -733,12 +740,11 @@ if [[ -n "${BOOT_METHOD:-}" ]] && [[ "${BOOT_METHOD}" != "isolinux" ]] ; then
   bailout
 fi
 
-# continue to support $FAI_DEBOOTSTRAP to specify the Debian suite and mirror URL.
-if [ -z "$FAI_DEBOOTSTRAP" ] ; then
+if [ -z "$BOOTSTRAP_MIRROR" ] ; then
   if [ -n "$WAYBACK_DATE" ] ; then
-    FAI_DEBOOTSTRAP="$SUITE http://snapshot.debian.org/archive/debian/$WAYBACK_DATE/"
+    BOOTSTRAP_MIRROR="http://snapshot.debian.org/archive/debian/$WAYBACK_DATE/"
   else
-    FAI_DEBOOTSTRAP="$SUITE http://deb.debian.org/debian"
+    BOOTSTRAP_MIRROR="http://deb.debian.org/debian"
   fi
 fi
 # }}}
@@ -784,10 +790,9 @@ else
       mv "${OUTPUT}"/grml_sources "${CHROOT_OUTPUT}"/grml-live/
 
       log "Executed FAI command line:"
-      log "${FAI_PROGRAM} ${GRML_FAI_CONFIG} ${CLASSES} ${FAI_ACTION} ${CHROOT_OUTPUT} ${CONFIGDUMP} ${FAI_DEBOOTSTRAP}"
-      einfo "${FAI_PROGRAM} ${GRML_FAI_CONFIG} ${CLASSES} ${FAI_ACTION} ${CHROOT_OUTPUT} ${CONFIGDUMP} ${FAI_DEBOOTSTRAP}"
-      # shellcheck disable=SC2086 # $FAI_DEBOOTSTRAP needs splitting
-      "${FAI_PROGRAM}" "${GRML_FAI_CONFIG}" "${CLASSES}" "${FAI_ACTION}" "${CHROOT_OUTPUT}" "${CONFIGDUMP}" ${FAI_DEBOOTSTRAP} 2>&1 | tee -a "${LOGFILE}"
+      log "${FAI_PROGRAM} ${GRML_FAI_CONFIG} ${CLASSES} ${FAI_ACTION} ${CHROOT_OUTPUT} ${CONFIGDUMP} ${SUITE} ${BOOTSTRAP_MIRROR}"
+      einfo "${FAI_PROGRAM} ${GRML_FAI_CONFIG} ${CLASSES} ${FAI_ACTION} ${CHROOT_OUTPUT} ${CONFIGDUMP} ${SUITE} ${BOOTSTRAP_MIRROR}"
+      "${FAI_PROGRAM}" "${GRML_FAI_CONFIG}" "${CLASSES}" "${FAI_ACTION}" "${CHROOT_OUTPUT}" "${CONFIGDUMP}" "${SUITE}" "${BOOTSTRAP_MIRROR}" 2>&1 | tee -a "${LOGFILE}"
       RC="${PIPESTATUS[0]}" # notice: bash-only
 
       # Fetches logs from "${CHROOT_OUTPUT}"/grml-live/log.
@@ -1463,7 +1468,7 @@ generate_build_info() {
     distri_info="${DISTRI_INFO}" \
     distri_name="${DISTRI_NAME}" \
     extract_iso_name="${EXTRACT_ISO_NAME}" \
-    fai_cmdline="${FAI_PROGRAM} ${GRML_FAI_CONFIG} ${CLASSES} ${FAI_ACTION} ${CHROOT_OUTPUT} ${configdump_placeholder} ${FAI_DEBOOTSTRAP}" \
+    fai_cmdline="${FAI_PROGRAM} ${GRML_FAI_CONFIG} ${CLASSES} ${FAI_ACTION} ${CHROOT_OUTPUT} ${configdump_placeholder} ${SUITE} ${BOOTSTRAP_MIRROR}" \
     fai_version="minifai" \
     grml_architecture="${ARCH}" \
     grml_bootid="${BOOTID}" \


### PR DESCRIPTION
Instead support a new `BOOTSTRAP_MIRROR` variable, which has *just* the mirror URL.

Judging by an example in the docs, since introducing minifai, we were not fully compatible with the old syntax.

Ideally minifai would determine the mirror URL from the class config, but that needs some form of marking one of the sources files as the bootstrap one. Ideas welcome.