### PR TITLE
build-driver: hide build-driver traceback when grml-live fails

### DIFF
--- a/build-driver/build.py
+++ b/build-driver/build.py
@@ -46,6 +46,22 @@ Examples:
     print(message.strip(), file=sys.stderr)
 
 
+class DelegatedProgramFailed(Exception):
+    program_name: str
+    returncode: str
+    cmd: list[str]
+
+    def __init__(self, program_name, returncode, cmd):
+        self.program_name = program_name
+        self.returncode = returncode
+        self.cmd = cmd
+
+    def message(self):
+        return f"{self.program_name} failed with exit code {self.returncode}, command was: " + (
+            " ".join(['"' + arg + '"' for arg in self.cmd])
+        )
+
+
 def run_x(args, check: bool = True, **kwargs):
     # str-ify Paths, not necessary, but for readability in logs.
     args = [arg if isinstance(arg, str) else str(arg) for arg in args]
@@ -135,7 +151,10 @@ def run_grml_live(
     if old_iso_path:
         grml_live_cmd += ["-b", "-e", old_iso_path]
     with ci_section("Building with grml-live", collapsed=False):
-        run_x(grml_live_cmd, env=env)
+        try:
+            run_x(grml_live_cmd, env=env)
+        except subprocess.CalledProcessError as except_inst:
+            raise DelegatedProgramFailed("grml-live", except_inst.returncode, except_inst.cmd)
 
 
 def upload_daily(job_name: str, build_dir: Path, job_timestamp: datetime.datetime):
@@ -349,7 +368,7 @@ def download_old_sources(tmp_dir: Path, old_iso_url: str) -> Path | None:
     return path
 
 
-def main(program_name: str, argv: list[str]) -> int:
+def _main(program_name: str, argv: list[str]) -> int:
     print(f"I: {program_name} started with {argv=}")
     try:
         grml_live_path = Path(argv.pop(0))
@@ -520,6 +539,13 @@ def main(program_name: str, argv: list[str]) -> int:
     print("I: Success.")
 
     return 0
+
+
+def main(program_name: str, argv: list[str]) -> int:
+    try:
+        return _main(program_name, argv)
+    except DelegatedProgramFailed as except_inst:
+        return bail(except_inst.message())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently a grml-live failure driven by build-driver has a very noisy traceback, looking like this:

```
  [!] Error: critical error while executing fai [exit code 2]. Exiting.
  [*] Cleaning up
E: Caught fatal exception
I: moving build results from /tmp/tmpkrp8sw9w to /builds/grml/build-daily/results
Traceback (most recent call last):
  File "/builds/grml/build-daily/grml-live/build-driver/build.py", line 526, in <module>
    sys.exit(main(sys.argv.pop(0), sys.argv))
             ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/builds/grml/build-daily/grml-live/build-driver/build.py", line 492, in main
    build(
    ~~~~~^
        build_dir,
        ^^^^^^^^^^
    ...<4 lines>...
        old_iso_path,
        ^^^^^^^^^^^^^
    )
    ^
  File "/builds/grml/build-daily/grml-live/build-driver/build.py", line 244, in build
    run_grml_live(
    ~~~~~~~~~~~~~^
        grml_live_path,
        ^^^^^^^^^^^^^^^
    ...<9 lines>...
        job_properties.job_timestamp,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/builds/grml/build-daily/grml-live/build-driver/build.py", line 138, in run_grml_live
    run_x(grml_live_cmd, env=env)
    ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/builds/grml/build-daily/grml-live/build-driver/build.py", line 54, in run_x
    return subprocess.run(args, check=check, **kwargs)
           ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/subprocess.py", line 577, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/builds/grml/build-daily/grml-live/grml-live', '-F', '-A', '-a', 'amd64', '-c', 'GRML_FULL,SOURCES', '-s', 'testing', '-v', 'd20260614b744', '-r', 'daily20260614build744testing', '-g', 'grml-full-amd64', '-i', 'grml-full-daily20260614build744testing-amd64.iso', '-o', '/tmp/tmpkrp8sw9w']' returned non-zero exit status 1.
```

Afterwards it should look like this:
```
  [!] Error: critical error while executing fai [exit code 2]. Exiting.
  [*] Cleaning up
E: Caught fatal exception
I: moving build results from /tmp/tmpkrp8sw9w to /builds/grml/build-daily/results
E: grml-live failed with exit code 1, command was: "/builds/grml/build-daily/grml-live/grml-live" "-F" "-A" "-a" "amd64" "-c" "GRML_FULL,SOURCES" "-s" "testing" "-v" "d20260614b744" "-r" "daily20260614build744testing" "-g" "grml-small-amd64" "-i" "grml-full-daily20260614build744testing-amd64.iso" "-o" "/tmp/tmpkrp8sw9w"
```
