### PR TITLE
Stop symlinking /etc/locale.alias

### DIFF
--- a/config/scripts/GRMLBASE/25-locales
+++ b/config/scripts/GRMLBASE/25-locales
@@ -30,7 +30,6 @@ set -u
 
    # restore *empty* directories because otherwise installation/upgrade of packages might fail
    [ -d "$target"/usr/share/locale ] || mkdir "$target"/usr/share/locale
-   $ROOTCMD ln -s /etc/locale.alias /usr/share/locale/locale.alias
 
    # make sure the directories of removed locales exist; ugly hack but no other solution present :(
    echo 'Creating empty /usr/share/locale/*/LC_MESSAGES directories'


### PR DESCRIPTION
Follow Debian glibc 2.42-1, see Debian bug #1095101

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1095101