### PR TITLE
DHCP client: use hardware/ethernet address as identification

### DIFF
--- a/config/files/GRMLBASE/etc/dhcpcd.conf
+++ b/config/files/GRMLBASE/etc/dhcpcd.conf
@@ -1,0 +1,49 @@
+# This file was deployed via grml-live's
+# ${GRML_FAI_CONFIG}/scripts/GRMLBASE/45-networking script, using
+# ${GRML_FAI_CONFIG}/files/GRMLBASE/etc/dhcpcd.conf
+# GRML-specific changes: use hardware address to construct DHCPv4
+# identification and SLAAC addresses. DUIDs rely on on-disk storage,
+# which is not available for Live ISO boots.
+
+# See dhcpcd.conf(5) for details.
+
+# Allow users of this group to interact with dhcpcd via the control socket.
+#controlgroup wheel
+
+# Inform the DHCP server of our hostname for DDNS.
+hostname
+
+# Use the hardware address of the interface for the Client ID.
+clientid
+# or
+# Use the same DUID + IAID as set in DHCPv6 for DHCPv4 ClientID as per RFC4361.
+# Some non-RFC compliant DHCP servers do not reply with this set.
+# In this case, comment out duid and enable clientid above.
+#duid
+
+# Persist interface configuration when dhcpcd exits.
+persistent
+
+# vendorclassid is set to blank to avoid sending the default of
+# dhcpcd-<version>:<os>:<machine>:<platform>
+vendorclassid
+
+# A list of options to request from the DHCP server.
+option domain_name_servers, domain_name, domain_search
+option static_routes, classless_static_routes
+# Respect the network MTU. This is applied to DHCP routes.
+option interface_mtu
+
+# Request a hostname from the network
+option host_name
+
+# Most distributions have NTP support.
+option ntp_servers
+
+# A ServerID is required by RFC2131.
+require dhcp_server_identifier
+
+# Generate SLAAC address using the Hardware Address of the interface
+slaac hwaddr
+# OR generate Stable Private IPv6 Addresses based from the DUID
+#slaac private

--- a/config/scripts/GRMLBASE/35-network
+++ b/config/scripts/GRMLBASE/35-network
@@ -9,6 +9,7 @@
 set -u
 set -e
 
+fcopy -M -v /etc/dhcpcd.conf
 fcopy -M -v /etc/exports.grml
 fcopy -M -v /etc/network/interfaces
 fcopy -M -v /etc/network/interfaces.examples


### PR DESCRIPTION
The default of using DUIDs would require on-disk storage for stable IP addresses, but obviously that does not exist for Live ISO boots. Use the hardware address for both DHCPv4 and for SLAAC (IPv6).