### PR TITLE
build-driver/build disable apt script warning

### DIFF
--- a/build-driver/build
+++ b/build-driver/build
@@ -9,6 +9,6 @@ set -x
 GRML_LIVE_PATH=$1
 PYTHONPATH="$GRML_LIVE_PATH"/build-driver
 echo -e "\e[0Ksection_start:$(date +%s):startupdeps[collapsed=true]\r\e[0KInstall dependencies for build.py"
-apt satisfy -q -y --no-install-recommends -o Dpkg::Options::=--force-confnew 'python3-minimal, python3-yaml'
+apt -oapt::cmd::disable-script-warning=1 satisfy -q -y --no-install-recommends -o Dpkg::Options::=--force-confnew 'python3-minimal, python3-yaml'
 echo -e "\e[0Ksection_end:$(date +%s):startupdeps\r\e[0K"
 exec "$PYTHONPATH"/build.py "$@"


### PR DESCRIPTION
Get rid of the WARNING
```
% podman run --rm -v "$PWD:/workspace" grml-live:latest build daily $PWD/output full amd64 testing
+ GRML_LIVE_PATH=/opt/grml-live
+ PYTHONPATH=/opt/grml-live/build-driver
++ date +%s
+ echo -e '\e[0Ksection_start:1766226652:startupdeps[collapsed=true]\r\e[0KInstall dependencies for build.py'
Install dependencies for build.py
+ apt satisfy -q -y --no-install-recommends -o Dpkg::Options::=--force-confnew 'python3-minimal, python3-yaml'

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
```
