### PR TITLE
grub: install unicode2.pf into correct place

### DIFF
--- a/config/media-scripts/GRMLBASE/31-grub
+++ b/config/media-scripts/GRMLBASE/31-grub
@@ -57,7 +57,8 @@ elif [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "i386" ] ; then
 fi
 
 # arch independent files
-cp -a "${target}"/usr/share/grub/unicode.pf2   "${media_dir}"/boot/grub/
+mkdir -p "${media_dir}"/boot/grub/fonts/
+cp -a "${target}"/usr/share/grub/unicode.pf2   "${media_dir}"/boot/grub/fonts/
 
 # adjust all variables in the templates with the according distribution information
 grml-live-adjust-boot-files "${media_dir}"/boot/grub/*


### PR DESCRIPTION
Fixes https://github.com/grml/grml-live/issues/472

Probably broken by da51d6b2fa9992568939e00af0c614c074c7109b