### PR TITLE
grml-lang: workaround XKBVARIANT bug in X11

### DIFF
--- a/config/files/GRMLBASE/usr/bin/grml-lang
+++ b/config/files/GRMLBASE/usr/bin/grml-lang
@@ -64,7 +64,11 @@ fi
 configure_keyboard
 
 eindent
-einfo "Configured Keyboard Layout: $XKBLAYOUT $XKBVARIANT."
+new_layout="$XKBLAYOUT"
+if [ -n "$XKBVARIANT" ] && [ "$XKBVARIANT" != "," ]; then
+  new_layout="$new_layout $XKBVARIANT"
+fi
+einfo "Configured Keyboard Layout: $new_layout."
 eend 0
 
 ## END OF FILE #################################################################

--- a/config/files/GRMLBASE/usr/share/grml-autoconfig/language-functions
+++ b/config/files/GRMLBASE/usr/share/grml-autoconfig/language-functions
@@ -6,7 +6,7 @@
 ################################################################################
 
 # Defaults. XKBLAYOUT is not defaulted, so caller can determine unhandled values.
-XKBVARIANT=""
+XKBVARIANT=","  # comma is necessary to avoid bug in Xorg server when switching from nodeadkeys to "".
 XKBOPTIONS=""
 LC_COLLATE=""
 LC_TIME=""


### PR DESCRIPTION
Xorg server apparently does not reset XKBVARIANT when it becomes unset in the udev database. Then combinations like us/nodeadkeys or gb/nodeadkeys do not work.

Fixes grml/grml#245.