### PR TITLE
grml-autoconfig _detect_virtual: prefer Virtualbox over KVM in virt-what

### DIFF
--- a/config/files/GRMLBASE/usr/share/grml-autoconfig/autoconfig.functions
+++ b/config/files/GRMLBASE/usr/share/grml-autoconfig/autoconfig.functions
@@ -123,8 +123,8 @@ _detect_virtual() {
   virt_what_result=$(virt-what 2>/dev/null)
   case "$virt_what_result" in
     *vmware*) VIRTUAL=true; VMWARE=true; VIRTUAL_ENV='VMware' ;;
-    *kvm*) VIRTUAL=true; KVM=true; VIRTUAL_ENV='KVM' ;;
     *virtualbox*) VIRTUAL=true; VIRTUALBOX=true; VIRTUAL_ENV='VirtualBox' ;;
+    *kvm*) VIRTUAL=true; KVM=true; VIRTUAL_ENV='KVM' ;;
   esac
   if [ -z "$VIRTUAL" ]; then
     # imvirt is slow. do not use it, if virt-what already found the hypervisor.


### PR DESCRIPTION
virt-what v1.27-1 as present in Debian/trixie might return both virtualbox *and* kvm when being invoked inside a VirtualBox VM (v7.1.12-dfsg-2 on Debian/trixie with kernel 6.12.43+deb13-amd64):

```
  # virt-what --version
  1.27

  # virt-what
  virtualbox
  kvm
```

virt-what reads `/sys/firmware/dmi/tables/DMI` to properly identify VirtualBox, but also executes `/usr/libexec/virt-what-cpuid-helper`, which reports `KVMKVMKVM`, and therefore seems to report both of them.

We don't have any actual automation for KVM usage, while all the VirtualBox support (e.g. for shared folders) isn't executed, because its reported as KVM VM, instead of VirtualBox. Adjust order of virt-what check accordingly to fix this.