### PR TITLE
GHA CI: use nightly.link for artifact comments

### DIFF
--- a/.github/workflows/comment-artifacts.yml
+++ b/.github/workflows/comment-artifacts.yml
@@ -1,113 +1,68 @@
-name: comment-artifacts
-
+name: Comment on pull request
 on:
   workflow_run:
     workflows: ["test-build"]
     types: [completed]
-
 jobs:
-  comment-pr:
-    if: github.event.workflow_run.event == 'pull_request'
+  pr_comment:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
-      - name: Get PR number from workflow run
-        id: pr
-        uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
+          # This snippet is public-domain, taken from
+          # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
           script: |
-            // Get the workflow run that triggered this
-            const workflowRun = context.payload.workflow_run;
+            async function upsertComment(owner, repo, issue_number, purpose, body) {
+              const {data: comments} = await github.rest.issues.listComments(
+                {owner, repo, issue_number});
 
-            // Get pull requests associated with the head SHA
-            const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: workflowRun.head_sha,
-            });
+              const marker = `<!-- bot: ${purpose} -->`;
+              body = marker + "\n" + body;
 
-            if (prs.data.length === 0) {
-              console.log('No PR found for commit', workflowRun.head_sha);
-              return;
+              const existing = comments.filter((c) => c.body.includes(marker));
+              if (existing.length > 0) {
+                const last = existing[existing.length - 1];
+                core.info(`Updating comment ${last.id}`);
+                await github.rest.issues.updateComment({
+                  owner, repo,
+                  body,
+                  comment_id: last.id,
+                });
+              } else {
+                core.info(`Creating a comment in issue / PR #${issue_number}`);
+                await github.rest.issues.createComment({issue_number, body, owner, repo});
+              }
             }
 
-            // Use the first PR (should be the one that triggered the workflow)
-            const pr = prs.data[0];
-            console.log('Found PR:', pr.number);
-            core.setOutput('number', pr.number);
-            core.setOutput('found', 'true');
+            const {owner, repo} = context.repo;
+            const run_id = ${{github.event.workflow_run.id}};
 
-      - name: Comment on PR with ISO artifact links
-        if: steps.pr.outputs.found == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const prNumber = ${{ steps.pr.outputs.number }};
-            const workflowRunId = context.payload.workflow_run.id;
-
-            // Get all artifacts from the triggering workflow run
-            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: workflowRunId,
-            });
-
-            // Filter to only ISO artifacts
-            const isoArtifacts = artifacts.data.artifacts.filter(a =>
-              a.name.startsWith('grml-live-build-result-')
-            );
-
-            if (isoArtifacts.length === 0) {
-              console.log('No ISO artifacts found');
-              return;
+            const pull_requests = ${{ toJSON(github.event.workflow_run.pull_requests) }};
+            if (!pull_requests.length) {
+              return core.error("This workflow doesn't match any pull requests!");
             }
 
-            // Build comment content
-            let comment = `## 💿 ISO Build Results\n\n`;
-            comment += `The following ISO build artifacts are available from this PR:\n\n`;
-
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts, {owner, repo, run_id});
+            if (!artifacts.length) {
+              return core.error(`No artifacts found`);
+            }
+            let body = `## 💿 ISO Build Results\n\n`;
+            body += `The following ISO build artifacts are available from this PR:\n\n`;
             // Sort artifacts by name for consistent ordering
-            isoArtifacts.sort((a, b) => a.name.localeCompare(b.name));
-
-            for (const artifact of isoArtifacts) {
-              const downloadUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${workflowRunId}/artifacts/${artifact.id}`;
-              comment += `- [${artifact.name}.zip](${downloadUrl}) (${(artifact.size_in_bytes / 1024 / 1024).toFixed(2)} MB)\n`;
+            artifacts.sort((a, b) => a.name.localeCompare(b.name));
+            for (const art of artifacts) {
+              body += `\n* [${art.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
             }
+            body += `\n> **Note:** Downloads are ZIP files containing the ISO images. Artifacts are available for 15 days.\n`;
+            body += `> **Build Information:**\n`;
+            body += `> - Workflow Run: [${run_id}](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${run_id})\n`;
+            body += `> - Commit: ${context.payload.workflow_run.head_sha.substring(0, 7)}\n`;
 
-            comment += `\n> **Note:** Downloads are ZIP files containing the ISO images. You need to be logged into GitHub to download. Artifacts are available for 15 days.\n`;
-            comment += `> \n`;
-            comment += `> **Build Information:**\n`;
-            comment += `> - Workflow Run: [${workflowRunId}](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${workflowRunId})\n`;
-            comment += `> - Commit: ${context.payload.workflow_run.head_sha.substring(0, 7)}\n`;
+            core.info("Review thread message body:", body);
 
-            // Check if comment already exists
-            const comments = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-            });
-
-            const botComment = comments.data.find(comment =>
-              comment.user.type === 'Bot' && comment.body.includes('💿 ISO Build Results')
-            );
-
-            if (botComment) {
-              // Update existing comment
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: comment
-              });
-              console.log('Updated existing comment');
-            } else {
-              // Create new comment
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body: comment
-              });
-              console.log('Created new comment');
+            for (const pr of pull_requests) {
+              await upsertComment(owner, repo, pr.number,
+                "nightly-link", body);
             }


### PR DESCRIPTION
Lets the artifacts be publicly downloadable, without logging into GitHub.