### PR TITLE
Easy outdated cheatcodes + boot help texts

### DIFF
--- a/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt
+++ b/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt
@@ -199,7 +199,7 @@ grml noswraid                         Disable scanning for software raid arrays 
 grml swraid                           Enable automatic assembling of software raid arrays
 grml nolvm                            Disable scanning for Logical Volumes (LVM)
 grml lvm                              Automatically activate Logical Volumes (LVM) during boot
-grml read-only                        Make sure all harddisk devices (/dev/hd* /dev/sd*) are forced to read-only mode
+grml read-only                        Make sure all harddisk devices (/dev/sd*) are forced to read-only mode
 grml ethdevice=...                    Use specified network device for network boot instead of default (eth0)
 grml ethdevice-timeout=...            Use specified network configuration timeout instead of default (15sec)
 grml xmodule=ati|fbdev|i810|mga       Use specified X.org-Module (1)

--- a/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt
+++ b/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt
@@ -158,7 +158,7 @@ Security / login related settings:
 grml ssh=password                     Set password for root & grml user and start ssh-server
 grml passwd=...                       Set password for root & grml user
 grml encpasswd=....                   Set specified hash as password for root & grml user, use e.g.
-                                      'mkpasswd -H md5' to generate such a hash (available in Grml >=2013.09)
+                                      'mkpasswd -m sha-512' to generate such a hash
 
 Service related settings:
 -------------------------

--- a/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt
+++ b/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt
@@ -119,7 +119,7 @@ grml isofrom=[fs:][/device]/grml.iso  Use specified ISO image for booting.
                                       Internally, the initrd will mount the given device, automatically detecting
                                       the file system.
                                       If needed, prefix the file system separated with a colon character to
-                                      override the automatic detection, like in "reiserfs:/dev/sda1/grml.iso".
+                                      override the automatic detection, like in "ext4:/dev/sda1/grml.iso".
                                       As an example, boot the according grml kernel and initrd using the
                                       bootoptions "boot=live isofrom=btrfs:/dev/vda40/path/to/grml.iso"
                                       NOTE: "fromiso" does the same as "isofrom", it's just there

--- a/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt
+++ b/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt
@@ -61,7 +61,7 @@ grml file=foobar.tbz                  Use specified file as name for configurati
 grml extract=/etc                     Extract only /etc from configuration archive,
                                       use it in combination with myconfig or netconfig
 grml persistence                      Enable persistency feature, more details available at
-                                      http://wiki.grml.org/doku.php?id=persistency
+                                      https://wiki.grml.org/doku.php?id=persistency
 grml hostname=...                     Set hostname to given argument
 grml hostname                         Set a random hostname
 grml nonetworking                     Do not create/overwrite /etc/network/interface during startup
@@ -93,7 +93,7 @@ grml config=path-name                 Unpack archive that path-name points to
 grml noautoconfig                     Disable searching for device labeled GRMLCFG
 grml nobeep                           Disable welcome chime, sounded before grml-quickconfig starts.
 
-Notice: Take a look at http://grml.org/config/ and 'man 1 grml-autoconfig'
+Notice: Take a look at https://grml.org/config/ and 'man 1 grml-autoconfig'
 for more information regarding the configuration framework of Grml.
 
 Booting related options:
@@ -139,7 +139,7 @@ grml module=grml                      Instead of using the default "$name.module
                                       be specified without the extension ".module"; it should be placed
                                       on "/live" directory of the live medium
                                       Useful for Multiboot USB pen, see
-                                      http://wiki.grml.org/doku.php?id=tips#multiboot_usb_pen
+                                      https://wiki.grml.org/doku.php?id=tips#multiboot_usb_pen
 grml bootid=mybootid                  Use specified argument as identifier for the ISO.
                                       mybootid is specified in /conf/bootid.txt on the ISO.
 grml ignore_bootid                    Disable bootid verification.
@@ -252,7 +252,7 @@ to skip some critical parts of the autodetection system.
 system after autoconfiguration by running a bourne shell script called
 "grml.sh" and/or extracting configuration files from a file named
 config.tbz from the root directory on the given device (or floppy).
-Take a look at http://grml.org/config/ for more information regarding
+Take a look at https://grml.org/config/ for more information regarding
 the configuration framework of grml.
 
 *) If you wish to remaster the CD, please don't forget to specify

--- a/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt
+++ b/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt
@@ -166,7 +166,7 @@ grml startup=script                   Start $script instead of grml-quickconfig 
 grml nogpm                            Disable GPM daemon
 grml noblank                          Disable console blanking
 grml noquick                          Disable grml-quickconfig startup script
-grml services={espeakup,portmap,...}  Start system service(s)
+grml services={espeakup,rpcbind,...}  Start system service(s)
 grml welcome                          Welcome message via soundoutput
 grml noeject                          Do NOT eject CD after halt/reboot
 grml noprompt                         Do NOT prompt to remove the CD when halting/rebooting the system

--- a/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt
+++ b/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt
@@ -198,7 +198,7 @@ grml swap                             Activate present/detected swap partitions
 grml noswraid                         Disable scanning for software raid arrays (creates /etc/mdadm/mdadm.conf)
 grml swraid                           Enable automatic assembling of software raid arrays
 grml nolvm                            Disable scanning for Logical Volumes (LVM)
-grml lvm                              Automatically activate Logival Volumes (LVM) during boot
+grml lvm                              Automatically activate Logical Volumes (LVM) during boot
 grml read-only                        Make sure all harddisk devices (/dev/hd* /dev/sd*) are forced to read-only mode
 grml ethdevice=...                    Use specified network device for network boot instead of default (eth0)
 grml ethdevice-timeout=...            Use specified network configuration timeout instead of default (15sec)

--- a/config/media-files/GRMLBASE/boot/grub/help/cheatcodes.txt
+++ b/config/media-files/GRMLBASE/boot/grub/help/cheatcodes.txt
@@ -11,7 +11,6 @@ debnet        search local partitions for file /etc/network/interfaces,
           copy /etc/network then to local system and restart networking
 localtime                   assume Hardware Clock (RTC) is in localtime
 tz=Europe/Vienna                         set timezone (default: tz=UTC)
-home=/dev/sda1                   use specified device as home directory
 keyboard=de                                                set keyboard
 lang=[at|ch|da|de|es|fr|it|...|us]              set keyboard + language
 myconfig=/dev/fd0              load configuration from specified device

--- a/config/media-files/GRMLBASE/boot/grub/help/cheatcodes.txt
+++ b/config/media-files/GRMLBASE/boot/grub/help/cheatcodes.txt
@@ -39,7 +39,7 @@ noirqbalance                               Disable kernel irq balancing
 initcall_debug  trace initcalls, see where kernel is dying during start
 lapic                    enable the local APIC even if BIOS disabled it
 max_loop=[1-256] Maximum number of loopback devices that can be mounted
-md= / raid=[noautodetect]        RAID options, see Documentation/md.txt
+md= / raid=[noautodetect]  RAID options, see Documentation/admin-guide/md.rst
 mem=nn[KMG]                  Force usage of a specific amount of memory
 nfsroot=                        NFS root filesystem for disk-less boxes
 noapic      Ignore all APIC hardware which may be present on the system

--- a/config/media-files/GRMLBASE/boot/grub/help/cheatcodes.txt
+++ b/config/media-files/GRMLBASE/boot/grub/help/cheatcodes.txt
@@ -3,8 +3,7 @@ Grml - Linux for sysadmins and users of texttools
 
 The following options can added to any selected menu item.
 
-blacklist=firewire-core               disable new (Juju) firewire stack
-blacklist=ieee1394                           disable old firewire stack
+blacklist=firewire-core                          disable firewire stack
 blacklist=ipw3945,prism54                     disable specified drivers
 blacklist=module1[,module2]  disable loading of specified module, e.g.:
 blacklist=usbcore                                   disable USB drivers

--- a/config/media-files/GRMLBASE/boot/grub/help/cheatcodes.txt
+++ b/config/media-files/GRMLBASE/boot/grub/help/cheatcodes.txt
@@ -37,7 +37,6 @@ Additional kernel and initramfs boot options:
 acpi={force|off|ht|strict}                         Define ACPI-settings
 apic={quiet(default)|verbose|debug} Set output verbosity whilst booting
 noirqbalance                               Disable kernel irq balancing
-ide?=   config (iomem/irq), tuning (serialize,reset,no{dma,tune,probe})
 initcall_debug  trace initcalls, see where kernel is dying during start
 lapic                    enable the local APIC even if BIOS disabled it
 max_loop=[1-256] Maximum number of loopback devices that can be mounted

--- a/config/media-files/GRMLBASE/boot/grub/help/cheatcodes.txt
+++ b/config/media-files/GRMLBASE/boot/grub/help/cheatcodes.txt
@@ -22,7 +22,7 @@ nolvm                          disable search for Logical Volumes (LVM)
 noquick                         disable grml-quickconfig startup script
 noswraid                       disable search for software RAID devices
 noudev                disable startup of udev (disables module loading)
-services=foo1[,foo2] start specified service(s) [/etc/init.d/name foo1]
+services=foo1[,foo2]           start specified service(s) [foo1, ...]
 ssh=password     set password for user grml + root and start ssh-server
 startx[=windowmanager]                     autostart X.org using grml-x
 swap                                   activate present swap partitions

--- a/config/media-files/GRMLBASE/boot/grub/help/config.txt
+++ b/config/media-files/GRMLBASE/boot/grub/help/config.txt
@@ -15,8 +15,8 @@ Usage examples:
 grml myconfig=/dev/sda1    -> mount usb device and extract config.tbz
                             and execute grml.sh if present
 grml netconfig=grml.org/config.tar.gz -> download file and extract it
-grml myconfig=/dev/fd0 file=foobar.tbz -> extract archive from floppy
-grml partconf=/dev/hda2    -> mount partition read-only and get files
+grml myconfig=/dev/sdb1 file=foobar.tbz -> extract archive from device
+grml partconf=/dev/sda2    -> mount partition read-only and get files
                             specified in  /etc/grml/partconf
 
 Press ENTER to return to the menu...


### PR DESCRIPTION
I asked Claude to review cheatcodes.txt and the grub help texts. It identified some low-hanging fruits. See below for a list, and also for some things that need discussion / deeper investigation.

I do not propose to merge this as is, as some changes need a deeper review and also the alignment is all fucked.

https://github.com/grml/grml-live/issues/296

## LLM-generated Summary

Review and update outdated information in `grml-cheatcodes.txt` and `boot/grub/help/*.txt`.

Each change is a separate commit with a reason in the commit message.

### cheatcodes.txt changes

- **fix "Logival" typo** — simple typo, `Logival` → `Logical` in the `lvm` boot option description
- **update HTTP URLs to HTTPS** — all 4 `http://grml.org` and `http://wiki.grml.org` URLs now use HTTPS
- **replace portmap with rpcbind in services example** — portmap was replaced by rpcbind in all Grml flavours (commit ac64887). The example `services={espeakup,portmap,...}` now uses `rpcbind`
- **replace reiserfs with ext4 in isofrom example** — reiserfsprogs was dropped from all flavours (commit 73fb627). The `isofrom=` filesystem prefix example now uses `ext4` instead of `reiserfs`
- **update mkpasswd example to use sha-512** — the `-H` flag is deprecated in current mkpasswd (whois package) in favor of `-m`, and md5 password hashes are insecure. Updated to `mkpasswd -m sha-512`. Also removed the `(available in Grml >=2013.09)` note
- **remove /dev/hd\* from read-only description** — the `/dev/hd*` device naming scheme is from the old IDE subsystem, which was removed from the Linux kernel in version 5.14

### grub help changes

- **remove ieee1394 blacklist example and update firewire-core** — the old ieee1394 firewire stack was removed from the kernel in 2.6.37 (2011). The "new (Juju)" firewire-core is now the only stack, so the qualifier was also dropped
- **remove ide?= kernel option** — the IDE subsystem was removed from the Linux kernel in version 5.14 (2021). The `ide?=` parameter no longer exists
- **update outdated device names in config examples** — replaced `/dev/fd0` (floppy) with `/dev/sdb1` and `/dev/hda2` (old IDE naming) with `/dev/sda2` in `config.txt` usage examples
- **remove home= boot option** — `home=` was deprecated and its handler was removed from grml-autoconfig (no match in `autoconfig.functions`). The option silently does nothing
- **remove /etc/init.d reference from services= description** — `service_wrapper()` in grml-autoconfig now uses `systemctl` directly, not init.d scripts
- **update kernel documentation path for md/RAID** — `Documentation/md.txt` was moved to `Documentation/admin-guide/md.rst` in kernel 4.10

## Points for discussion

### VNC notes
Lines 180 and 185 of `grml-cheatcodes.txt` say "[Note: Grml 2011.12+ doesn't include a VNC server.]" and "[Note: Grml 2011.12+ doesn't include a VNC client.]". However, `x11vnc` is listed in `config/package_config/GRML_FULL`, and `config_vnc()` in `autoconfig.functions` actively uses it. These notes appear to be outdated — or `x11vnc` was re-added at some point after 2011.12. Worth investigating whether the notes should be removed or updated, and whether vnc_connect (which uses `vncviewer`) actually works.

### read-only boot option and modern device types
The `read-only` description now says `/dev/sd*` only. This should be investigated: does the actual implementation also cover `/dev/mmcblk*` (eMMC/SD cards) and `/dev/nvme*` (NVMe) devices? If not, it probably should, and the documentation should reflect whatever the implementation does.

### wiki.grml.org tips link
The multiboot USB pen link (`https://wiki.grml.org/doku.php?id=tips#multiboot_usb_pen`) may not be stable long-term. It could be worth replacing this with a link to the actual tips/documentation on grml.org proper, but that would need stable, non-wiki URLs to point to first.

### Right-alignment in grub help
Some of the edits in `boot/grub/help/cheatcodes.txt` break the right-alignment pattern that some (but not all) of the original lines followed. The file was already inconsistent in this regard. Worth deciding whether to enforce consistent alignment across the file or accept the current state.

### portmap debconf entry
`config/debconf/GRMLBASE` still contains a `portmap portmap/loopback boolean false` entry (line 7). This may be dead config if portmap is no longer installed, or it may be provided by rpcbind's compatibility layer. Worth checking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)