### PR TITLE
grml.sources snapshot: disable

### DIFF
--- a/config/files/GRMLBASE/etc/apt/sources.list.d/grml.sources
+++ b/config/files/GRMLBASE/etc/apt/sources.list.d/grml.sources
@@ -3,4 +3,5 @@ URIs: http://deb.grml.org
 Suites: grml-stable grml-live grml-testing
 Components: main
 Enabled: yes
+Snapshot: disable
 Signed-By: /usr/share/keyrings/grml-archive-keyring.gpg


### PR DESCRIPTION
* ref: https://bugs.debian.org/1106576 & grml/grml-keyring@c6bc4a0