### PR TITLE
Remove wm-ng (fluxbox wrapper) leftovers

### DIFF
--- a/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt
+++ b/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt
@@ -171,7 +171,6 @@ grml welcome                          Welcome message via soundoutput
 grml noeject                          Do NOT eject CD after halt/reboot
 grml noprompt                         Do NOT prompt to remove the CD when halting/rebooting the system
 grml startx{=windowmanager}           Start X window system automatically
-                                      Default window manager (if not provided): wm-ng (wrapper around fluxbox)
 grml nostartx                         If using startx as default bootoption the nostartx *disables* automatic
                                       startup of X again. (This bootoption is relevant for grml based derivatives
                                       which decide to enable startx by default only, plain grml does not use

--- a/config/scripts/GRMLBASE/90-update-alternatives
+++ b/config/scripts/GRMLBASE/90-update-alternatives
@@ -65,11 +65,6 @@ if $ROOTCMD update-alternatives --list www-browser 2>/dev/null | grep -q '/w3m' 
   $ROOTCMD update-alternatives --set www-browser /usr/bin/w3m
 fi
 
-if $ROOTCMD update-alternatives --list x-window-manager 2>/dev/null | grep -q '/wm-ng' ; then
-  echo "Setting wm-ng as x-window-manager using update-alternatives."
-  $ROOTCMD update-alternatives --set x-window-manager /usr/bin/wm-ng
-fi
-
 # sadly isn't available via update-alternates, anyway - use
 # ntfs-3g (if available) as default for ntfs
 if [ -r "$target"/sbin/mount.ntfs-3g ] || [ -L "$target"/sbin/mount.ntfs-3g ] ; then


### PR DESCRIPTION
Removed in commit grml/grml-scripts@2f61167e819df4fbb3dce0761e657d25ebb9834d in 2011.