### PR TITLE
grub: limit default max resolution

### DIFF
--- a/config/media-files/GRMLBASE/boot/grub/header.cfg
+++ b/config/media-files/GRMLBASE/boot/grub/header.cfg
@@ -3,7 +3,8 @@ set timeout=20
 
 if loadfont unicode ; then
    insmod png
-   set gfxmode=auto
+   # Default to a "small" resolution to avoid completely unreadable high-res modes.
+   set gfxmode=1280x1024,1024x768,auto
  
    if [ "${grub_platform}" == "efi" ] ; then
      insmod efi_gop


### PR DESCRIPTION
To improve readability on displays with high resolutions (2k or higher).

Closes grml/grml#263