### PR TITLE
fluxbox menu: drop grml-exec-wrapper usage

### DIFF
--- a/config/files/GRML_FULL/etc/skel/.fluxbox/menu
+++ b/config/files/GRML_FULL/etc/skel/.fluxbox/menu
@@ -3,7 +3,7 @@
     [exec] (Firefox) {firefox} <>
     [exec] (Run ...) {fbrun} <>
     [exec] (configure network) {sudo x-terminal-emulator -T "grml-network" -e /usr/sbin/grml-network} <>
-    [exec] (configure and run terminalserver) {grml-exec-wrapper -p grml-terminalserver sudo x-terminal-emulator -T "grml-terminalserver" -e /usr/sbin/grml-terminalserver} <>
+    [exec] (configure and run terminalserver) {sudo x-terminal-emulator -T "grml-terminalserver" -e /usr/sbin/grml-terminalserver} <>
     [separator]
     [submenu] (Applications) {} <>
         [include] (/etc/X11/fluxbox/menudefs.hook) {} <>


### PR DESCRIPTION
In commit 9a07cb1657673145ba04b6f84476489cad1b44bc of grml-scripts.git we dropped grml-exec-wrapper.

Drop its usage within the fluxbox menu to fix
grml-terminalserver menu entry.