### PR TITLE
SW: drop flashrom package from GRML_FULL

### DIFF
--- a/config/package_config/GRML_FULL
+++ b/config/package_config/GRML_FULL
@@ -280,7 +280,6 @@ zsh
 
 # system info/mgmt
 augeas-tools
-flashrom
 inxi
 memtester
 stressant


### PR DESCRIPTION
`CONFIG_IO_STRICT_DEVMEM` is enabled by default on Debian kernels, so access to `/dev/mem` is no longer available as it used to be.

Only via kernel option iomem=relaxed it *could* work, though flashrom shouldn't have any real use-case on Grml, esp. now that e.g. fwupd exists.

FTR, removing it frees ~1.107 of disk space.

Closes: https://github.com/grml/grml-kernel/issues/1