### PR TITLE
9p virtio: do not complain if mount_tag doesn't exist

### DIFF
--- a/config/files/GRMLBASE/usr/share/grml-autoconfig/autoconfig.functions
+++ b/config/files/GRMLBASE/usr/share/grml-autoconfig/autoconfig.functions
@@ -37,7 +37,7 @@ if [ -z "$CMDLINE" ]; then
   CMDLINE="$(< /proc/cmdline)"
   [ -d "${LIVECD_PATH}/bootparams/" ] && CMDLINE="$CMDLINE $(cat "${LIVECD_PATH}"/bootparams/* | tr '\n' ' ')"
   TAG="grml-parameters"
-  if grep -q "$TAG" /sys/bus/virtio/devices/*/mount_tag 2>/dev/null ; then
+  if grep -q "$TAG" /sys/bus/virtio/devices/*/mount_tag &>/dev/null ; then
     MOUNTDIR="$(mktemp -d)"
     mount -t 9p -o trans=virtio,ro "$TAG" "$MOUNTDIR"
     CMDLINE="$CMDLINE $(cat "$MOUNTDIR"/* 2>/dev/null | tr '\n' ' ')"


### PR DESCRIPTION
We try to read bootparameters from 9p virtio filesystem, though if none are configured/present, sourcing
/usr/share/grml-autoconfig/autoconfig.functions complains with:

```
  /usr/share/grml-autoconfig/autoconfig.functions:40: no matches found: /sys/bus/virtio/devices/*/mount_tag
```

Spotted while debugging something else. :)