### PR TITLE
GHA: update actions to latest stable versions

### DIFF
--- a/.github/workflows/comment-artifacts.yml
+++ b/.github/workflows/comment-artifacts.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Get PR number from workflow run
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             // Get the workflow run that triggered this
@@ -40,7 +40,7 @@ jobs:
 
       - name: Comment on PR with ISO artifact links
         if: steps.pr.outputs.found == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const prNumber = ${{ steps.pr.outputs.number }};

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,13 +26,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -84,7 +84,7 @@ jobs:
 
     - name: Extract metadata
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
@@ -93,7 +93,7 @@ jobs:
           type=raw,value=latest-${{ matrix.platform.arch }},enable={{is_default_branch}}
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./Dockerfile
@@ -122,7 +122,7 @@ jobs:
 
     steps:
     - name: Log in to Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -196,7 +196,7 @@ jobs:
 
     steps:
     - name: Log in to Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -10,8 +10,8 @@ jobs:
     name: ruff format check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install ruff
@@ -27,7 +27,7 @@ jobs:
     name: autoconfig tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: run_tests
         run: |
           # Install lsb-functions, etc.
@@ -40,7 +40,7 @@ jobs:
     name: shellcheck all scripts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: shellcheck
         run: |
           echo "Running shellcheck on all shell scripts..."

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - run: ./test/gha-build-deb.sh
         name: "Build .deb for ${{matrix.host_release}}"
@@ -32,7 +32,7 @@ jobs:
           HOST_RELEASE: ${{matrix.host_release}}
 
       - name: Archive built .deb
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: deb-${{matrix.host_release}}
           if-no-files-found: error
@@ -55,7 +55,7 @@ jobs:
 
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - run: ./test/gha-build-iso.sh initial
         name: "Build ISO on ${{matrix.host_release}} ${{matrix.arch}}${{matrix.extra_classes && format(' with {0}', matrix.extra_classes) || ''}}"
@@ -67,7 +67,7 @@ jobs:
 
       - name: Archive built ISO
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: grml-live-build-result-initial-${{github.event.pull_request.number && format('pr{0}-', github.event.pull_request.number) || ''}}${{matrix.host_release}}-${{matrix.arch}}${{matrix.extra_classes && format('-{0}', matrix.extra_classes) || ''}}
           if-no-files-found: error
@@ -85,7 +85,7 @@ jobs:
 
       - name: Archive repacked ISO
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: grml-live-build-result-repack-${{github.event.pull_request.number && format('pr{0}-', github.event.pull_request.number) || ''}}${{matrix.host_release}}-${{matrix.arch}}${{matrix.extra_classes && format('-{0}', matrix.extra_classes) || ''}}
           if-no-files-found: error


### PR DESCRIPTION
Spotted while working on PR 521, where GitHub reported in its `Complete job` console output:

```
  Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected:
  actions/checkout@v4, actions/upload-artifact@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
  [...]
```

Bump all actions to their most recent versions:

- actions/checkout: v4 → v6
- actions/github-script: v7 → v9
- actions/setup-python: v5 → v6
- actions/upload-artifact: v4 → v7
- docker/build-push-action: v5 → v7
- docker/login-action: v3 → v4
- docker/metadata-action: v5 → v6
- docker/setup-buildx-action: v3 → v4