### PR TITLE
grub: do not load bochs driver on UEFI platform

### DIFF
--- a/config/media-files/GRMLBASE/boot/grub/header.cfg
+++ b/config/media-files/GRMLBASE/boot/grub/header.cfg
@@ -12,9 +12,6 @@ if loadfont unicode ; then
    if [ "${grub_platform}" == "pc" ] ; then
      # x86 BIOS boot only
      insmod vbe
-   fi
-   if [ "${grub_cpu}" != "arm64" ] ; then
-     # x86 only
      insmod video_bochs
      insmod video_cirrus
    fi


### PR DESCRIPTION
Our openqa-test runs are affected by what is described in Debian bug [1036019](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1036019), qemu upstream report https://gitlab.com/qemu-project/qemu/-/work_items/2562

When our ISO boots on an UEFI platform that is actually QEMU, after GRUB drew its menu, the kernel tries to drive the framebuffer using the UEFI firmware, but that then produces garbled video. If I read the upstream report right, this is because both the bochs and the UEFI video drivers modify the video state, but the UEFI firmware will not know what the bochs driver did.

See https://salsa.debian.org/grub-team/grub/-/merge_requests/84/diffs for what Debian applied. While we cannot influence building of the (SB) images, we can restrict what gets actually loaded.