### PR TITLE
build-driver: remove SNAPSHOT

### DIFF
--- a/build-driver/build.py
+++ b/build-driver/build.py
@@ -358,7 +358,7 @@ def main(program_name: str, argv: list[str]) -> int:
             flavor = argv.pop(0)
             arch = argv.pop(0)
             debian_suite = ""  # filled from config
-            classes_for_mode = ["SNAPSHOT", "NO_ONLINE"]
+            classes_for_mode = ["NO_ONLINE"]
             upload_to_daily = False
 
         elif build_mode == "daily":


### PR DESCRIPTION
Apparently useless since dfb358d88e061165bcebb281502934ad2e609f56.

Noticed via a comment from @anarcat on IRC.