### PR TITLE
grub: drop loading of efi_uga module

### DIFF
--- a/config/media-files/GRMLBASE/boot/grub/header.cfg
+++ b/config/media-files/GRMLBASE/boot/grub/header.cfg
@@ -6,7 +6,6 @@ if loadfont unicode ; then
    set gfxmode=auto
 
    insmod efi_gop
-   insmod efi_uga
    insmod vbe
    # insmod vga  # disabled "vga", its way too slow for graphics mode.
    insmod video_bochs


### PR DESCRIPTION
Long deprecated, and was finally removed from grub 2.14-2, see https://tracker.debian.org/news/1715036/accepted-grub2-214-2-source-into-unstable/ and https://www.phoronix.com/news/Linux-6.14-EFI

Commit 1c456802a1e70757250d39a91c78dadadffaf11d stopped including it in our custom-built grub images.