### PR TITLE
SW: add systemd-boot-tools to GRML_SMALL + GRML_FULL

### DIFF
--- a/config/package_config/GRML_FULL
+++ b/config/package_config/GRML_FULL
@@ -74,6 +74,7 @@ kpartx
 mbr
 partclone
 parted
+systemd-boot-tools
 
 # disk wiping
 nwipe

--- a/config/package_config/GRML_SMALL
+++ b/config/package_config/GRML_SMALL
@@ -41,6 +41,7 @@ smartmontools
 kpartx
 mbr
 parted
+systemd-boot-tools
 
 # disk wiping
 nwipe


### PR DESCRIPTION
systemd-boot-tools provides the bootctl tool, which serves to be useful for fixing systemd-boot setups.

Requires only 212kb of disk space on.

See https://github.com/orgs/grml/discussions/255