### PR TITLE
initramfs: include exfat kernel module in initramfs by default

### DIFF
--- a/config/files/GRMLBASE/etc/initramfs-tools/modules
+++ b/config/files/GRMLBASE/etc/initramfs-tools/modules
@@ -1,0 +1,6 @@
+# This file is installed by grml-live in 80-initramfs.
+# Its purpose is to always include the following modules in the initramfs,
+# and load them early in the boot process, see initramfs.conf(5)
+
+# useful for USB boot
+exfat

--- a/config/scripts/GRMLBASE/80-initramfs
+++ b/config/scripts/GRMLBASE/80-initramfs
@@ -14,6 +14,8 @@ target=${target:?}
 
 fcopy -M -v /etc/initramfs-tools/conf.d/xz-compress
 
+fcopy -M -v /etc/initramfs-tools/modules
+
 fcopy -m root,root,0755 -v /usr/share/initramfs-tools/hooks/virtio-gpu
 
 if ! [ -f "$target"/usr/share/initramfs-tools/scripts/live ] ; then


### PR DESCRIPTION
This should serve useful for booting from USB devices using exfat