### PR TITLE
Import caps-ctrl script from grml-scripts

### DIFF
--- a/config/files/GRMLBASE/usr/bin/caps-ctrl
+++ b/config/files/GRMLBASE/usr/bin/caps-ctrl
@@ -1,0 +1,78 @@
+#!/bin/zsh
+# Filename:      caps-ctrl
+# Purpose:       switch caps to control key and vice versa for linux console and X
+# Authors:       grml-team (grml.org),  (c) Matthias Kopfermann <maddi@grml.org>
+# Bug-Reports:   see http://grml.org/bugs/
+# License:       This file is licensed under the GPL v2.
+################################################################################
+
+if [[ -f /etc/grml/script-functions ]] ; then
+	source /etc/grml/script-functions && \
+   	check4progs xmodmap loadkeys dumpkeys || exit 1
+fi
+if [[ -f /etc/grml/lsb-functions ]] ; then
+	source /etc/grml/lsb-functions
+else
+	einfo() { echo  "$*" ; }
+	eerror() { echo "$*" ; }
+	eend() { echo "$*" ; }
+fi
+
+emulate zsh
+
+if [[ -z $DISPLAY  ]] ; then # test if X is not running when calling us
+         if [ $(id -u) != 0 ] ; then # test if user root did invoke this command
+            eerror "As of Linux 2.6.15 you need root permissions for changing"
+            eerror "the keyboard on console using loadkeys for security reasons."
+            eerror "Run this program with root permissions. Exiting." ; eend 1
+            exit 1
+         fi
+         dumpkeys | grep -q '^keycode  58 = Caps_Lock' && \
+         ( einfo "caps-ctrl - switching caps lock and control key."
+
+           loadkeys <<- EOT
+           keycode 58 = $(repeat 15 echo -n 'Control ')
+           keycode 29 = $(repeat 7 echo -n 'Caps_Lock ')
+		EOT
+           eend $?
+
+        ) || (
+          einfo "caps-ctrl - switching caps lock and control key."
+
+           loadkeys <<- EOT
+           keycode 58 = $(repeat 15 echo -n 'Caps_Lock ')
+           keycode 29 = $(repeat 7 echo -n 'Control ')
+		EOT
+           eend $?
+         )
+
+else     # running under X
+        (
+        einfo "caps-ctrl - switching caps lock and control key."
+        einfo "If you notice errors, please make sure the xmodmap you have is right"
+        einfo "or use e.g. \"setxkbmap us\" beforehand."
+        xmodmap -pke | grep 'Caps_Lock' > /dev/null || (
+        xmodmap - <<- EOT
+        keycode 66 = Caps_Lock
+		EOT
+        )
+
+        xmodmap - <<- EOT
+        remove Lock = Caps_Lock
+        remove Control = Control_L
+        !remove Control = Control_R
+
+        keysym Control_L = Caps_Lock
+        keysym Caps_Lock = Control_L
+        !keysym Control_R = Caps_Lock
+        !keysym Caps_Lock = Control_R
+
+        add lock = Caps_Lock
+        add Control = Control_L
+        !add Control = Control_R
+		EOT
+        eend $?
+        )
+fi # end of test if X or console is used
+
+## END OF FILE #################################################################

--- a/config/files/GRMLBASE/usr/bin/caps-ctrl
+++ b/config/files/GRMLBASE/usr/bin/caps-ctrl
@@ -6,10 +6,36 @@
 # License:       This file is licensed under the GPL v2.
 ################################################################################
 
-if [[ -f /etc/grml/script-functions ]] ; then
-	source /etc/grml/script-functions && \
-   	check4progs xmodmap loadkeys dumpkeys || exit 1
-fi
+check4progs() {
+	local RTN=0
+	local oldifs="${IFS}"
+	local ARG d found
+
+	while [ $# -gt 0 ]; do
+		ARG="$1"
+		shift
+
+		found=0
+		IFS=:
+		for d in $PATH; do
+			if [ -x "${d}/${ARG}" ]; then
+				found=1
+				break
+			fi
+		done
+		IFS="${oldifs}"
+
+		if [ ${found} -eq 0 ]; then
+			printf "%s: binary not found\n" "${ARG}" >&2
+			RTN=1
+		fi
+	done
+
+	return $RTN
+}
+
+check4progs xmodmap loadkeys dumpkeys || exit 1
+
 if [[ -f /etc/grml/lsb-functions ]] ; then
 	source /etc/grml/lsb-functions
 else

--- a/config/files/GRMLBASE/usr/bin/caps-ctrl
+++ b/config/files/GRMLBASE/usr/bin/caps-ctrl
@@ -37,30 +37,26 @@ check4progs() {
 check4progs xmodmap loadkeys dumpkeys || exit 1
 
 if [[ -z $DISPLAY  ]] ; then # test if X is not running when calling us
-         if [ $(id -u) != 0 ] ; then # test if user root did invoke this command
+         if [ "$(id -u)" != 0 ] ; then # test if user root did invoke this command
             echo "As of Linux 2.6.15 you need root permissions for changing"
             echo "the keyboard on console using loadkeys for security reasons."
             echo "Run this program with root permissions. Exiting."
             exit 1
          fi
-         dumpkeys | grep -q '^keycode  58 = Caps_Lock' && \
-         ( echo "caps-ctrl - switching caps lock and control key."
-
+         echo "caps-ctrl - switching caps lock and control key."
+         if dumpkeys | grep -q '^keycode  58 = Caps_Lock' ; then
            loadkeys <<- EOT
            keycode 58 = $(printf 'Control %.0s' {1..15})
            keycode 29 = $(printf 'Caps_Lock %.0s' {1..7})
 		EOT
-        ) || (
-          echo "caps-ctrl - switching caps lock and control key."
-
+         else
            loadkeys <<- EOT
            keycode 58 = $(printf 'Caps_Lock %.0s' {1..15})
            keycode 29 = $(printf 'Control %.0s' {1..7})
 		EOT
-         )
+         fi
 
 else     # running under X
-        (
         echo "caps-ctrl - switching caps lock and control key."
         echo "If you notice errors, please make sure the xmodmap you have is right"
         echo "or use e.g. \"setxkbmap us\" beforehand."
@@ -68,7 +64,6 @@ else     # running under X
         xmodmap - <<- EOT
         keycode 66 = Caps_Lock
 		EOT
-        )
 
         xmodmap - <<- EOT
         remove Lock = Caps_Lock

--- a/config/files/GRMLBASE/usr/bin/caps-ctrl
+++ b/config/files/GRMLBASE/usr/bin/caps-ctrl
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/bash
 # Filename:      caps-ctrl
 # Purpose:       switch caps to control key and vice versa for linux console and X
 # Authors:       grml-team (grml.org),  (c) Matthias Kopfermann <maddi@grml.org>
@@ -18,8 +18,6 @@ else
 	eend() { echo "$*" ; }
 fi
 
-emulate zsh
-
 if [[ -z $DISPLAY  ]] ; then # test if X is not running when calling us
          if [ $(id -u) != 0 ] ; then # test if user root did invoke this command
             eerror "As of Linux 2.6.15 you need root permissions for changing"
@@ -31,8 +29,8 @@ if [[ -z $DISPLAY  ]] ; then # test if X is not running when calling us
          ( einfo "caps-ctrl - switching caps lock and control key."
 
            loadkeys <<- EOT
-           keycode 58 = $(repeat 15 echo -n 'Control ')
-           keycode 29 = $(repeat 7 echo -n 'Caps_Lock ')
+           keycode 58 = $(printf 'Control %.0s' {1..15})
+           keycode 29 = $(printf 'Caps_Lock %.0s' {1..7})
 		EOT
            eend $?
 
@@ -40,8 +38,8 @@ if [[ -z $DISPLAY  ]] ; then # test if X is not running when calling us
           einfo "caps-ctrl - switching caps lock and control key."
 
            loadkeys <<- EOT
-           keycode 58 = $(repeat 15 echo -n 'Caps_Lock ')
-           keycode 29 = $(repeat 7 echo -n 'Control ')
+           keycode 58 = $(printf 'Caps_Lock %.0s' {1..15})
+           keycode 29 = $(printf 'Control %.0s' {1..7})
 		EOT
            eend $?
          )

--- a/config/files/GRMLBASE/usr/bin/caps-ctrl
+++ b/config/files/GRMLBASE/usr/bin/caps-ctrl
@@ -36,45 +36,34 @@ check4progs() {
 
 check4progs xmodmap loadkeys dumpkeys || exit 1
 
-if [[ -f /etc/grml/lsb-functions ]] ; then
-	source /etc/grml/lsb-functions
-else
-	einfo() { echo  "$*" ; }
-	eerror() { echo "$*" ; }
-	eend() { echo "$*" ; }
-fi
-
 if [[ -z $DISPLAY  ]] ; then # test if X is not running when calling us
          if [ $(id -u) != 0 ] ; then # test if user root did invoke this command
-            eerror "As of Linux 2.6.15 you need root permissions for changing"
-            eerror "the keyboard on console using loadkeys for security reasons."
-            eerror "Run this program with root permissions. Exiting." ; eend 1
+            echo "As of Linux 2.6.15 you need root permissions for changing"
+            echo "the keyboard on console using loadkeys for security reasons."
+            echo "Run this program with root permissions. Exiting."
             exit 1
          fi
          dumpkeys | grep -q '^keycode  58 = Caps_Lock' && \
-         ( einfo "caps-ctrl - switching caps lock and control key."
+         ( echo "caps-ctrl - switching caps lock and control key."
 
            loadkeys <<- EOT
            keycode 58 = $(printf 'Control %.0s' {1..15})
            keycode 29 = $(printf 'Caps_Lock %.0s' {1..7})
 		EOT
-           eend $?
-
         ) || (
-          einfo "caps-ctrl - switching caps lock and control key."
+          echo "caps-ctrl - switching caps lock and control key."
 
            loadkeys <<- EOT
            keycode 58 = $(printf 'Caps_Lock %.0s' {1..15})
            keycode 29 = $(printf 'Control %.0s' {1..7})
 		EOT
-           eend $?
          )
 
 else     # running under X
         (
-        einfo "caps-ctrl - switching caps lock and control key."
-        einfo "If you notice errors, please make sure the xmodmap you have is right"
-        einfo "or use e.g. \"setxkbmap us\" beforehand."
+        echo "caps-ctrl - switching caps lock and control key."
+        echo "If you notice errors, please make sure the xmodmap you have is right"
+        echo "or use e.g. \"setxkbmap us\" beforehand."
         xmodmap -pke | grep 'Caps_Lock' > /dev/null || (
         xmodmap - <<- EOT
         keycode 66 = Caps_Lock
@@ -95,7 +84,6 @@ else     # running under X
         add Control = Control_L
         !add Control = Control_R
 		EOT
-        eend $?
         )
 fi # end of test if X or console is used
 

--- a/config/files/GRMLBASE/usr/share/man/man1/caps-ctrl.1
+++ b/config/files/GRMLBASE/usr/share/man/man1/caps-ctrl.1
@@ -1,0 +1,31 @@
+.\" Filename:      caps-ctrl.1
+.\" Purpose:       man page for caps-ctrl
+.\" Authors:       grml-team (grml.org), (c) Michael Prokop <mika@grml.org>
+.\" Bug-Reports:   see http://grml.org/bugs/
+.\" License:       This file is licensed under the GPL v2.
+.\"###############################################################################
+
+.\"###############################################################
+.TH caps\-ctrl 1
+.SH "NAME"
+caps\-ctrl \- switch Caps\-Lock key
+.\"#######################################################
+.SH "DESCRIPTION"
+.B grml\-lang
+Switch keyboard settings of key known as "Caps-Lock" between
+using Caps-Lock either as control- or shift-key. Notice:
+running caps-ctrl on console requires root-permissions,
+running it in X window system works as normal user.
+
+.SH "BUGS"
+Probably. Please report any bugs you find and report
+feedback and suggestions to the Grml team.
+See https://grml.org/bugs/ for further information.
+Thank you!
+
+.SH "COPYRIGHT"
+This man page is copyright \(co 2004-2011 by the Grml team.
+Included scripts are under various copyrights, please see
+the sources.
+.\"###### END OF FILE ##########################################################
+.\" vim:tw=60

--- a/config/scripts/GRMLBASE/43-grml-tools
+++ b/config/scripts/GRMLBASE/43-grml-tools
@@ -15,6 +15,9 @@ target=${target:?}
 fcopy -m root,root,0755 -v /usr/bin/random-hostname
 fcopy -m root,root,0644 /usr/share/man/man1/random-hostname.1
 
+fcopy -m root,root,0755 -v /usr/bin/caps-ctrl
+fcopy -m root,root,0644 /usr/share/man/man1/caps-ctrl.1
+
 fcopy -m root,root,0755 -v /usr/sbin/grml2ram
 fcopy -m root,root,0644 /usr/share/man/man8/grml2ram.8
 


### PR DESCRIPTION
The last script from grml-scripts. This is a kinda stupid import to not break anything. In https://github.com/grml/grml-scripts/issues/27 we thought it should be merged into grml-lang/keyboard/..., but that's too big right now.