### PR TITLE
SW: remove grml-live from GRML_FULL

### DIFF
--- a/config/package_config/GRML_FULL
+++ b/config/package_config/GRML_FULL
@@ -1,6 +1,5 @@
 PACKAGES install
 
-grml-live
 grml-paste
 grml-quickconfig-standard
 


### PR DESCRIPTION
We're considering to remove the grml-live Debian package from our Debian repository at deb.grml.org, given that grml-live is working fine from within its git repository and we expect our users to typically use that.

Probably there's no need to ship grml-live on our Grml ISOs by default, so let's start by removing it from our grml-full ISOs.

See https://github.com/grml/grml-live/issues/512