### PR TITLE
SW: add tio to GRML_SMALL + GRML_FULL

### DIFF
--- a/config/package_config/GRML_FULL
+++ b/config/package_config/GRML_FULL
@@ -261,6 +261,7 @@ cu
 minicom
 setserial
 statserial
+tio
 
 # shell
 bash

--- a/config/package_config/GRML_SMALL
+++ b/config/package_config/GRML_SMALL
@@ -124,6 +124,7 @@ zstd
 cu
 setserial
 statserial
+tio
 
 # shell
 bash


### PR DESCRIPTION
tio is a simple TTY terminal I/O application, requires ~250kB on grml-full and 829 kB (with liblua5.4-0) on grml-small.

Thanks: Martin Karresand for the suggestion