### PR TITLE
Fix output directory handling if base directory doesn't exist

### DIFF
--- a/grml-live
+++ b/grml-live
@@ -252,7 +252,7 @@ while getopts "a:C:c:d:D:e:g:i:I:o:r:s:S:t:U:v:w:AbBFhnNqQRuVz" opt; do
     I) CHROOT_INSTALL="$OPTARG" ;;
     n) SKIP_MKISOFS=1 ;;
     N) BOOTSTRAP_ONLY=1; SKIP_MKISOFS=1; SKIP_MKSQUASHFS=1 ;;
-    o) OUTPUT="$(readlink -f "$OPTARG")" ;;
+    o) OUTPUT="$(readlink -m "$OPTARG")" ;;
     q) SKIP_MKSQUASHFS=1 ;;
     Q) SKIP_NETBOOT=1 ;;
     r) RELEASENAME="$OPTARG" ;;


### PR DESCRIPTION
When invoking grml-live with `-o /srv/grml-live/grml64-mika_2025.11-1`, while `/srv/grml-live/` doesn't exist yet, we end up with the current working directory plus "grml" as its output directory instead of the requested `/srv/grml-live/grml64-mika_2025.11-1`. This is unexpected behavior.

Fix by using `readlink -m` instead of `readlink -f`. see readlink(1):

```
  % MANWIDTH=72 man readlink | sed -n '/--canonicalize/,/^$/p'
       -f, --canonicalize
              canonicalize  by  following every symlink in every compo‐
              nent of the given name recursively; all but the last com‐
              ponent must exist

       -e, --canonicalize-existing
              canonicalize by following every symlink in  every  compo‐
              nent  of  the given name recursively, all components must
              exist

       -m, --canonicalize-missing
              canonicalize by following every symlink in  every  compo‐
              nent  of the given name recursively, without requirements
              on components existence
```

Closes: https://github.com/grml/grml-live/issues/448