### PR TITLE
/etc/locale.gen: add en_DK.UTF-8 as used within our default locales

### DIFF
--- a/config/files/GRMLBASE/etc/locale.gen
+++ b/config/files/GRMLBASE/etc/locale.gen
@@ -15,10 +15,11 @@
 # change this file without affecting the use of debconf, however, since it
 # does read in your changes.
 
-# Locales for languages supported by grml-lang
+# Locales for languages supported by grml-lang or used on live system
 de_AT.UTF-8 UTF-8
 de_CH.UTF-8 UTF-8
 de_DE.UTF-8 UTF-8
+en_DK.UTF-8 UTF-8
 en_GB.UTF-8 UTF-8
 en_US.UTF-8 UTF-8
 es_ES.UTF-8 UTF-8


### PR DESCRIPTION
We use LC_TIME="en_DK.UTF-8" in our default locales, so the according locales need to be present on the live system. Followup fix for commit b4bfd616e023fbe082fea992a92443a9585b5e69

Thanks to @crpb  for reporting