### PR TITLE
SW: drop grml-desktop from XORG

### DIFF
--- a/config/package_config/XORG
+++ b/config/package_config/XORG
@@ -12,8 +12,6 @@ xserver-xorg-video-all
 fluxbox
 # generate X configuration:
 grml-x
-# configuration for several window managers:
-grml-desktop
 # osd_cat:
 xosd-bin
 # Esetroot:


### PR DESCRIPTION
grml-desktop went into grml-live (see
commit 83683d3edfe8b3c7391034297d23ff60610ec14b),
and is no longer maintained, and might even
cause package installation failures like
with /etc/skel/.xinitrc:

```
  *** .xinitrc (Y/I/N/O/D/Z) [default=N] ? dpkg: error processing package grml-desktop (--configure): end of file on stdin at conffile prompt
```