### PR TITLE
Use en_DK.UTF-8 as new default for LC_TIME

### DIFF
--- a/config/files/GRMLBASE/usr/share/grml-autoconfig/language-functions
+++ b/config/files/GRMLBASE/usr/share/grml-autoconfig/language-functions
@@ -131,12 +131,11 @@ case "$LANGUAGE" in
                 XKBVARIANT="dvorak"
                 ;;
         en|en-utf8)
-                # English in Austria [see us + uk for american and english version!]
+                # "Grml english" AKA defaults (see us + uk for plain american and english versions)
                 LANG="en_US.UTF-8"
                 LANGUAGE="en"
                 XKBLAYOUT="us"
-                LC_COLLATE="de_AT.UTF-8"
-                LC_TIME="de_AT.UTF-8"
+                LC_TIME="en_DK.UTF-8"
                 ;;
         el|el-utf8)
                 # Greek


### PR DESCRIPTION
At the last Grml dev meeting, we agreed to change LC_TIME to "en_DK.UTF-8" for our default language setting (AKA en / en-utf8).  This should avoid further surprises with a mix of english and german locales, while still providing good defaults, also see https://github.com/grml/grml/issues/265

While at it, no longer explicitly set LC_COLLATE.

Closes: grml/grml/issues/276