### PR TITLE
minifai: support APT_PROXY for mmdebstrap

### DIFF
--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -660,6 +660,8 @@ def install_base(conf_dir: Path, chroot_dir: Path, classes, debian_suite: str, m
     if os.environ.get("GRML_LIVE_DEBUG_APT", "") != "":
         args.insert(1, f"--aptopt={APT_DEBUG_ACQUIRE}")
         args.insert(1, "--chrooted-customize-hook=rm /etc/apt/apt.conf.d/99mmdebstrap")
+    if os.environ.get("APT_PROXY", "") != "":
+        args.insert(1, "--aptopt='Acquire::http { Proxy \"" + os.environ["APT_PROXY"] + '"; }')
 
     run_x(args)
     os.unlink(keyring_tempfile.name)


### PR DESCRIPTION
Inform mmdebstrap about the proxy for APT, when APT_PROXY is set.