### PR TITLE
GRMLBASE/50-addons: fix merging addons directory

### DIFF
--- a/config/media-scripts/GRMLBASE/50-addons
+++ b/config/media-scripts/GRMLBASE/50-addons
@@ -23,8 +23,8 @@ echo "I: installing addons."
 
 # copy files and report which ones get installed
 if grml-live-command copy-media-files media -r "/arch/${ARCH}/boot/addons" && $ROOTCMD test -d "${GRML_LIVE_MEDIADIR}/arch" ; then
-  $ROOTCMD mv "${GRML_LIVE_MEDIADIR}/arch/${ARCH}/boot/addons" "${GRML_LIVE_MEDIADIR}/boot/"
-  $ROOTCMD rmdir "${GRML_LIVE_MEDIADIR}/arch/${ARCH}/boot" "${GRML_LIVE_MEDIADIR}/arch/${ARCH}" "${GRML_LIVE_MEDIADIR}/arch"
+  $ROOTCMD cp -rv "${GRML_LIVE_MEDIADIR}/arch/${ARCH}/boot/addons" "${GRML_LIVE_MEDIADIR}/boot/"
+  $ROOTCMD rm -rf "${GRML_LIVE_MEDIADIR}/arch"
 else
   # legacy path (before https://github.com/grml/grml-live-grml/pull/11):
   echo "I: trying to install legacy path /boot/addons"


### PR DESCRIPTION
On FULL and AMD64 builds, /boot/addons already exists before 50-addons runs. `mv` then fails as it does not "merge" directories.

Use `cp -r` and `rm -r` instead to get the "merge" behaviour.

Maybe it would be better to extend fcopy/copy-media-files to allow a destination path.

Fix from #402 was not complete.