### PR TITLE
SW: add firmware-mediatek to GRMLBASE

### DIFF
--- a/config/package_config/GRMLBASE
+++ b/config/package_config/GRMLBASE
@@ -65,6 +65,7 @@ firmware-libertas
 firmware-linux
 firmware-linux-free
 firmware-linux-nonfree
+firmware-mediatek
 firmware-misc-nonfree
 firmware-myricom
 firmware-netxen


### PR DESCRIPTION
F.e. some Tuxedo systems come with mediatek WiFi devices, so make sure we have working network on such hardware.

Thanks: Helmut Grohne for bringing this to our attention