### PR TITLE
minifai: disable python cache files

### DIFF
--- a/usr/lib/grml-live/minifai
+++ b/usr/lib/grml-live/minifai
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S python3 -B
 """
 Loader script for minifai to allow running it without installing the grml_live package.
 """


### PR DESCRIPTION
Equivalent of PYTHONDONTWRITEBYTECODE=1, but without needing it in an env var.

Closes #507