### PR TITLE
autoconfig: improve "Found CPUs" message

### DIFF
--- a/config/files/GRMLBASE/usr/share/grml-autoconfig/autoconfig.functions
+++ b/config/files/GRMLBASE/usr/share/grml-autoconfig/autoconfig.functions
@@ -551,7 +551,17 @@ config_cpu(){
   cpu_info="$(lscpu | sed -n '/^Model name:/s/[^:]*:\s*//p')"
   num_cpus=$(grep -c processor /proc/cpuinfo)
 
-  einfo "Found ${num_cpus} CPU(s): ${cpu_info}"
+  # QEMU VMs on arm64 can report "Model name: -"
+  if [ -n "$cpu_info" ] && [ "$cpu_info" != "-" ]; then
+    cpu_info=": ${cpu_info}"
+  else
+    cpu_info=""
+  fi
+  if [ "$num_cpus" = "1" ]; then
+    einfo "Found 1 CPU${cpu_info}"
+  else
+    einfo "Found ${num_cpus} CPUs${cpu_info}"
+  fi
   eend 0
 }
 # }}}


### PR DESCRIPTION
* When only 1 processor is found, show "1 CPU", not "1 CPU(s)"
* When no model name is available (example: in qemu on arm64), hide the model name instead of showing "-"

Closes: grml/grml-live#509