### PR TITLE
GRML_SMALL add fping to network utilities

### DIFF
--- a/config/package_config/GRML_SMALL
+++ b/config/package_config/GRML_SMALL
@@ -77,6 +77,7 @@ mmdebstrap
 atftp
 bridge-utils
 ethtool
+fping
 ifenslave
 ifupdown
 iperf3


### PR DESCRIPTION
 * fping: sends ICMP ECHO_REQUEST packets to network hosts

- it shouldn't take up too much space

> apt show fping |grep Installed-Size
Installed-Size: 95.2 kB

- doesn't pull in any other stuff

> root@grml-fork-small ~ # apt --simulate install fping
> Installing:
  fping
> Summary:
  Upgrading: 0, Installing: 1, Removing: 0, Not Upgrading: 0
Inst fping (5.1-1 Debian:testing [amd64])
Conf fping (5.1-1 Debian:testing [amd64])


just an idea or better for GRML_FULL? but there will be another pr for oping in GRML_FULL which also comes with a fancy tui.