### PR TITLE
GRUB: adjust loadfont usage for Secure Boot mode

### DIFF
--- a/config/media-files/GRMLBASE/boot/grub/header.cfg
+++ b/config/media-files/GRMLBASE/boot/grub/header.cfg
@@ -1,7 +1,7 @@
 set default=0
 set timeout=20
 
-if loadfont /boot/grub/unicode.pf2 ; then
+if loadfont unicode ; then
    insmod png
    set gfxmode=auto
    insmod gfxterm


### PR DESCRIPTION
With "loadfont /boot/grub/unicode2.pf2" it fails in Secure Boot mode with:

```
  error: prohibited by secure boot policy
```

As a result we don't get our nice graphical boot splash with gfxterm, but end up in the console based fallback menu.

While loadfont prevents loading of specific font files in Secure Boot mode, loading its included unicode font works.