### PR TITLE
SW: drop grml-paste

### DIFF
--- a/config/package_config/GRML_FULL
+++ b/config/package_config/GRML_FULL
@@ -1,7 +1,6 @@
 PACKAGES install
 
 grml-live
-grml-paste
 grml-quickconfig-standard
 
 # base os

--- a/config/package_config/GRML_SMALL
+++ b/config/package_config/GRML_SMALL
@@ -1,6 +1,5 @@
 PACKAGES install
 
-grml-paste
 grml-quickconfig-standard
 
 # base os


### PR DESCRIPTION
To keep daily images buildable until a solution for grml-paste can be found. See Debian bug #1124076 https://bugs.debian.org/1124076