### PR TITLE
SW: remove speedtest-cli from GRML_FULL

### DIFF
--- a/config/package_config/GRML_FULL
+++ b/config/package_config/GRML_FULL
@@ -182,7 +182,6 @@ ser2net
 sipcalc
 snmp
 socat
-speedtest-cli
 ssmping
 tcpdump
 tcptraceroute


### PR DESCRIPTION
Introduced in commit f16d872136a9db55a798ee4d1501adff05fae0b7 , removed from Debian in bug #1136353.

Supposedly superseded by speedtest-go, which we can consider adding whenever it becomes available.