### PR TITLE
grml-live: make MIRROR_DIRECTORY readonly in chroot

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,6 +28,7 @@ Depends:
  rsync,
  socat,
  squashfs-tools,
+ util-linux (>= 2.39~),
  xorriso,
  ${misc:Depends},
 Recommends:

--- a/grml-live
+++ b/grml-live
@@ -744,7 +744,8 @@ mkdir -p "$CHROOT_OUTPUT" || bailout 5 "Problem with creating $CHROOT_OUTPUT"
 
 if [ -n "${MIRROR_DIRECTORY}" ] ; then
   mkdir -p "${CHROOT_OUTPUT}/${MIRROR_DIRECTORY}"
-  mount --bind "${MIRROR_DIRECTORY}" "${CHROOT_OUTPUT}/${MIRROR_DIRECTORY}"
+  # -o rbind needs util-linux >= 2.39
+  mount -o rbind,ro=recursive "${MIRROR_DIRECTORY}" "${CHROOT_OUTPUT}/${MIRROR_DIRECTORY}" || bailout 5 "Failed to bind-mount ${MIRROR_DIRECTORY}"
 fi
 
 log "Executed FAI command line:"

--- a/grml-live
+++ b/grml-live
@@ -150,9 +150,17 @@ else
 fi
 # }}}
 
-# umount all directories {{{
+# umount all directories beneath CHROOT_OUTPUT {{{
+_UMOUNT_ALL_ATTEMPTED=""
 umount_all() {
-   [ -n "$MIRROR_DIRECTORY" ] && umount "${CHROOT_OUTPUT}/${MIRROR_DIRECTORY}"
+  [ -n "${CHROOT_OUTPUT}" ] && [ -d "${CHROOT_OUTPUT}" ] || return 0
+  [ -z "${_UMOUNT_ALL_ATTEMPTED}" ] || return 0
+  _UMOUNT_ALL_ATTEMPTED=1
+  local mountpoint
+  while IFS= read -r mountpoint; do
+    einfo "Unmounting ${mountpoint} ..."
+    umount -R "${mountpoint}" ; eend $?
+  done < <(findmnt -k -l -n -o TARGET | awk -v path="${CHROOT_OUTPUT%/}/" 'index($0, path) == 1' | sort -r)
 }
 # }}}
 


### PR DESCRIPTION
Drive-by: umount all mountpoints inside CHROOT_OUTPUT during cleanup. Frees us from tracking which directories got mounted into CHROOT_OUTPUT.

mount with rbind needs util-linux >= 2.39, available in bookworm.

Serves as a basis for mounting further directories into the chroot area.
