### PR TITLE
grml-live: remove "sid" hack for debootstrap

### DIFF
--- a/grml-live
+++ b/grml-live
@@ -693,9 +693,6 @@ create_efi_img() {
 # on-the-fly configuration {{{
 
 case "${SUITE}" in
-  # /usr/share/debootstrap/scripts/unstable does not exist, so use 'sid'
-  # for bootstrapping, but DEBIAN_UNSTABLE elsewhere:
-   unstable) SUITE='sid' ; CLASSES="DEBIAN_UNSTABLE,$CLASSES" ;;
   # avoid having to maintain DEBIAN_UNSTABLE *and* DEBIAN_SID class files:
         sid)               CLASSES="DEBIAN_UNSTABLE,$CLASSES" ;;
   # otherwise map e.g. bookworm to DEBIAN_BOOKWORM:


### PR DESCRIPTION
Not necessary given we use mmdebstrap.