### PR TITLE
SW: GRML_FULL: remove mpt-status

### DIFF
--- a/config/package_config/GRML_FULL
+++ b/config/package_config/GRML_FULL
@@ -56,7 +56,6 @@ fio
 gdisk
 iotop
 lsscsi
-mpt-status
 multipath-tools
 ncdu
 nocache


### PR DESCRIPTION
mpt-status is unmaintained in Debian and was removed from testing.