### PR TITLE
Fix squashfs exclude usage for grml-live directory

### DIFF
--- a/config/grml/squashfs-excludes
+++ b/config/grml/squashfs-excludes
@@ -3,3 +3,4 @@ run/*
 var/run/*
 var/lock/*
 var/lib/dkms/*
+grml-live/*

--- a/grml-live
+++ b/grml-live
@@ -834,12 +834,10 @@ else
    # 1) leaking containerization supplied selinux attributes into the squashfs,
    # 2) prevents unpacking errors in a later build-only step in containers not supporting xattrs.
    SQUASHFS_OPTIONS="$SQUASHFS_OPTIONS -no-xattrs"
-   # Ignore build directory inside chroot.
-   SQUASHFS_OPTIONS="$SQUASHFS_OPTIONS -e grml-live/*"
 
    # support exclusion of files via exclude-file:
-   if [ -n "$SQUASHFS_EXCLUDES_FILE" ] && [ "$SQUASHFS_EXCLUDES_FILE" ] ; then
-      SQUASHFS_OPTIONS="$SQUASHFS_OPTIONS -ef $SQUASHFS_EXCLUDES_FILE -wildcards"
+   if [ -n "${SQUASHFS_EXCLUDES_FILE}" ] && [ -r "${SQUASHFS_EXCLUDES_FILE}" ] ; then
+     SQUASHFS_OPTIONS="${SQUASHFS_OPTIONS} -wildcards -ef ${SQUASHFS_EXCLUDES_FILE}"
    fi
 
    # log stuff


### PR DESCRIPTION
The /grml-live/* files end up in the Grml ISO, providing:

* /grml-live/media/ with EFI, GRML, boot + conf directories, and files autorun.inf, cdrom.ico

* /grml-live/netboot with "tftpboot" and all the GRUB/pxelinux/kernel/initrd files

* /grml-live/tools/ with scripts grml-live-adjust-boot-files + grml-live-copy-file-logged

Those are files that are prepared for usage on the ISO, and given that they are present in the squashfs already, they don't add that much to the squashfs file size overall, but it's still unexpected and doesn't make much sense to ship as such.

We even tried to explicitly exclude it, but this didn't work as expected. Instead, drop the hardcoded usage via SQUASHFS_OPTIONS and instead handle it within the existing SQUASHFS_EXCLUDES_FILE file (enabled by default as such), and adjust its usage by enabling the "-wildcards" option also.