### PR TITLE
autoconfig: remove reference to grml-swapon

### DIFF
--- a/config/files/GRMLBASE/usr/share/grml-autoconfig/autoconfig.functions
+++ b/config/files/GRMLBASE/usr/share/grml-autoconfig/autoconfig.functions
@@ -430,7 +430,7 @@ if [ -z "$INSTALLED" ] ; then
         case "$f" in swap)
           eindent
           if [ -n "$NOSWAP" ]; then
-             ewarn "Ignoring swap partition ${WHITE}$p${NORMAL}. (Force usage via boot option 'swap', or execute grml-swapon)"
+             ewarn "Ignoring swap partition ${WHITE}$p${NORMAL}. (Force usage via boot option 'swap', or use swapon)"
              eend 0
           else
              case "$(dd if="$p" bs=1 count=6 skip=4086 2>/dev/null)" in


### PR DESCRIPTION
Removed in grml/grml-scripts@215cc67a523b920f8f31cf0d1b36c481f42bfe41

See https://github.com/grml/grml-scripts/issues/27