### PR TITLE
SW: remove duplicated grub-pc-bin from GRML_FULL

### DIFF
--- a/config/package_config/GRML_FULL
+++ b/config/package_config/GRML_FULL
@@ -352,8 +352,6 @@ cpuid
 memtest86+
 # broken userland debugging
 ltrace
-# disk partitioning/boot
-grub-pc-bin
 
 # PXE boot
 grml-terminalserver
@@ -376,8 +374,6 @@ cpuid
 memtest86+
 # broken userland debugging
 ltrace
-# disk partitioning/boot
-grub-pc-bin
 
 # PXE boot
 grml-terminalserver


### PR DESCRIPTION
Already in GRMLBASE as a dependency of grub-pc.

Was part of #459, but can be done immediately.