### PR TITLE
Add virtio_gpu to initramfs for proper console on arm64 in libvirt/qemu

### DIFF
--- a/config/files/GRMLBASE/usr/share/initramfs-tools/hooks/virtio-gpu
+++ b/config/files/GRMLBASE/usr/share/initramfs-tools/hooks/virtio-gpu
@@ -1,0 +1,27 @@
+#!/bin/sh
+# This file was deployed via grml-live's
+# ${GRML_FAI_CONFIG}/scripts/GRMLBASE/80-initramfs script, using
+# ${GRML_FAI_CONFIG}/files/GRMLBASE/usr/share/initramfs-tools/hooks/virtio-gpu
+#
+# Purpose: hook for adding virtio_gpu module to initramfs
+
+set -e
+
+# initramfs-tools header
+
+PREREQ=""
+prereqs()
+{
+        echo "${PREREQ}"
+}
+
+case "${1}" in
+        prereqs)
+                prereqs
+                exit 0
+                ;;
+esac
+
+. /usr/share/initramfs-tools/hook-functions
+
+manual_add_modules virtio_gpu

--- a/config/scripts/GRMLBASE/80-initramfs
+++ b/config/scripts/GRMLBASE/80-initramfs
@@ -14,6 +14,8 @@ target=${target:?}
 
 fcopy -M -v /etc/initramfs-tools/conf.d/xz-compress
 
+fcopy -m root,root,0755 -v /usr/share/initramfs-tools/hooks/virtio-gpu
+
 if ! [ -f "$target"/usr/share/initramfs-tools/scripts/live ] ; then
   echo "Error: live-boot/-initramfs does not seem to be present, can not create initramfs. Exiting.">&2
   exit 1


### PR DESCRIPTION
When booting arm64 in libvirt with its aarch64 (qemu-system-aarch64) [...], it by default seems to run qemu with something like:

```
  -device {"driver":"virtserialport","bus":"virtio-serial0.0","nr":1,"chardev":"charchannel0","id":"channel0","name":"org.qemu.guest_agent.0"}
  -device {"driver":"virtio-gpu-pci","id":"video0","max_outputs":1,"bus":"pci.8","addr":"0x0"}
```

By default no output during bootup is visible ("Display output is not active") until grml-quickconfig starts up. By adding boot options "console=ttyAMA0 console=tty0" the usual boot process is visible, but we get plenty of:

```
 setfont: ERROR kdfontop.c:212 put_font_kdfontop: Unable to load such font with such kernel version
```

... messages during bootup (after our 'Write settings for language [...] into /etc/default/locale.')

By adding the virtio_gpu to the initramfs, the boot process looks as expected.

FTR: this adds gpu/drm/virtio/virtio-gpu.ko.xz + its dependency virtio/virtio_dma_buf.ko.xz (all the other dependencies are already there) with ~60KB to the initramfs.