### PR TITLE
grub: load video modules only on platforms where they exist

### DIFF
--- a/config/media-files/GRMLBASE/boot/grub/header.cfg
+++ b/config/media-files/GRMLBASE/boot/grub/header.cfg
@@ -4,12 +4,19 @@ set timeout=20
 if loadfont unicode ; then
    insmod png
    set gfxmode=auto
-
-   insmod efi_gop
-   insmod vbe
-   # insmod vga  # disabled "vga", its way too slow for graphics mode.
-   insmod video_bochs
-   insmod video_cirrus
+ 
+   if [ "${grub_platform}" == "efi" ] ; then
+     insmod efi_gop
+   fi
+   if [ "${grub_platform}" == "pc" ] ; then
+     # x86 BIOS boot only
+     insmod vbe
+   fi
+   if [ "${grub_cpu}" != "arm64" ] ; then
+     # x86 only
+     insmod video_bochs
+     insmod video_cirrus
+   fi
 
    insmod gfxterm
    terminal_output gfxterm


### PR DESCRIPTION
All boot modes currently complain about some video modules missing, and this also slows down initial grub startup, because the error messages are printed using slow video primitives.

Example on x86 UEFI boot:
```
error: ../../../grub-core/fs/fshelp.c:260:file `/boot/grub/x86_64-efi/vbe.mod' not found.
```