### PR TITLE
unshare based builder

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -49,9 +49,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        host_release:
-          - forky
-          - trixie
         extra_classes:
           - ""
           - "GRML_GHACI_CLOUD"
@@ -66,9 +63,8 @@ jobs:
           persist-credentials: false
 
       - run: ./test/gha-build-iso.sh initial
-        name: "Build ISO on ${{matrix.host_release}} ${{matrix.arch}}${{matrix.extra_classes && format(' with {0}', matrix.extra_classes) || ''}}"
+        name: "Build ISO on ${{matrix.arch}}${{matrix.extra_classes && format(' with {0}', matrix.extra_classes) || ''}}"
         env:
-          HOST_RELEASE: ${{matrix.host_release}}
           EXTRA_CLASSES: ${{matrix.extra_classes}}
           ARCH: ${{matrix.arch}}
           GITHUB_PR_NUMBER: ${{github.event.pull_request.number}}
@@ -77,16 +73,15 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
-          name: grml-live-build-result-initial-${{github.event.pull_request.number && format('pr{0}-', github.event.pull_request.number) || ''}}${{matrix.host_release}}-${{matrix.arch}}${{matrix.extra_classes && format('-{0}', matrix.extra_classes) || ''}}
+          name: grml-live-build-result-initial-${{github.event.pull_request.number && format('pr{0}-', github.event.pull_request.number) || ''}}-${{matrix.arch}}${{matrix.extra_classes && format('-{0}', matrix.extra_classes) || ''}}
           if-no-files-found: error
           retention-days: 15
           path: |
             results-initial/*
 
       - run: ./test/gha-build-iso.sh build-only-twice
-        name: "Repack ISO twice on ${{matrix.host_release}} ${{matrix.arch}}${{matrix.extra_classes && format(' with {0}', matrix.extra_classes) || ''}}"
+        name: "Repack ISO twice ${{matrix.arch}}${{matrix.extra_classes && format(' with {0}', matrix.extra_classes) || ''}}"
         env:
-          HOST_RELEASE: ${{matrix.host_release}}
           EXTRA_CLASSES: ${{matrix.extra_classes}}
           ARCH: ${{matrix.arch}}
           GITHUB_PR_NUMBER: ${{github.event.pull_request.number}}
@@ -95,7 +90,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
-          name: grml-live-build-result-repack-${{github.event.pull_request.number && format('pr{0}-', github.event.pull_request.number) || ''}}${{matrix.host_release}}-${{matrix.arch}}${{matrix.extra_classes && format('-{0}', matrix.extra_classes) || ''}}
+          name: grml-live-build-result-repack-${{github.event.pull_request.number && format('pr{0}-', github.event.pull_request.number) || ''}}-${{matrix.arch}}${{matrix.extra_classes && format('-{0}', matrix.extra_classes) || ''}}
           if-no-files-found: error
           retention-days: 15
           path: |

--- a/build-driver/build.py
+++ b/build-driver/build.py
@@ -496,7 +496,9 @@ def _main(program_name: str, argv: list[str]) -> int:
     # avoid building on mounted volume
     tmp_root = Path(tempfile.gettempdir())
     tmp_dir = Path(tempfile.mkdtemp(dir=tmp_root))
+    tmp_dir.chmod(0o775)
     build_dir = Path(tempfile.mkdtemp(dir=tmp_root))
+    build_dir.chmod(0o775)
 
     # Do it now, as the next block needs curl installed.
     install_debian_dependencies()

--- a/build-driver/build.py
+++ b/build-driver/build.py
@@ -494,11 +494,12 @@ def _main(program_name: str, argv: list[str]) -> int:
     print(f"I: {output_dir=}")
 
     # avoid building on mounted volume
-    tmp_root = Path(tempfile.gettempdir())
-    tmp_dir = Path(tempfile.mkdtemp(dir=tmp_root))
+    tmp_dir = Path(tempfile.mkdtemp(prefix="gltmp"))
     tmp_dir.chmod(0o775)
-    build_dir = Path(tempfile.mkdtemp(dir=tmp_root))
+    print(f"I: {tmp_dir=}")
+    build_dir = Path(tempfile.mkdtemp(prefix="glbuild"))
     build_dir.chmod(0o775)
+    print(f"I: {build_dir=}")
 
     # Do it now, as the next block needs curl installed.
     install_debian_dependencies()

--- a/build-driver/build.py
+++ b/build-driver/build.py
@@ -126,8 +126,6 @@ def run_grml_live(
     grml_fai_config = grml_live_path / "config"
     env.update(
         {
-            "GRML_FAI_CONFIG": str(grml_fai_config),
-            "LIVE_CONF": str(grml_live_path / "etc" / "grml" / "grml-live.conf"),
             "SOURCE_DATE_EPOCH": str(int(source_date_epoch.timestamp())),
         }
     )
@@ -135,6 +133,10 @@ def run_grml_live(
     grml_live_cmd = [
         grml_live_path / "grml-live",
         "-F",  # do not prompt
+        "-C",
+        str(grml_live_path / "etc" / "grml" / "grml-live.conf"),
+        "-D",
+        str(grml_fai_config),
         "-c",
         ",".join(classes),
         "-s",

--- a/build-driver/build.py
+++ b/build-driver/build.py
@@ -91,8 +91,15 @@ def is_ci():
 
 
 def apt_satisfy(deps: str):
+    args = ["apt-get", "satisfy", "-q", "-y", "--no-install-recommends", deps.strip()]
+    if os.getuid() != 0:
+        if os.getenv("CI", "") == "":
+            print(f"I: Skipping apt install, set CI=true to force. Would install: {deps.strip()}")
+            return
+        else:
+            args = ["sudo", "-n", "--preserve-env=DEBIAN_FRONTEND", "--", *args]
     run_x(
-        ["apt-get", "satisfy", "-q", "-y", "--no-install-recommends", deps.strip()],
+        args,
         env=dict(os.environ) | {"DEBIAN_FRONTEND": "noninteractive"},
     )
 
@@ -400,7 +407,7 @@ def _main(program_name: str, argv: list[str]) -> int:
 
     if not is_ci():
         print("I: No CI variable found, assuming local test build")
-        if not is_docker():
+        if not is_docker() and os.getuid() == 0:
             return bail("E: Not running inside docker, exiting to avoid data damage")
 
     build_config = load_config(build_config_file)

--- a/docs/grml-live.8.adoc
+++ b/docs/grml-live.8.adoc
@@ -110,12 +110,14 @@ advance. Usage example: '-d 2009-10-30'
   -D **CONFIGURATION_DIRECTORY**::
 
 The specified directory is used as configuration directory for grml-live.
-By default /usr/share/grml-live/config is used as default configuration directory.
+By default, when running from source (git checkout), `config` from the source
+directory is used. When running from an installed package, the default is
+`/usr/share/grml-live/config`.
 If you want to have different configuration scripts, package definitions, etc.
 without messing with the global configuration under /usr/share/grml-live/config
 provided by grml-live this option provides you the option to use your own
 configuration directory.
-This directory is what's being referred to as ${GRML_FAI_CONFIG} throughout this
+This directory is what's being referred to as `$GRML_FAI_CONFIG` throughout this
 documentation.
 
   -e **EXTRACT_ISO_NAME**::
@@ -497,14 +499,25 @@ The resulting ISO can then be found in `./grml/grml_isos/`.
 What is $GRML_FAI_CONFIG?
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The variable '$GRML_FAI_CONFIG' is pointing to the directory /usr/share/grml-live/config
-by default.
-To provide you a maximum of flexibility you can set up your own configuration directory
-(e.g. based on /usr/share/grml-live/config) and use
-this directory running grml-live with the '-D <config_dir>' option.
-Now '$GRML_FAI_CONFIG' points to the specified directory and all the
+`$GRML_FAI_CONFIG` is where grml-live looks for the configuration directory,
+which defines what ends up being part of your Grml build. See the section
+<<class-concept,The class concept>> for details.
+
+By default, `$GRML_FAI_CONFIG` points to the configuration shipped with
+grml-live. If you are running grml-live from a source (git) checkout,
+it defaults to using the `config` directory from that checkout.
+If you are running grml-live from an installed package, it defaults to
+`/usr/share/grml-live/config`.
+
+To provide you a maximum of flexibility you can set up your own configuration
+directory and use it with the `-D <config_dir>` option.
+Now `$GRML_FAI_CONFIG` points to the specified directory and all the
 configuration files, scripts and hooks will be taken from your
-'$GRML_FAI_CONFIG' directory.
+`$GRML_FAI_CONFIG` directory.
+
+We encourage you to fork grml-live.git and apply your changes to the `config`
+directory as git commits.
+
 
 [[how-to-debug]]
 I've problems with the build process. How to start debugging?

--- a/docs/grml-live.8.adoc
+++ b/docs/grml-live.8.adoc
@@ -427,6 +427,9 @@ a bug report. Check out <<deploy-on-debian,How do I deploy
 grml-live on a plain Debian installation>> for details how to set up grml-live
 on a plain, original Debian system.
 
+* Linux user namespaces must work, and the executing user needs subuid and subgid
+ranges assigned. See the manual pages subuid(5) and subgid(5).
+
 * enough free disk space. At least 2GB are required for a minimal grml-live
 run (\~1GB for the chroot, \~400MB for the build target, \~35MB for the netboot
 files and \~350MB for the resulting ISO plus some temporary files).
@@ -436,7 +439,7 @@ space.
 * fast network access for retrieving the Debian packages used for creating the
 chroot (check out "local mirror" to workaround this problem as far as possible)
 
-* your output directory should not be mounted with any of the "nodev", "noexec"
+* your output directory must not be mounted with any of the "nodev", "noexec"
 or "nosuid" mount options. (/tmp typically is at least "nodev" and "nosuid" on
 most systems.)
 
@@ -636,6 +639,18 @@ dpkg-dev is a simple and easy approach.
 
 Finally invoke grml-live with your class name (`CUSTOM` in this example) added
 to the list of classes on the command line (see grml-live option `-c`).
+
+[[userns]]
+Error: `unshare: no line matching ... in /etc/subuid`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+grml-live uses Linux user namespaces, instead of running everything as root on
+your host system. This requires that your user has "subuid" and "subgid" ranges
+assigned. See the manual pages subuid(5), subgid(5) and newuidmap(1).
+
+On Debian systems, when the `uidmap` package is installed, newly created users
+automatically get subuid and subgid ranges assigned by useradd(8).
+
 
 [[run-from-git]]
 Obtaining and running grml-live

--- a/docs/grml-live.8.adoc
+++ b/docs/grml-live.8.adoc
@@ -158,7 +158,7 @@ chroot system) and grml_isos (where the resulting ISO is stored).
 
 Build the ISO without (re-)creating the squashfs compressed file using mksquashfs.
 This option is useful if you just want to update parts outside the chroot in the ISO.
-Consider combining this option with the build-only option '-b'.
+The media-scripts are still run.
 
   -r **RELEASENAME**::
 

--- a/grml-live
+++ b/grml-live
@@ -481,11 +481,13 @@ fi
 # for example isolinux does not like '-' inside the directory name
 SHORT_NAME="$(echo "$GRML_NAME" | tr -d ',./;\- ')"
 
+# shellcheck disable=SC2034 # Calculated for CONFIGDUMP.
 RELEASE_INFO="$GRML_NAME $VERSION - Release Codename $RELEASENAME"
 
+# shellcheck disable=SC2034 # Calculated for CONFIGDUMP.
 SQUASHFS_NAME="$GRML_NAME.squashfs"
 
-# shellcheck disable=SC2034 # Calculated just to write it into CONFIGDUMP.
+# shellcheck disable=SC2034 # Calculated for CONFIGDUMP.
 BOOT_FILE="/conf/bootfile_${SHORT_NAME}_${SOURCE_DATE_EPOCH}"
 
 if [ -z "$BOOTID" ] ; then

--- a/grml-live
+++ b/grml-live
@@ -655,8 +655,6 @@ if [ "$RC" != 0 ] ; then
   bailout 1
 fi
 
-mv "${CHROOT_OUTPUT}"/grml-live/grml_sources/ "${OUTPUT}"
-
 log "Finished execution of stage 'fai $FAI_ACTION' [$(date)]"
 einfo "Finished execution of stage 'fai $FAI_ACTION'"
 # }}}
@@ -771,38 +769,6 @@ if hasclass RELEASE && [ "$RC" = 0 ] ; then
      fi
    )
 fi
-# }}}
-
-# {{{
-create_sourcespackages() {
-  if ! hasclass SOURCES ; then
-    log "Skipping source package generation, only enabled with class SOURCES"
-    return 0
-  fi
-
-  local OUTPUT_FILE SOURCES_DIR
-  OUTPUT_FILE="${OUTPUT}/$(basename "${ISO_NAME}" .iso)-sources.tar"
-  SOURCES_DIR="${OUTPUT}/grml_sources/"
-
-  if ! [ -d "${SOURCES_DIR}" ] ; then
-    eerror "Base directory ${SOURCES_DIR} not present, can not generate source package" ; eend 1
-    bailout 22
-  fi
-
-  if tar -C "${OUTPUT}" -cf "${OUTPUT_FILE}" "$(basename "${SOURCES_DIR}")" ; then
-   (
-     # shellcheck disable=SC2164 # We just wrote there. If it disappeared, too bad.
-     cd "$(dirname "${OUTPUT_FILE}")"
-     sha256sum "$(basename "${OUTPUT_FILE}")" > "${OUTPUT_FILE}.sha256"
-   )
-   einfo "Generated source package ${OUTPUT_FILE}" ; eend 0
- else
-   eerror "Could not generate source package ${OUTPUT_FILE}" ; eend 1
-   bailout 22
- fi
-}
-
-create_sourcespackages
 # }}}
 
 # finalize {{{

--- a/grml-live
+++ b/grml-live
@@ -659,8 +659,6 @@ if [ -n "$CHROOT_INSTALL" ] ; then
   fi
 fi
 
-cap_timestamps "$CHROOT_OUTPUT"
-
 if [ -n "$SKIP_MKSQUASHFS" ] ; then
    log   "Skipping stage 'squashfs' as requested via option -q"
    ewarn "Skipping stage 'squashfs' as requested via option -q" ; eend 0

--- a/grml-live
+++ b/grml-live
@@ -576,13 +576,6 @@ fi
 extract_iso
 # }}}
 
-# helper to cap mtime on all files in a folder {{{
-cap_timestamps() {
-  # ensure that no timestamps are newer than $SOURCE_DATE_EPOCH
-  find "$1" -newermt "@${SOURCE_DATE_EPOCH}" -print0 | TZ=UTC xargs -0r touch --no-dereference --date="@${SOURCE_DATE_EPOCH}"
-}
-# }}}
-
 # on-the-fly configuration {{{
 
 case "${SUITE}" in

--- a/grml-live
+++ b/grml-live
@@ -638,9 +638,9 @@ fi
 mkdir -p "$CHROOT_OUTPUT" || bailout 5 "Problem with creating $CHROOT_OUTPUT"
 
 log "Executed FAI command line:"
-log "${FAI_PROGRAM} ${GRML_FAI_CONFIG} ${CLASSES} ${FAI_ACTION} ${CHROOT_OUTPUT} ${CONFIGDUMP} ${SUITE} ${BOOTSTRAP_MIRROR}"
-einfo "${FAI_PROGRAM} ${GRML_FAI_CONFIG} ${CLASSES} ${FAI_ACTION} ${CHROOT_OUTPUT} ${CONFIGDUMP} ${SUITE} ${BOOTSTRAP_MIRROR}"
-"${FAI_PROGRAM}" "${GRML_FAI_CONFIG}" "${CLASSES}" "${FAI_ACTION}" "${CHROOT_OUTPUT}" "${CONFIGDUMP}" "${SUITE}" "${BOOTSTRAP_MIRROR}" 2>&1 | tee -a "${LOGFILE}"
+log "${FAI_PROGRAM} ${GRML_FAI_CONFIG} ${CLASSES} ${FAI_ACTION} ${OUTPUT} ${CONFIGDUMP} ${SUITE} ${BOOTSTRAP_MIRROR}"
+einfo "${FAI_PROGRAM} ${GRML_FAI_CONFIG} ${CLASSES} ${FAI_ACTION} ${OUTPUT} ${CONFIGDUMP} ${SUITE} ${BOOTSTRAP_MIRROR}"
+"${FAI_PROGRAM}" "${GRML_FAI_CONFIG}" "${CLASSES}" "${FAI_ACTION}" "${OUTPUT}" "${CONFIGDUMP}" "${SUITE}" "${BOOTSTRAP_MIRROR}" 2>&1 | tee -a "${LOGFILE}"
 RC="${PIPESTATUS[0]}" # notice: bash-only
 
 # Fetches logs from "${CHROOT_OUTPUT}"/grml-live/log.
@@ -742,7 +742,7 @@ generate_build_info() {
     distri_info="${DISTRI_INFO}" \
     distri_name="${DISTRI_NAME}" \
     extract_iso_name="${EXTRACT_ISO_NAME}" \
-    fai_cmdline="${FAI_PROGRAM} ${GRML_FAI_CONFIG} ${CLASSES} ${FAI_ACTION} ${CHROOT_OUTPUT} ${configdump_placeholder} ${SUITE} ${BOOTSTRAP_MIRROR}" \
+    fai_cmdline="${FAI_PROGRAM} ${GRML_FAI_CONFIG} ${CLASSES} ${FAI_ACTION} ${OUTPUT} ${configdump_placeholder} ${SUITE} ${BOOTSTRAP_MIRROR}" \
     fai_version="minifai" \
     grml_architecture="${ARCH}" \
     grml_bootid="${BOOTID}" \

--- a/grml-live
+++ b/grml-live
@@ -645,20 +645,14 @@ export SECURE_BOOT
 export WAYBACK_DATE
 export VERSION
 
-log "Executed FAI command line:"
-log "${FAI_PROGRAM} ${GRML_FAI_CONFIG} ${CLASSES} ${FAI_ACTION} ${OUTPUT} ${CONFIGDUMP} ${SUITE} ${BOOTSTRAP_MIRROR}"
-einfo "${FAI_PROGRAM} ${GRML_FAI_CONFIG} ${CLASSES} ${FAI_ACTION} ${OUTPUT} ${CONFIGDUMP} ${SUITE} ${BOOTSTRAP_MIRROR}"
 "${FAI_PROGRAM}" "${GRML_FAI_CONFIG}" "${CLASSES}" "${FAI_ACTION}" "${OUTPUT}" "${CONFIGDUMP}" "${SUITE}" "${BOOTSTRAP_MIRROR}" 2>&1 | tee -a "${LOGFILE}"
 RC="${PIPESTATUS[0]}" # notice: bash-only
 
 if [ "$RC" != 0 ] ; then
-  log    "Error: critical error while executing fai [exit code ${RC}]. Exiting."
-  eerror "Error: critical error while executing fai [exit code ${RC}]. Exiting." ; eend 1
+  log    "Error: internal program failed [exit code ${RC}]. Exiting."
+  eerror "Error: internal program failed [exit code ${RC}]. Exiting." ; eend 1
   bailout 1
 fi
-
-log "Finished execution of stage 'fai $FAI_ACTION' [$(date)]"
-einfo "Finished execution of stage 'fai $FAI_ACTION'"
 # }}}
 
 # finalize {{{

--- a/grml-live
+++ b/grml-live
@@ -578,14 +578,14 @@ else
   FAI_ACTION=dirinstall
 fi
 
-if ! [ "$FAI_ACTION" = dirinstall ] && [ -z "$EXTRACT_ISO_NAME" ] && ! [ -r "$CHROOT_OUTPUT/etc/debian_version" ] ; then
+if ! [ "$FAI_ACTION" = dirinstall ] && [ -z "$EXTRACT_ISO_NAME" ] && ! [ -r "$CHROOT_OUTPUT/etc/os-release" ] ; then
   log    "Error: does not look like you have a working chroot. Updating/building not possible."
   eerror "Error: does not look like you have a working chroot. Updating/building not possible. (Drop -u/-b/-B option?)"
   eend 1
   bailout 20
 fi
 
-if [ "$FAI_ACTION" = dirinstall ] && [ -r "$CHROOT_OUTPUT/etc/debian_version" ] ; then
+if [ "$FAI_ACTION" = dirinstall ] && [ -r "$CHROOT_OUTPUT/etc/os-release" ] ; then
   log    "Error: the chroot already exists. Refusing to overwrite it."
   eerror "Error: the chroot already exists. Refusing to overwrite it. (Add -u/-b/-B option?)"
   eend 1

--- a/grml-live
+++ b/grml-live
@@ -535,48 +535,6 @@ set | grep -E \
   > "${CONFIGDUMP}"
 # }}}
 
-# unpack iso/squashfs {{{
-extract_iso() {
-if [ -n "$EXTRACT_ISO_NAME" ]; then
-  log "Unpacking ISO from ${EXTRACT_ISO_NAME}"
-  einfo "Unpacking ISO from ${EXTRACT_ISO_NAME}"
-  local rc=0
-  local tempdir
-  tempdir=$(mktemp -d)
-  mkdir -p "${tempdir}/live/"
-  "$OSIRROX_BINARY" -indev "${EXTRACT_ISO_NAME}" -extract live "${tempdir}/live/" ; rc=$?
-  if [ "$rc" != 0 ]; then
-    rm -rf "$tempdir"
-    log "osirrox failed"
-    eerror "osirrox failed"
-    eend 1
-    bailout 1
-  fi
-
-  local squashfs
-  squashfs=( "${tempdir}"/live/*/*.squashfs )
-  if (( ${#squashfs[@]} != 0 )) && [ -r "${squashfs[0]}" ]; then
-    log "Will $UNSQUASHFS_BINARY ${squashfs[0]}"
-    "$UNSQUASHFS_BINARY" -d "${CHROOT_OUTPUT}" "${squashfs[0]}" ; rc=$?
-  else
-    log "Error: Could not find any *.squashfs files on the ISO"
-    eerror "Error: Could not find any *.squashfs files on the ISO"
-    eend 1
-    bailout 1
-  fi
-
-  rm -rf "$tempdir"
-  if [ "$rc" != 0 ]; then
-    log "unsquashfs failed"
-    eerror "unsquashfs failed"
-    eend 1
-    bailout 1
-  fi
-fi
-}
-extract_iso
-# }}}
-
 # on-the-fly configuration {{{
 
 case "${SUITE}" in
@@ -616,7 +574,7 @@ else
   FAI_ACTION=dirinstall
 fi
 
-if ! [ "$FAI_ACTION" = dirinstall ] && ! [ -r "$CHROOT_OUTPUT/etc/debian_version" ] ; then
+if ! [ "$FAI_ACTION" = dirinstall ] && [ -z "$EXTRACT_ISO_NAME" ] && ! [ -r "$CHROOT_OUTPUT/etc/debian_version" ] ; then
   log    "Error: does not look like you have a working chroot. Updating/building not possible."
   eerror "Error: does not look like you have a working chroot. Updating/building not possible. (Drop -u/-b/-B option?)"
   eend 1

--- a/grml-live
+++ b/grml-live
@@ -104,7 +104,11 @@ HOSTNAME=''
 USERNAME=''
 CHROOT_INSTALL=''
 CONFIGDUMP=''
+EXTRACT_ISO_NAME=''
 FAI_PROGRAM=$GRML_LIVE_LIB_DIR/minifai
+LIVE_CONF=''
+LOCAL_CONFIG=''
+WAYBACK_DATE=''
 # }}}
 
 # don't use colors/escape sequences
@@ -214,8 +218,6 @@ if [ -n "$LOCAL_CONFIG" ]; then
     bailout 1
   fi
   LOCAL_CONFIG=$(readlink -f "$LOCAL_CONFIG")
-else
-  LOCAL_CONFIG=''
 fi
 # }}}
 
@@ -634,9 +636,16 @@ mkdir -p "$CHROOT_OUTPUT" || bailout 5 "Problem with creating $CHROOT_OUTPUT"
 
 # minifai needs to see these
 export CHROOT_INSTALL
+export CMDLINE
+export EXTRACT_ISO_NAME
 export GRML_NAME
+export GRML_LIVE_VERSION
 export ISO_NAME
+export LIVE_CONF
+export LOCAL_CONFIG
 export MKSQUASHFS_BINARY
+export SECURE_BOOT
+export WAYBACK_DATE
 
 log "Executed FAI command line:"
 log "${FAI_PROGRAM} ${GRML_FAI_CONFIG} ${CLASSES} ${FAI_ACTION} ${OUTPUT} ${CONFIGDUMP} ${SUITE} ${BOOTSTRAP_MIRROR}"
@@ -657,56 +666,6 @@ einfo "Finished execution of stage 'fai $FAI_ACTION'"
 # BUILD_OUTPUT - execute arch specific stuff and squashfs {{{
 mkdir -p "$BUILD_OUTPUT" || bailout 6 "Problem with creating $BUILD_OUTPUT for stage ARCH"
 
-# information how the ISO was generated {{{
-# shellcheck disable=SC2034
-generate_build_info() {
-  local output_dir_placeholder="<output_dir>"
-  local configdump_placeholder="<configdump_file>"
-  jo -p \
-    build_date="${DATE}" \
-    build_dirty="${BUILD_DIRTY}" \
-    build_only="${BUILD_ONLY}" \
-    chroot_install="${CHROOT_INSTALL}" \
-    classes="${CLASSES}" \
-    default_bootoptions="${DEFAULT_BOOTOPTIONS}" \
-    distri_info="${DISTRI_INFO}" \
-    distri_name="${DISTRI_NAME}" \
-    extract_iso_name="${EXTRACT_ISO_NAME}" \
-    fai_cmdline="${FAI_PROGRAM} ${GRML_FAI_CONFIG} ${CLASSES} ${FAI_ACTION} ${OUTPUT} ${configdump_placeholder} ${SUITE} ${BOOTSTRAP_MIRROR}" \
-    fai_version="minifai" \
-    grml_architecture="${ARCH}" \
-    grml_bootid="${BOOTID}" \
-    grml_build_output="${BUILD_OUTPUT}" \
-    grml_chroot_output="${CHROOT_OUTPUT}" \
-    grml_debian_version="${SUITE}" \
-    grml_iso_name="${ISO_NAME}" \
-    grml_iso_output="${ISO_OUTPUT}" \
-    grml_live_cmdline="${CMDLINE}" \
-    grml_live_config_file="${LIVE_CONF}" \
-    grml_live_version="${GRML_LIVE_VERSION}" \
-    grml_local_config="${LOCAL_CONFIG}" \
-    grml_name="${GRML_NAME}" \
-    grml_short_name="${SHORT_NAME}" \
-    grml_username="${USERNAME}" \
-    grml_version="${VERSION}" \
-    host_architecture="$(dpkg --print-architecture || true)" \
-    mkisofs_cmdline="${XORRISO_BINARY} -as mkisofs -V '${GRML_NAME} ${VERSION}' -publisher 'grml-live | grml.org' -l -r -J ${BOOT_ARGS} ${EFI_ARGS} -o ${ISO_OUTPUT}/${ISO_NAME}" \
-    mkisofs_version="$(${XORRISO_BINARY} --version 2>/dev/null | head -1 || true)" \
-    mksquashfs_cmdline="${MKSQUASHFS_BINARY} ${CHROOT_OUTPUT}/ ${BUILD_OUTPUT}/live/${GRML_NAME}/${GRML_NAME}.squashfs -noappend ${SQUASHFS_OPTIONS}" \
-    mksquashfs_version="$(${MKSQUASHFS_BINARY} -version | head -1 || true)" \
-    release_info="${RELEASE_INFO}" \
-    release_name="${RELEASENAME}" \
-    secure_boot="${SECURE_BOOT}" \
-    skip_mksquashfs="${SKIP_MKSQUASHFS}" \
-    squashfs_name="${SQUASHFS_NAME}" \
-    timestamp="${SOURCE_DATE_EPOCH}" \
-    update_only="${UPDATE}" \
-    wayback_date="${WAYBACK_DATE}" \
-  -- | \
-   sed "s|$OUTPUT|${output_dir_placeholder}|g"
-}
-# }}}
-
 # ISO_OUTPUT - iso build {{{
 EFI_ARGS="-eltorito-alt-boot -e boot/efi.img -no-emul-boot -isohybrid-gpt-basdat"
 
@@ -719,13 +678,6 @@ else
 fi
 
 mkdir -p "$ISO_OUTPUT" || bailout 6 "Problem with creating $ISO_OUTPUT for stage 'iso build'"
-
-log   "Generating build information in conf/buildinfo.json"
-einfo "Generating build information in conf/buildinfo.json"
-mkdir -p "$BUILD_OUTPUT"/conf/
-generate_build_info > "$BUILD_OUTPUT"/conf/buildinfo.json
-cp "$BUILD_OUTPUT"/conf/buildinfo.json "$LOG_OUTPUT"/buildinfo.json
-eend $?
 
 log "${XORRISO_BINARY} -as mkisofs -V '${GRML_NAME} ${VERSION}' -publisher 'grml-live | grml.org' -l -r -J ${BOOT_ARGS} ${EFI_ARGS} -o ${ISO_OUTPUT}/${ISO_NAME}"
 einfo "Generating ISO file..."

--- a/grml-live
+++ b/grml-live
@@ -27,12 +27,14 @@ GRML_LIVE_INSTALL_PREFIX=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/
 if [ -e "${GRML_LIVE_INSTALL_PREFIX}"/usr/lib/grml-live ]; then
     # assume source checkout
     GRML_LIVE_LIB_DIR="${GRML_LIVE_INSTALL_PREFIX}"/usr/lib/grml-live
+    DEFAULT_GRML_FAI_CONFIG="$(readlink -f "${GRML_LIVE_INSTALL_PREFIX}"/config)"
     if command -v git &>/dev/null; then
         GRML_LIVE_VERSION=$(git describe --always)
     fi
 else
     GRML_LIVE_INSTALL_PREFIX=${GRML_LIVE_INSTALL_PREFIX}/../
     GRML_LIVE_LIB_DIR=${GRML_LIVE_INSTALL_PREFIX}/lib/grml-live
+    DEFAULT_GRML_FAI_CONFIG=/usr/share/grml-live/config
 fi
 # }}}
 
@@ -49,7 +51,7 @@ Usage: $PN [options, see as follows]
    -c <class[es]>          classes to be used for building the ISO
    -C <configfile>         configuration file for grml-live
    -d <date>               use specified date instead of build time as date of release
-   -D <configdir>          use specified configuration directory instead of /usr/share/grml-live/config
+   -D <configdir>          use specified configuration directory instead of ${DEFAULT_GRML_FAI_CONFIG}
    -e <iso_name>           extract ISO and squashfs contents from iso_name
    -F                      force execution without prompting
    -g <grml_name>          set the grml flavour name
@@ -307,7 +309,7 @@ fi
 [ -n "$DEFAULT_BOOTOPTIONS" ]     || DEFAULT_BOOTOPTIONS=''
 [ -n "$DISTRI_INFO" ]             || DISTRI_INFO='Grml - Live Linux for system administrators'
 [ -n "$DISTRI_NAME" ]             || DISTRI_NAME="grml"
-[ -n "$GRML_FAI_CONFIG" ]         || GRML_FAI_CONFIG='/usr/share/grml-live/config'
+[ -n "$GRML_FAI_CONFIG" ]         || GRML_FAI_CONFIG="${DEFAULT_GRML_FAI_CONFIG}"
 [ -n "$GRML_NAME" ]               || GRML_NAME='grml'
 [ -n "$HOSTNAME" ]                || HOSTNAME='grml'
 [ -n "$OUTPUT" ]                  || OUTPUT="$PWD/grml/"

--- a/grml-live
+++ b/grml-live
@@ -676,12 +676,6 @@ if [ -n "$CHROOT_INSTALL" ] ; then
   fi
 fi
 
-# create md5sum file:
-# shellcheck disable=SC2094 # find execution ignores written file
-( cd "$BUILD_OUTPUT"/GRML/"${GRML_NAME}" &&
-find ../.. -type f -not -name md5sums -exec md5sum {} \; > md5sums )
-# }}}
-
 # information how the ISO was generated {{{
 # shellcheck disable=SC2034
 generate_build_info() {

--- a/grml-live
+++ b/grml-live
@@ -748,8 +748,6 @@ generate_build_info > "$BUILD_OUTPUT"/conf/buildinfo.json
 cp "$BUILD_OUTPUT"/conf/buildinfo.json "$LOG_OUTPUT"/buildinfo.json
 eend $?
 
-cap_timestamps "$BUILD_OUTPUT"
-
 log "${XORRISO_BINARY} -as mkisofs -V '${GRML_NAME} ${VERSION}' -publisher 'grml-live | grml.org' -l -r -J ${BOOT_ARGS} ${EFI_ARGS} -o ${ISO_OUTPUT}/${ISO_NAME}"
 einfo "Generating ISO file..."
 touch -d @"$SOURCE_DATE_EPOCH" "$BUILD_OUTPUT"/

--- a/grml-live
+++ b/grml-live
@@ -102,6 +102,7 @@ BUILD_ONLY=''
 BUILD_DIRTY=''
 HOSTNAME=''
 USERNAME=''
+CHROOT_INSTALL=''
 CONFIGDUMP=''
 FAI_PROGRAM=$GRML_LIVE_LIB_DIR/minifai
 # }}}
@@ -632,6 +633,7 @@ fi
 mkdir -p "$CHROOT_OUTPUT" || bailout 5 "Problem with creating $CHROOT_OUTPUT"
 
 # minifai needs to see these
+export CHROOT_INSTALL
 export GRML_NAME
 export ISO_NAME
 export MKSQUASHFS_BINARY
@@ -654,19 +656,6 @@ einfo "Finished execution of stage 'fai $FAI_ACTION'"
 
 # BUILD_OUTPUT - execute arch specific stuff and squashfs {{{
 mkdir -p "$BUILD_OUTPUT" || bailout 6 "Problem with creating $BUILD_OUTPUT for stage ARCH"
-
-# support installation of local files into the chroot/ISO
-if [ -n "$CHROOT_INSTALL" ] ; then
-  if ! [ -d "$CHROOT_INSTALL" ] ; then
-     log "Configuration variable \$CHROOT_INSTALL is set but not a directory; ignoring"
-     ewarn "Configuration variable \$CHROOT_INSTALL is set but not a directory; ignoring"
-  else
-     log "Copying local files to chroot as requested via \$CHROOT_INSTALL"
-     einfo "Copying local files to chroot as requested via \$CHROOT_INSTALL"
-     rsync -avz --inplace "$CHROOT_INSTALL"/ "$CHROOT_OUTPUT/"
-     eend $?
-  fi
-fi
 
 # information how the ISO was generated {{{
 # shellcheck disable=SC2034

--- a/grml-live
+++ b/grml-live
@@ -493,7 +493,6 @@ BUILD_OUTPUT="${OUTPUT}/grml_cd"
 CHROOT_OUTPUT="${OUTPUT}/grml_chroot"
 ISO_OUTPUT="${OUTPUT}/grml_isos"
 LOG_OUTPUT="${OUTPUT}/grml_logs"
-NETBOOT="${OUTPUT}/netboot"
 # }}}
 
 # create log file {{{
@@ -772,40 +771,6 @@ if hasclass RELEASE && [ "$RC" = 0 ] ; then
      fi
    )
 fi
-# }}}
-
-# netboot package {{{
-create_netbootpackage() {
-  local OUTPUT_NAME
-  local OUTPUT_FILE
-  OUTPUT_NAME=$(basename "${ISO_NAME}" .iso)-netboot
-  OUTPUT_FILE="${NETBOOT}/${OUTPUT_NAME}.tar"
-
-  mkdir -p "$NETBOOT"
-
-  local OUTPUTDIR="${NETBOOT}/build_tmp"
-
-  local WORKING_DIR="${OUTPUTDIR}/${OUTPUT_NAME}/"
-  mkdir -p "$WORKING_DIR"
-  cp --preserve=timestamp -r "$CHROOT_OUTPUT/grml-live/netboot/." "$WORKING_DIR/"
-
-  cap_timestamps "$OUTPUTDIR"
-  if tar -C "$OUTPUTDIR" -cf "${OUTPUT_FILE}" "${OUTPUT_NAME}" ; then
-    (
-      # shellcheck disable=SC2164 # We just wrote there. If it disappeared, too bad.
-      cd "$(dirname "${OUTPUT_FILE}")"
-      sha256sum "$(basename "${OUTPUT_FILE}")" > "${OUTPUT_FILE}.sha256"
-    )
-    einfo "Generated netboot package ${OUTPUT_FILE}" ; eend 0
-    rm -rf "${OUTPUTDIR}"
-  else
-    rm -rf "${OUTPUTDIR}"
-    eerror "Could not generate netboot package ${OUTPUT_FILE}" ; eend 1
-    bailout 21
-  fi
-}
-
-create_netbootpackage
 # }}}
 
 # {{{

--- a/grml-live
+++ b/grml-live
@@ -501,7 +501,6 @@ NETBOOT="${OUTPUT}/netboot"
 rm -f "$LOGFILE"
 mkdir -p "$(dirname "${LOGFILE}")"
 touch "$LOGFILE"
-chown root:adm "$LOGFILE"
 chmod 664 "$LOGFILE"
 # }}}
 

--- a/grml-live
+++ b/grml-live
@@ -646,12 +646,6 @@ einfo "Finished execution of stage 'fai $FAI_ACTION'"
 # BUILD_OUTPUT - execute arch specific stuff and squashfs {{{
 mkdir -p "$BUILD_OUTPUT" || bailout 6 "Problem with creating $BUILD_OUTPUT for stage ARCH"
 
-# prepare ISO
-einfo "Installing media files from chroot build"
-log   "Installing media files from chroot build"
-cp --preserve=timestamp -r "$CHROOT_OUTPUT/grml-live/media/." "$BUILD_OUTPUT/"
-eend 0
-
 # support installation of local files into the chroot/ISO
 if [ -n "$CHROOT_INSTALL" ] ; then
   if ! [ -d "$CHROOT_INSTALL" ] ; then

--- a/grml-live
+++ b/grml-live
@@ -313,6 +313,7 @@ fi
 [ -n "$SUITE" ]                   || SUITE='testing'
 [ -n "$USERNAME" ]                || USERNAME='grml'
 [ -n "$VERSION" ]                 || VERSION='0.0.1'
+[ -n "$ISO_NAME" ]                || ISO_NAME="${GRML_NAME}_${VERSION}.iso"
 # }}}
 
 # some misc checks before doing work {{{
@@ -640,6 +641,7 @@ mkdir -p "$CHROOT_OUTPUT" || bailout 5 "Problem with creating $CHROOT_OUTPUT"
 
 # minifai needs to see these
 export GRML_NAME
+export ISO_NAME
 export MKSQUASHFS_BINARY
 
 log "Executed FAI command line:"
@@ -727,8 +729,6 @@ generate_build_info() {
 # }}}
 
 # ISO_OUTPUT - iso build {{{
-[ -n "$ISO_NAME" ] || ISO_NAME="${GRML_NAME}_${VERSION}.iso"
-
 EFI_ARGS="-eltorito-alt-boot -e boot/efi.img -no-emul-boot -isohybrid-gpt-basdat"
 
 if [ "$ARCH" = "arm64" ]; then

--- a/grml-live
+++ b/grml-live
@@ -136,18 +136,6 @@ else
 fi
 # }}}
 
-# store logfiles {{{
-store_logfiles() {
-  # move minifai logs into grml_logs directory
-  mkdir -p "$LOG_OUTPUT"/fai/
-  cp --preserve=timestamp -r "$CHROOT_OUTPUT"/grml-live/log/* "$LOG_OUTPUT"/fai/
-  rm -rf "$CHROOT_OUTPUT"/grml-live/log
-
-  # ensure files are readable.
-  chmod a+rX "$LOG_OUTPUT"/fai/
-}
-# }}}
-
 # clean exit {{{
 bailout() {
   [ -n "$CONFIGDUMP"      ]  && rm -f  "$CONFIGDUMP"
@@ -642,10 +630,6 @@ log "${FAI_PROGRAM} ${GRML_FAI_CONFIG} ${CLASSES} ${FAI_ACTION} ${OUTPUT} ${CONF
 einfo "${FAI_PROGRAM} ${GRML_FAI_CONFIG} ${CLASSES} ${FAI_ACTION} ${OUTPUT} ${CONFIGDUMP} ${SUITE} ${BOOTSTRAP_MIRROR}"
 "${FAI_PROGRAM}" "${GRML_FAI_CONFIG}" "${CLASSES}" "${FAI_ACTION}" "${OUTPUT}" "${CONFIGDUMP}" "${SUITE}" "${BOOTSTRAP_MIRROR}" 2>&1 | tee -a "${LOGFILE}"
 RC="${PIPESTATUS[0]}" # notice: bash-only
-
-# Fetches logs from "${CHROOT_OUTPUT}"/grml-live/log.
-# Also run this on failure.
-store_logfiles
 
 if [ "$RC" != 0 ] ; then
   log    "Error: critical error while executing fai [exit code ${RC}]. Exiting."

--- a/grml-live
+++ b/grml-live
@@ -492,9 +492,7 @@ if [ -z "$BOOTID" ] ; then
   BOOTID=$(echo "${GRML_NAME}${VERSION}" | tr -d ',./;\- ')
 fi
 
-BUILD_OUTPUT="${OUTPUT}/grml_cd"
 CHROOT_OUTPUT="${OUTPUT}/grml_chroot"
-ISO_OUTPUT="${OUTPUT}/grml_isos"
 LOG_OUTPUT="${OUTPUT}/grml_logs"
 # }}}
 
@@ -632,9 +630,8 @@ if [ "$FAI_ACTION" = dirinstall ] && [ -r "$CHROOT_OUTPUT/etc/debian_version" ] 
   bailout 20
 fi
 
-mkdir -p "$CHROOT_OUTPUT" || bailout 5 "Problem with creating $CHROOT_OUTPUT"
-
 # minifai needs to see these
+export ARCH
 export CHROOT_INSTALL
 export CMDLINE
 export EXTRACT_ISO_NAME
@@ -646,6 +643,7 @@ export LOCAL_CONFIG
 export MKSQUASHFS_BINARY
 export SECURE_BOOT
 export WAYBACK_DATE
+export VERSION
 
 log "Executed FAI command line:"
 log "${FAI_PROGRAM} ${GRML_FAI_CONFIG} ${CLASSES} ${FAI_ACTION} ${OUTPUT} ${CONFIGDUMP} ${SUITE} ${BOOTSTRAP_MIRROR}"
@@ -661,48 +659,6 @@ fi
 
 log "Finished execution of stage 'fai $FAI_ACTION' [$(date)]"
 einfo "Finished execution of stage 'fai $FAI_ACTION'"
-# }}}
-
-# BUILD_OUTPUT - execute arch specific stuff and squashfs {{{
-mkdir -p "$BUILD_OUTPUT" || bailout 6 "Problem with creating $BUILD_OUTPUT for stage ARCH"
-
-# ISO_OUTPUT - iso build {{{
-EFI_ARGS="-eltorito-alt-boot -e boot/efi.img -no-emul-boot -isohybrid-gpt-basdat"
-
-if [ "$ARCH" = "arm64" ]; then
-  # No BIOS boot on arm64, only UEFI
-  BOOT_ARGS=""
-else
-  # Use GRUB for BIOS boot via El Torito
-  BOOT_ARGS="-b boot/grub/i386-pc/eltorito.img -no-emul-boot -boot-load-size 4 -boot-info-table --grub2-boot-info --grub2-mbr ${BUILD_OUTPUT}/boot/grub/i386-pc/boot_hybrid.img"
-fi
-
-mkdir -p "$ISO_OUTPUT" || bailout 6 "Problem with creating $ISO_OUTPUT for stage 'iso build'"
-
-log "${XORRISO_BINARY} -as mkisofs -V '${GRML_NAME} ${VERSION}' -publisher 'grml-live | grml.org' -l -r -J ${BOOT_ARGS} ${EFI_ARGS} -o ${ISO_OUTPUT}/${ISO_NAME}"
-einfo "Generating ISO file..."
-touch -d @"$SOURCE_DATE_EPOCH" "$BUILD_OUTPUT"/
-# shellcheck disable=SC2086 # BOOT_ARGS and EFI_ARGS need splitting
-"${XORRISO_BINARY}" -as mkisofs -V "${GRML_NAME} ${VERSION}" -publisher 'grml-live | grml.org' -l -r -J ${BOOT_ARGS} ${EFI_ARGS} -o "${ISO_OUTPUT}/${ISO_NAME}" "$BUILD_OUTPUT"/
-RC=$?
-eend $RC
-
-# do not continue on errors, otherwise we might generate/overwrite the ISO with dd if=... stuff
-if [ "$RC" != 0 ] ; then
-  log    "Error: critical error while generating ISO [exit code ${RC}]. Exiting."
-  eerror "Error: critical error while generating ISO [exit code ${RC}]. Exiting." ; eend 1
-  bailout "$RC"
-fi
-
-# generate ISO checksums if we are using class 'RELEASE':
-if hasclass RELEASE && [ "$RC" = 0 ] ; then
-   (
-     if cd "$ISO_OUTPUT" ; then
-       sha256sum "${ISO_NAME}" > "${ISO_NAME}.sha256" && \
-       touch -r "${ISO_NAME}" "${ISO_NAME}.sha256"
-     fi
-   )
-fi
 # }}}
 
 # finalize {{{

--- a/grml-live
+++ b/grml-live
@@ -79,23 +79,20 @@ More details: man grml-live + /usr/share/doc/grml-live/grml-live.html
 
 Please send your bug reports and feedback to the grml-team: http://grml.org/bugs/
 "
-   [ "$(id -u 2>/dev/null)" != 0 ] && echo "Please notice that this script requires root permissions."
 }
 
-# make sure it's possible to get usage information without being
-# root or actually executing the script
 if [ "$1" = '-h' ] || [ "$1" = '--help' ] ; then
    usage
    exit 0
 fi
 # }}}
 
-# some runtime checks {{{
-# we need root permissions for the build-process:
-if [ "$(id -u 2>/dev/null)" != 0 ] ; then
-   echo "Error: please run this script with uid 0 (root)." >&2
+# prevent running as root {{{
+if [ "$(id -u 2>/dev/null)" = 0 ] ; then
+   echo "Error: grml-live needs to run as non-root with working user namespaces." >&2
    exit 1
 fi
+# }}}
 
 # lsb-functions and configuration stuff {{{
 # make sure they are not set by default

--- a/grml-live
+++ b/grml-live
@@ -139,7 +139,6 @@ fi
 # clean exit {{{
 bailout() {
   [ -n "$CONFIGDUMP"      ]  && rm -f  "$CONFIGDUMP"
-  [ -n "$SQUASHFS_STDERR" ]  && rm -rf "$SQUASHFS_STDERR"
   [ -n "$1" ] && EXIT="$1" || EXIT="1"
   [ -n "$2" ] && eerror "$2">&2
   log "------------------------------------------------------------------------------"
@@ -414,8 +413,20 @@ if [ -n "$BUILD_ONLY" ] && [ -n "$UPDATE" ] ; then
   eerror "Only one of -b and -u can be given at a time. Remove one of them."
   bailout 1
 fi
+if [ -n "$BUILD_ONLY" ] && [ -n "$SKIP_MKSQUASHFS" ] ; then
+  eerror "Only one of -b and -q can be given at a time. Remove one of them."
+  bailout 1
+fi
 if [ -n "$BUILD_DIRTY" ] && [ -n "$UPDATE" ] ; then
   eerror "Only one of -B and -u can be given at a time. Remove one of them."
+  bailout 1
+fi
+if [ -n "$BUILD_DIRTY" ] && [ -n "$SKIP_MKSQUASHFS" ] ; then
+  eerror "Only one of -B and -q can be given at a time. Remove one of them."
+  bailout 1
+fi
+if [ -n "$UPDATE" ] && [ -n "$SKIP_MKSQUASHFS" ] ; then
+  eerror "Only one of -u and -q can be given at a time. Remove one of them."
   bailout 1
 fi
 # }}}
@@ -605,6 +616,8 @@ elif [ -n "$UPDATE" ] ; then
   FAI_ACTION=softupdate
 elif [ -n "$BUILD_DIRTY" ] ; then
   FAI_ACTION=rebuild
+elif [ -n "$SKIP_MKSQUASHFS" ] ; then
+  FAI_ACTION=rebuild_media
 else
   FAI_ACTION=dirinstall
 fi
@@ -624,6 +637,10 @@ if [ "$FAI_ACTION" = dirinstall ] && [ -r "$CHROOT_OUTPUT/etc/debian_version" ] 
 fi
 
 mkdir -p "$CHROOT_OUTPUT" || bailout 5 "Problem with creating $CHROOT_OUTPUT"
+
+# minifai needs to see these
+export GRML_NAME
+export MKSQUASHFS_BINARY
 
 log "Executed FAI command line:"
 log "${FAI_PROGRAM} ${GRML_FAI_CONFIG} ${CLASSES} ${FAI_ACTION} ${OUTPUT} ${CONFIGDUMP} ${SUITE} ${BOOTSTRAP_MIRROR}"
@@ -657,44 +674,6 @@ if [ -n "$CHROOT_INSTALL" ] ; then
      rsync -avz --inplace "$CHROOT_INSTALL"/ "$CHROOT_OUTPUT/"
      eend $?
   fi
-fi
-
-if [ -n "$SKIP_MKSQUASHFS" ] ; then
-   log   "Skipping stage 'squashfs' as requested via option -q"
-   ewarn "Skipping stage 'squashfs' as requested via option -q" ; eend 0
-else
-   mkdir -p "$BUILD_OUTPUT"/live/"${GRML_NAME}"/
-
-   # use block size 1m as this gives good result with regards to time + compression
-   SQUASHFS_OPTIONS="-b 1m -comp xz"
-
-   # Ignore all extended attributes. This avoids:
-   # 1) leaking containerization supplied selinux attributes into the squashfs,
-   # 2) prevents unpacking errors in a later build-only step in containers not supporting xattrs.
-   SQUASHFS_OPTIONS="$SQUASHFS_OPTIONS -no-xattrs"
-
-   # Static file exclusion list.
-   SQUASHFS_OPTIONS="${SQUASHFS_OPTIONS} -wildcards -ef ${GRML_FAI_CONFIG}/grml/squashfs-excludes"
-
-   # log stuff
-   SQUASHFS_STDERR="$(mktemp -t grml-live.XXXXXX)"
-   einfo "Squashfs build information: running $MKSQUASHFS_BINARY using options: $SQUASHFS_OPTIONS"
-
-   log "$MKSQUASHFS_BINARY $CHROOT_OUTPUT/ $BUILD_OUTPUT/live/${GRML_NAME}/${GRML_NAME}.squashfs -noappend $SQUASHFS_OPTIONS"
-   # shellcheck disable=SC2086 # $SQUASHFS_OPTIONS needs splitting
-   if "$MKSQUASHFS_BINARY" "$CHROOT_OUTPUT/" "$BUILD_OUTPUT"/live/"${GRML_NAME}"/"${GRML_NAME}".squashfs \
-      -noappend $SQUASHFS_OPTIONS 2>"${SQUASHFS_STDERR}" ; then
-      echo "${GRML_NAME}.squashfs" > "$BUILD_OUTPUT"/live/"${GRML_NAME}"/filesystem.module
-      log "Finished execution of stage 'squashfs' [$(date)]"
-      einfo "Finished execution of stage 'squashfs'" ; eend 0
-   else
-      log    "Error: there was a critical error executing stage 'squashfs' [$(date)]:"
-      log    "$(cat "$SQUASHFS_STDERR")"
-      eerror "Error: there was a critical error executing stage 'squashfs':"
-      cat    "${SQUASHFS_STDERR}"
-      eend 1
-      bailout
-   fi
 fi
 
 # create md5sum file:
@@ -800,15 +779,6 @@ if hasclass RELEASE && [ "$RC" = 0 ] ; then
        touch -r "${ISO_NAME}" "${ISO_NAME}.sha256"
      fi
    )
-fi
-
-if [ "$RC" = 0 ] ; then
-   log   "Finished execution of stage 'iso build' [$(date)]"
-   einfo "Finished execution of stage 'iso build'" ; eend 0
-else
-   log    "Error: there was a critical error ($RC) executing stage 'iso build' [$(date)]"
-   eerror "Error: there was a critical error executing stage 'iso build'" ; eend 1
-   bailout "$RC"
 fi
 # }}}
 

--- a/test/gha-build-iso.sh
+++ b/test/gha-build-iso.sh
@@ -26,11 +26,24 @@ run_build() {
     local results_directory
     results_directory=$3
 
-    docker run -i --rm --volume "${PWD}:/source" -e SKIP_SOURCES=1 -e DO_DAILY_UPLOAD=0 -e EXTRA_CLASSES="${EXTRA_CLASSES:-}" -e GITHUB_PR_NUMBER="${GITHUB_PR_NUMBER:-}" -w /source debian:"$HOST_RELEASE" \
-        bash -c \
-        "apt-get update -qq && apt-get satisfy -q -y --no-install-recommends 'git, ca-certificates' \
-        && git config --global --add safe.directory /source \
-        && /source/build-driver/build /source ${build_mode} /source/${config_filename} ghaci $ARCH trixie"
+    export SKIP_SOURCES=1
+    export DO_DAILY_UPLOAD=0
+    export EXTRA_CLASSES="${EXTRA_CLASSES:-}"
+    export GITHUB_PR_NUMBER="${GITHUB_PR_NUMBER:-}"
+    sudo apt-get update -qq
+    sudo apt-get satisfy -q -y --no-install-recommends 'git, ca-certificates, debian-archive-keyring'
+    if [ "$(cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns || true)" == "1" ]; then
+        # workaround unshare restrictions on Ubuntu 24.04. Symptom seen:
+        # "unshare: cannot change root filesystem propagation: Permission denied"
+        echo "W: turning off apparmor_restrict_unprivileged_usern to avoid unshare failure"
+        echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+    fi
+
+    # Processes in usernamespace must be able to chdir() to all parent directories
+    # so they can read the files in grml-live/config.
+    sudo chmod a+rX /home/runner
+
+    ./build-driver/build "${PWD}" "${build_mode}" "${PWD}"/"${config_filename}" ghaci "${ARCH}" testing
 
     sudo chmod -R a+rX results
     sudo mv results "${results_directory}"
@@ -49,12 +62,12 @@ elif [ "$MODE" = "build-only-twice" ]; then
     cat >build-gha-ci-test-config-build-only-first <<EOT
 ---
 last_release: "2024.12"
-debian_suite: trixie
+debian_suite: testing
 release_version: "${GITHUB_PR_NUMBER:+pr$GITHUB_PR_NUMBER-}ci1"
 release_name: "${GITHUB_PR_NUMBER:+PR$GITHUB_PR_NUMBER }CI1"
 base_iso:
     ghaci:
-        $ARCH: "file:///source/$INPUT_ISO"
+        $ARCH: "file://${PWD}/${INPUT_ISO}"
 EOT
 
     run_build build-gha-ci-test-config-build-only-first release results-build-only-first
@@ -63,12 +76,12 @@ EOT
     cat >build-gha-ci-test-config-build-only-second <<EOT
 ---
 last_release: "2024.12"
-debian_suite: trixie
+debian_suite: testing
 release_version: "${GITHUB_PR_NUMBER:+pr$GITHUB_PR_NUMBER-}ci2"
 release_name: "${GITHUB_PR_NUMBER:+PR$GITHUB_PR_NUMBER }CI2"
 base_iso:
     ghaci:
-        $ARCH: "file:///source/$INPUT_ISO"
+        $ARCH: "file://${PWD}/${INPUT_ISO}"
 EOT
 
     run_build build-gha-ci-test-config-build-only-second release results-build-only-second

--- a/usr/lib/grml-live/.gitignore
+++ b/usr/lib/grml-live/.gitignore
@@ -3,4 +3,5 @@
 /.venv
 /*.egg-info
 /dist
+/uv.lock
 __pycache__

--- a/usr/lib/grml-live/grml_live/file_ops.py
+++ b/usr/lib/grml-live/grml_live/file_ops.py
@@ -1,0 +1,31 @@
+import itertools
+import os
+from pathlib import Path
+
+
+def clamp_to_source_date_epoch(root_dir: Path | str):
+    source_date_epoch = os.environ["SOURCE_DATE_EPOCH"]
+    root_dir = Path(root_dir)
+    epoch = int(source_date_epoch)
+    dev0 = root_dir.lstat().st_dev
+
+    print(f"I: Clamping mtimes in {root_dir} to {epoch}")
+    os.utime(root_dir, (epoch, epoch), follow_symlinks=False)
+
+    for dirpath, dirnames, filenames in os.walk(root_dir, followlinks=False):
+        kept_dirs = []
+        for name in dirnames:
+            path = os.path.join(dirpath, name)
+            stat_result = os.lstat(path)
+            if stat_result.st_dev != dev0:
+                continue
+            kept_dirs.append(name)
+            if stat_result.st_mtime > epoch:
+                os.utime(path, (epoch, epoch), follow_symlinks=False)
+
+        dirnames[:] = kept_dirs
+
+        for name in itertools.chain(dirnames, filenames):
+            path = os.path.join(dirpath, name)
+            if os.lstat(path).st_mtime > epoch:
+                os.utime(path, (epoch, epoch), follow_symlinks=False)

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -833,6 +833,39 @@ def create_netboot_package(
         run_x(["sha256sum", output_name.name], cwd=output_name.parent, stdout=checksum_file_handle)
 
 
+def create_sources_package(
+    output_dir: Path,
+    chroot_sources_dir: Path,
+    iso_name: str,
+):
+    """
+    Create sources tar package.
+    Filename is derived from the iso_name, and its toplevel directory matches the tar filename.
+    """
+    output_basename = iso_name.rpartition(".iso")[0] + "-sources"
+    output_name = output_dir / (output_basename + ".tar")
+    print(f"I: building sources tar: {output_name.name}")
+
+    run_x(
+        [
+            "tar",
+            "-C",
+            chroot_sources_dir,
+            "-cf",
+            output_name,
+            "--owner=0",
+            "--group=0",
+            "--transform",
+            r"s|^./|" + output_basename + "/|",
+            ".",
+        ]
+    )
+
+    checksum_filename = Path(str(output_name) + ".sha256")
+    with checksum_filename.open("wt") as checksum_file_handle:
+        run_x(["sha256sum", output_name.name], cwd=output_name.parent, stdout=checksum_file_handle)
+
+
 def _run_tasks(
     conf_dir: Path,
     output_dir: Path,
@@ -934,6 +967,12 @@ def _run_tasks(
                     chroot_directories.netboot_dir,
                     iso_name,
                 )
+                if "SOURCES" in classes:
+                    create_sources_package(
+                        output_dir,
+                        chroot_directories.sources_dir,
+                        iso_name,
+                    )
 
                 # After this, no new files should appear.
                 create_on_media_md5sums(grml_cd_dir, grml_name)

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -878,7 +878,14 @@ def _run_tasks(
                     ],
                 )
 
+                # After this, no new files should appear.
                 create_on_media_md5sums(grml_cd_dir, grml_name)
+
+                # After this, no files should be touched any more.
+                source_date_epoch = os.getenv("SOURCE_DATE_EPOCH")
+                if source_date_epoch:
+                    print(f"I: Clamping mtimes to {source_date_epoch}")
+                    unshared_service.run(unshared_helper.clamp_to_source_date(grml_cd_dir, source_date_epoch))
 
     finally:
         copy_directory_out(grml_logs_dir / "fai", chroot_directories.log_dir)

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -798,6 +798,41 @@ def create_on_media_md5sums(grml_cd_dir: Path, grml_name: str):
     run_x(["/bin/ls", "-la", md5sums_file])
 
 
+def create_netboot_package(
+    output_dir: Path,
+    chroot_netboot_dir: Path,
+    iso_name: str,
+):
+    """
+    Create netboot tar package.
+    Filename is derived from the iso_name, and its toplevel directory matches the tar filename.
+    """
+    output_basename = iso_name.rpartition(".iso")[0] + "-netboot"
+    output_netboot_dir = output_dir / "netboot"
+    output_netboot_dir.mkdir()
+    output_name = output_netboot_dir / (output_basename + ".tar")
+    print(f"I: building netboot tar: {output_name.name}")
+
+    run_x(
+        [
+            "tar",
+            "-C",
+            chroot_netboot_dir,
+            "-cf",
+            output_name,
+            "--owner=0",
+            "--group=0",
+            "--transform",
+            r"s|^./|" + output_basename + "/|",
+            ".",
+        ]
+    )
+
+    checksum_filename = Path(str(output_name) + ".sha256")
+    with checksum_filename.open("wt") as checksum_file_handle:
+        run_x(["sha256sum", output_name.name], cwd=output_name.parent, stdout=checksum_file_handle)
+
+
 def _run_tasks(
     conf_dir: Path,
     output_dir: Path,
@@ -893,6 +928,11 @@ def _run_tasks(
                         str(chroot_directories.media_dir) + "/.",
                         grml_cd_dir,
                     ],
+                )
+                create_netboot_package(
+                    output_dir,
+                    chroot_directories.netboot_dir,
+                    iso_name,
                 )
 
                 # After this, no new files should appear.

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -24,6 +24,10 @@ from .packages import PackageList, parse_class_packages
 
 APT_DEBUG_ACQUIRE = "Debug::Acquire::http=true"
 
+# UID/GID *inside* the userns that is mapped to the executing user.
+UNSHARE_UID = 65536
+UNSHARE_GID = 65536
+
 
 class FaiScriptFailed(Exception):
     pass
@@ -97,8 +101,8 @@ def _prepare_subprocess_args(args, *, unshared: bool, chroot_dir: Path | None, *
             "unshare",
             "--user",
             "--map-auto",
-            "--map-user=65536",
-            "--map-group=65536",
+            f"--map-user={UNSHARE_UID}",
+            f"--map-group={UNSHARE_GID}",
             "--pid",
             "--mount-proc",
             "--uts",

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -764,6 +764,25 @@ def mksquashfs(
     )
 
 
+def create_on_media_md5sums(grml_cd_dir: Path, grml_name: str):
+    print("I: preparing md5sums file")
+
+    grml_dir = grml_cd_dir / "GRML"
+    grml_dir.mkdir(exist_ok=True)  # media-scripts may have created it
+    named_grml_dir = grml_dir / grml_name
+    named_grml_dir.mkdir(exist_ok=True)  # media-scripts may have created it
+    md5sums_file = named_grml_dir / "md5sums"
+
+    filenames = [
+        filename.relative_to(grml_cd_dir) for filename in sorted(grml_cd_dir.rglob("*")) if not filename.is_dir()
+    ]
+
+    with md5sums_file.open("wb") as output:
+        run_x(["/bin/md5sum", *filenames], cwd=grml_cd_dir, stdout=output)
+
+    run_x(["/bin/ls", "-la", md5sums_file])
+
+
 def _run_tasks(
     conf_dir: Path,
     output_dir: Path,
@@ -858,6 +877,8 @@ def _run_tasks(
                         grml_cd_dir,
                     ],
                 )
+
+                create_on_media_md5sums(grml_cd_dir, grml_name)
 
     finally:
         copy_directory_out(grml_logs_dir / "fai", chroot_directories.log_dir)

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -937,7 +937,16 @@ def _build_buildinfo_data(
         "grml_username": grml_live_config["USERNAME"],
         "grml_version": grml_live_config["VERSION"],
         "host_architecture": host_arch,
-        "mkisofs_cmdline": "...",
+        "mkisofs_cmdline": " ".join(
+            _build_xorriso_options(
+                output_dir / "grml_isos",
+                output_dir / "grml_cd",
+                grml_live_config["GRML_NAME"],
+                grml_live_config["VERSION"],
+                os.environ["ISO_NAME"],
+                os.environ["ARCH"],
+            )
+        ),
         "mkisofs_version": mkisofs_version,
         "mksquashfs_cmdline": " ".join(_build_mksquashfs_options(conf_dir)),
         "mksquashfs_version": mksquashfs_version,
@@ -969,6 +978,69 @@ def write_buildinfo_json(
     print(f"I: buildinfo data:\n{buildinfo!s}")
     (grml_cd_dir / "conf").mkdir(exist_ok=True)
     (grml_cd_dir / "conf" / "buildinfo.json").write_text(json.dumps(buildinfo))
+
+
+def _build_xorriso_options(
+    iso_dir: Path, grml_cd_dir: Path, grml_name: str, version: str, iso_name: str, arch: str
+) -> list[str]:
+
+    efi_args = ["-eltorito-alt-boot", "-e", "boot/efi.img", "-no-emul-boot", "-isohybrid-gpt-basdat"]
+
+    if arch == "arm64":
+        # No BIOS boot on arm64, only UEFI
+        boot_args = []
+    elif arch == "amd64":
+        # TODO: avoid the arch check and use the file existence instead
+        # Use GRUB for BIOS boot via El Torito
+        boot_args = [
+            "-b",
+            "boot/grub/i386-pc/eltorito.img",
+            "-no-emul-boot",
+            "-boot-load-size",
+            "4",
+            "-boot-info-table",
+            "--grub2-boot-info",
+            "--grub2-mbr",
+            str(grml_cd_dir / "boot" / "grub" / "i386-pc" / "boot_hybrid.img"),
+        ]
+    else:
+        raise NotImplementedError()
+
+    return [
+        "xorriso",
+        "-as",
+        "mkisofs",
+        "-V",
+        f"{grml_name} {version}",
+        "-publisher",
+        "grml-live | grml.org",
+        "-l",
+        "-r",
+        "-J",
+        *boot_args,
+        *efi_args,
+        "-o",
+        str(iso_dir / iso_name),
+        str(grml_cd_dir) + "/",
+    ]
+
+
+def create_media(
+    output_dir: Path,
+    grml_cd_dir: Path,
+    grml_name: str,
+    version: str,
+    iso_name: str,
+    arch: str,
+):
+    iso_dir = output_dir / "grml_isos"
+    iso_dir.mkdir()
+    print("I: Generating ISO file ...")
+    run_x(_build_xorriso_options(iso_dir, grml_cd_dir, grml_name, version, iso_name, arch))
+
+    checksum_filename = Path(str(iso_dir / iso_name) + ".sha256")
+    with checksum_filename.open("wt") as checksum_file_handle:
+        run_x(["sha256sum", iso_name], cwd=iso_dir, stdout=checksum_file_handle)
 
 
 def _run_tasks(
@@ -1004,12 +1076,16 @@ def _run_tasks(
         )
     )
 
+    arch = os.environ["ARCH"]
+    print(f"I: ARCH: {arch!r}")
     chroot_install = os.environ["CHROOT_INSTALL"]
     print(f"I: CHROOT_INSTALL: {chroot_install!r}")
     grml_name = os.environ["GRML_NAME"]
     print(f"I: GRML_NAME: {grml_name!r}")
     iso_name = os.environ["ISO_NAME"]
     print(f"I: ISO_NAME: {iso_name!r}")
+    version = os.environ["VERSION"]
+    print(f"I: VERSION: {version!r}")
 
     do_skiptask(dynamic_state, skip_tasks)
 
@@ -1094,6 +1170,8 @@ def _run_tasks(
                 if source_date_epoch:
                     print(f"I: Clamping mtimes to {source_date_epoch}")
                     unshared_service.run(unshared_helper.clamp_to_source_date(grml_cd_dir, source_date_epoch))
+
+                create_media(output_dir, grml_cd_dir, grml_name, version, iso_name, arch)
 
     finally:
         copy_directory_out(grml_logs_dir / "fai", chroot_directories.log_dir)

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -6,6 +6,7 @@
 import argparse
 import contextlib
 import datetime
+import json
 import os
 import shlex
 import shutil
@@ -892,6 +893,84 @@ def create_sources_package(
         run_x(["sha256sum", output_name.name], cwd=output_name.parent, stdout=checksum_file_handle)
 
 
+def _build_buildinfo_data(
+    conf_dir: Path,
+    output_dir: Path,
+    fai_action: str,
+    classes: list[str],
+    grml_live_config: dict[str, str],
+):
+    # TODO: collect the data in each step creating the data, instead of doing it all here.
+    proc = popen(["dpkg", "--print-architecture"], stdout=subprocess.PIPE, text=True)
+    stdout_data, _ = proc.communicate()
+    host_arch = stdout_data.strip()
+
+    proc = popen(["xorriso", "--version"], stdout=subprocess.PIPE, text=True)
+    stdout_data, _ = proc.communicate()
+    mkisofs_version = stdout_data.splitlines()[0].strip()
+
+    proc = popen(["mksquashfs", "-version"], stdout=subprocess.PIPE, text=True)
+    stdout_data, _ = proc.communicate()
+    mksquashfs_version = stdout_data.splitlines()[0].strip()
+
+    buildinfo = {
+        "build_date": grml_live_config["DATE"],
+        "fai_action": fai_action,
+        "chroot_install": os.environ["CHROOT_INSTALL"],
+        "classes": ",".join(classes),
+        "default_bootoptions": grml_live_config["DEFAULT_BOOTOPTIONS"],
+        "distri_info": grml_live_config["DISTRI_INFO"],
+        "distri_name": grml_live_config["DISTRI_NAME"],
+        "extract_iso_name": os.environ["EXTRACT_ISO_NAME"],
+        "fai_cmdline": " ".join(sys.argv[1:]),
+        "fai_version": "minifai",
+        "grml_architecture": os.environ["ARCH"],
+        "grml_bootid": grml_live_config["BOOTID"],
+        "grml_debian_version": os.environ["SUITE"],
+        "grml_iso_name": os.environ["ISO_NAME"],
+        "grml_live_cmdline": os.environ["CMDLINE"],
+        "grml_live_config_file": os.environ["LIVE_CONF"],
+        "grml_live_version": os.environ["GRML_LIVE_VERSION"],
+        "grml_local_config": os.environ["LOCAL_CONFIG"],
+        "grml_name": grml_live_config["GRML_NAME"],
+        "grml_short_name": grml_live_config["SHORT_NAME"],
+        "grml_username": grml_live_config["USERNAME"],
+        "grml_version": grml_live_config["VERSION"],
+        "host_architecture": host_arch,
+        "mkisofs_cmdline": "...",
+        "mkisofs_version": mkisofs_version,
+        "mksquashfs_cmdline": " ".join(_build_mksquashfs_options(conf_dir)),
+        "mksquashfs_version": mksquashfs_version,
+        "release_info": grml_live_config["RELEASE_INFO"],
+        "release_name": grml_live_config["RELEASENAME"],
+        "secure_boot": os.environ["SECURE_BOOT"],
+        "timestamp": os.environ["SOURCE_DATE_EPOCH"],
+        "wayback_date": os.environ["WAYBACK_DATE"],
+    }
+    buildinfo = {key: value.replace(str(output_dir), "<output_dir>") for key, value in buildinfo.items()}
+    return buildinfo
+
+
+def write_buildinfo_json(
+    conf_dir: Path,
+    output_dir: Path,
+    grml_cd_dir: Path,
+    fai_action: str,
+    classes: list[str],
+    grml_live_config: dict[str, str],
+):
+    buildinfo = _build_buildinfo_data(
+        conf_dir,
+        output_dir,
+        fai_action,
+        classes,
+        grml_live_config,
+    )
+    print(f"I: buildinfo data:\n{buildinfo!s}")
+    (grml_cd_dir / "conf").mkdir(exist_ok=True)
+    (grml_cd_dir / "conf" / "buildinfo.json").write_text(json.dumps(buildinfo))
+
+
 def _run_tasks(
     conf_dir: Path,
     output_dir: Path,
@@ -992,6 +1071,9 @@ def _run_tasks(
                         grml_cd_dir,
                     ],
                 )
+
+                write_buildinfo_json(conf_dir, output_dir, grml_cd_dir, fai_action, classes, grml_live_config)
+
                 create_netboot_package(
                     output_dir,
                     chroot_directories.netboot_dir,

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -621,6 +621,31 @@ def install_base(conf_dir: Path, chroot_dir: Path, classes, debian_suite: str, m
     run_x(args)
 
 
+def extract_iso(chroot_dir: Path, extract_iso_name: str):
+    """Unpack squashfs from an existing ISO to use it as the chroot_dir contents."""
+    print(f"I: Unpacking ISO from {extract_iso_name}")
+
+    try:
+        # Run unshared, so the unpacked chroot is owned by the correct uids.
+        run_x(["osirrox", "-indev", extract_iso_name, "-extract", "live", chroot_dir])
+        temp_files = sorted(chroot_dir.rglob("*"))
+        print(f"D: found extracted files: {temp_files!s}")
+
+        squashfs_files = sorted(chroot_dir.glob("*/*.squashfs"))
+        if not squashfs_files:
+            raise RuntimeError(f"Could not find any squashfs files in ISO {extract_iso_name}")
+        if len(squashfs_files) != 1:
+            raise RuntimeError(
+                f"Found more than one squashfs file in ISO {extract_iso_name}: {' '.join(squashfs_files)}"
+            )
+        run_x(["unsquashfs", "-f", "-d", chroot_dir, squashfs_files[0]], unshared=True)
+        run_x(["rm", "-rf", *temp_files], unshared=True)
+    except:
+        # This should be safe as chroot_dir is expected to be empty at first!
+        run_x(["rm", "-rf", chroot_dir], unshared=True)
+        raise
+
+
 def should_skip_task(dynamic_state: DynamicState, task: str) -> bool:
     if task in dynamic_state.skip_tasks:
         print(f'I: Skipping FAI task "{task}", as dynamically requested')
@@ -1214,9 +1239,6 @@ def _main(program_name: str, argv: list[str]) -> int:
         raise ValueError(f"Output directory {output_dir} does not exist")
 
     chroot_dir = output_dir / "grml_chroot"
-    chroot_dir.mkdir(
-        exist_ok=True  # for now, as grml_live has to mount the mirror
-    )
 
     grml_live_config = _parse_bash_set(args.grml_live_config.read_text())
     show_env("configdump", grml_live_config)
@@ -1227,6 +1249,18 @@ def _main(program_name: str, argv: list[str]) -> int:
         with start_unshared_service() as unshared_service:
             unshared_service.run(unshared_helper.hello_world())
             skiptasks = []
+
+            extract_iso_name = os.environ["EXTRACT_ISO_NAME"]
+            if extract_iso_name:
+                if args.action == FaiAction.DIRINSTALL:
+                    raise ValueError("Building a new chroot is incompatible with extracting an existing ISO")
+                extract_iso(chroot_dir, extract_iso_name)
+            else:
+                try:
+                    chroot_dir.mkdir()
+                except FileExistsError:
+                    if args.action == FaiAction.DIRINSTALL:
+                        raise ValueError(f"chroot directory {chroot_dir} unexpectedly already exists") from None
 
             if args.action == FaiAction.DIRINSTALL:
                 install_base(conf_dir, chroot_dir, classes, args.debian_suite, args.mirror_url)

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -34,6 +34,10 @@ class FaiScriptFailed(Exception):
     pass
 
 
+class ProgramStartFailed(Exception):
+    pass
+
+
 class FaiAction(StrEnum):
     DIRINSTALL = "dirinstall"
     SOFTUPDATE = "softupdate"
@@ -526,13 +530,24 @@ def start_unshared_service():
         args = unshared_helper.make_server_command(socket_path)
         subproc = popen(args, unshared=True)
 
-        listen_socket.settimeout(120)
-        try:
-            request_socket, _ = listen_socket.accept()
-        except TimeoutError:
-            print("E: unshared helper service did not connect")
+        request_socket = None
+        # 12 sec total timeout
+        listen_socket.settimeout(1)
+        for _ in range(12):
+            try:
+                request_socket, _ = listen_socket.accept()
+            except TimeoutError:
+                if subproc.poll() is not None:
+                    print(f"E: unshared helper service exited with rc={subproc.returncode} before connecting")
+                    raise ProgramStartFailed() from None
+                continue
+
+            break
+
+        if request_socket is None:
+            print("E: unshared helper service did not connect after timeout")
             subproc.kill()
-            raise
+            raise ProgramStartFailed()
 
         yield UnsharedService(request_socket)
 
@@ -935,13 +950,13 @@ def _main(program_name: str, argv: list[str]) -> int:
     grml_live_config = _parse_bash_set(args.grml_live_config.read_text())
     show_env("configdump", grml_live_config)
 
-    with start_unshared_service() as unshared_service:
-        unshared_service.run(unshared_helper.hello_world())
+    rc = 0
 
-        skiptasks = []
-        rc = 0
+    try:
+        with start_unshared_service() as unshared_service:
+            unshared_service.run(unshared_helper.hello_world())
+            skiptasks = []
 
-        try:
             if args.action == FaiAction.DIRINSTALL:
                 install_base(conf_dir, chroot_dir, classes, args.debian_suite, args.mirror_url)
             elif args.action == FaiAction.SOFTUPDATE:
@@ -967,13 +982,13 @@ def _main(program_name: str, argv: list[str]) -> int:
                     skiptasks,
                     unshared_service,
                 )
-        except (ClassFileParsingFailed, FaiScriptFailed):
-            # assume exception site already printed relevant info
-            rc = 3
-        except Exception:
-            print(f"E: {now_for_log()} minifai main caught fatal exception")
-            traceback.print_exc()
-            rc = 2
+    except (ClassFileParsingFailed, FaiScriptFailed, ProgramStartFailed):
+        # assume exception site already printed relevant info
+        rc = 3
+    except Exception:
+        print(f"E: {now_for_log()} minifai main caught fatal exception")
+        traceback.print_exc()
+        rc = 2
 
     print(f"I: minifai exiting with exit code {rc}")
     return rc

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -728,6 +728,32 @@ def copy_directory_out(
     )
 
 
+def install_extra_chroot_files(
+    chroot_dir: Path,
+    chroot_install: str,
+    unshared_service: UnsharedService,
+):
+    if not chroot_install:
+        return
+    chroot_install_source_dir = Path(chroot_install)
+    if not chroot_install_source_dir.exists() or not chroot_install_source_dir.is_dir():
+        print("W: Configuration variable $CHROOT_INSTALL is set but not a directory; ignoring")
+        return
+
+    print(f"I: Copying local files to chroot from {chroot_install_source_dir!s}")
+    unshared_service.run(
+        unshared_helper.run_program(
+            [
+                "rsync",
+                "-avz",
+                "--inplace",
+                str(chroot_install_source_dir) + "/",
+                str(chroot_dir) + "/",
+            ]
+        )
+    )
+
+
 def _build_mksquashfs_options(conf_dir: Path) -> list[str]:
     squashfs_excludes_file = conf_dir / "grml" / "squashfs-excludes"
     options = [
@@ -899,6 +925,8 @@ def _run_tasks(
         )
     )
 
+    chroot_install = os.environ["CHROOT_INSTALL"]
+    print(f"I: CHROOT_INSTALL: {chroot_install!r}")
     grml_name = os.environ["GRML_NAME"]
     print(f"I: GRML_NAME: {grml_name!r}")
     iso_name = os.environ["ISO_NAME"]
@@ -942,6 +970,8 @@ def _run_tasks(
             if not should_skip_task(dynamic_state, "configure"):
                 for class_name in classes:
                     run_class_scripts("scripts", conf_dir, chroot_dir, class_name, helper_tools_paths, env)
+
+                install_extra_chroot_files(chroot_dir, chroot_install, unshared_service)
 
             if not should_skip_task(dynamic_state, "squashfs"):
                 # mksquashfs is the last thing that should need the userns.

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -20,7 +20,7 @@ from enum import StrEnum
 from pathlib import Path
 from threading import Event, Thread
 
-from . import unshared_helper
+from . import file_ops, unshared_helper
 from .classes import ClassFileParsingFailed, parse_class_varfile
 from .packages import PackageList, parse_class_packages
 
@@ -1190,11 +1190,7 @@ def _run_tasks(
                 # After this, no new files should appear.
                 create_on_media_md5sums(grml_cd_dir, grml_name)
 
-                # After this, no files should be touched any more.
-                source_date_epoch = os.getenv("SOURCE_DATE_EPOCH")
-                if source_date_epoch:
-                    print(f"I: Clamping mtimes to {source_date_epoch}")
-                    unshared_service.run(unshared_helper.clamp_to_source_date(grml_cd_dir, source_date_epoch))
+                file_ops.clamp_to_source_date_epoch(grml_cd_dir)
 
                 create_media(output_dir, grml_cd_dir, grml_name, version, iso_name, arch)
 

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -7,6 +7,7 @@ import argparse
 import contextlib
 import datetime
 import os
+import shlex
 import shutil
 import socket
 import subprocess
@@ -82,6 +83,35 @@ class UnsharedService:
 
 def now_for_log() -> str:
     return datetime.datetime.now().isoformat()
+
+
+def _unquote_bash_single(s: str):
+    out, i, n = [], 0, len(s)
+    while i < n:
+        c = s[i]
+        if c == "'":
+            j = s.index("'", i + 1)
+            out.append(s[i + 1 : j])
+            i = j + 1
+        elif c == "\\" and i + 1 < n:
+            out.append(s[i + 1])
+            i += 2
+        else:
+            out.append(c)
+            i += 1
+    return "".join(out)
+
+
+def _parse_bash_set(text: str) -> dict[str, str]:
+    """Parse output of bash set, when restricted to single line key=value pairs."""
+    env = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        key, _, value = line.partition("=")
+        env[key] = _unquote_bash_single(value)
+    return env
 
 
 def _prepare_subprocess_args(args, *, unshared: bool, chroot_dir: Path | None, **kwargs):
@@ -687,7 +717,7 @@ def _run_tasks(
     output_dir: Path,
     chroot_dir: Path,
     classes: list[str],
-    grml_live_config: Path,
+    grml_live_config: dict[str, str],
     fai_action: str,
     skip_tasks: list[str],
     unshared_service: UnsharedService,
@@ -709,7 +739,11 @@ def _run_tasks(
 
     # duplicate grml_live_config into the chroot, so chrooted scripts can use it.
     grml_live_config_chroot = chroot_directories.build_dir / "config"
-    unshared_service.run(unshared_helper.write_file_text(grml_live_config_chroot, grml_live_config.read_text()))
+    unshared_service.run(
+        unshared_helper.write_file_text(
+            grml_live_config_chroot, "\n".join(f"{k}={shlex.quote(v)}" for k, v in grml_live_config.items())
+        )
+    )
 
     do_skiptask(dynamic_state, skip_tasks)
 
@@ -811,6 +845,9 @@ def _main(program_name: str, argv: list[str]) -> int:
         exist_ok=True  # for now, as grml_live has to mount the mirror
     )
 
+    grml_live_config = _parse_bash_set(args.grml_live_config.read_text())
+    show_env("configdump", grml_live_config)
+
     with start_unshared_service() as unshared_service:
         unshared_service.run(unshared_helper.hello_world())
 
@@ -836,7 +873,7 @@ def _main(program_name: str, argv: list[str]) -> int:
                     output_dir,
                     chroot_dir,
                     classes,
-                    args.grml_live_config,
+                    grml_live_config,
                     args.action,
                     skiptasks,
                     unshared_service,

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -18,7 +18,7 @@ from enum import StrEnum
 from pathlib import Path
 from threading import Event, Thread
 
-from . import intarget_tools
+from . import unshared_helper
 from .classes import ClassFileParsingFailed, parse_class_varfile
 from .packages import PackageList, parse_class_packages
 
@@ -59,13 +59,28 @@ class BuildDirectories:
     sources_dir: Path
 
 
+@dataclass
+class UnsharedService:
+    request_socket: socket.socket
+
+    def run(self, op: dict, check=True) -> int:
+        res = unshared_helper.send_ops_to_server(self.request_socket, [op])
+        if check and res:
+            raise RuntimeError(f"E: unshared operation failed with rc={res}, op: {op}")
+        return res
+
+    def batch(self, ops: list[dict], check=True) -> int:
+        res = unshared_helper.send_ops_to_server(self.request_socket, ops)
+        if check and res:
+            raise RuntimeError(f"E: unshared operations failed with rc={res}, ops: {ops}")
+        return res
+
+
 def now_for_log() -> str:
     return datetime.datetime.now().isoformat()
 
 
-def run_x(args, check: bool = True, **kwargs):
-    """Run program. Output goes to stdout/stderr."""
-    # str-ify Paths, not necessary, but for readability in logs.
+def _prepare_subprocess_args(args, *, unshared: bool, chroot_dir: Path | None, **kwargs):
     args = [arg if isinstance(arg, str) else str(arg) for arg in args]
     args_str = '" "'.join(args)
     if "env" in kwargs:
@@ -75,17 +90,62 @@ def run_x(args, check: bool = True, **kwargs):
             env["SOURCE_DATE_EPOCH"] = os.environ["SOURCE_DATE_EPOCH"]
         kwargs["env"] = env | kwargs["env"]  # do not update original dict
 
-    print(f'D: Running "{args_str}"', flush=True)
-    return subprocess.run(args, check=check, **kwargs)
+    prefix_args = []
+    hint = ""
+    if unshared:
+        unshare = [
+            "unshare",
+            "--user",
+            "--map-auto",
+            "--map-user=65536",
+            "--map-group=65536",
+            "--pid",
+            "--mount-proc",
+            "--uts",
+            "--fork",
+            "--kill-child",
+            "--setuid",
+            "0",
+            "--setgid",
+            "0",
+        ]
+        hint = "unshared"
+        if chroot_dir:
+            unshare = [*unshare, "--root", str(chroot_dir)]
+            hint = f"{hint} in chroot {chroot_dir}"
+        prefix_args = [*unshare, "--"]
+    elif chroot_dir:
+        prefix_args = ["chroot", str(chroot_dir)]
+
+    print(f'D: Running{" " + hint if hint else ""} "{args_str}"', flush=True)
+    return prefix_args, args, kwargs
 
 
-def run_chrooted(chroot_dir: Path, args, check: bool = True, **kwargs):
+def run_x(args, check: bool = True, unshared: bool = False, chroot_dir: Path | None = None, **kwargs):
+    """Run program. Output goes to stdout/stderr."""
+    prefix_args, args, kwargs = _prepare_subprocess_args(args, unshared=unshared, chroot_dir=chroot_dir, **kwargs)
+
+    return subprocess.run(prefix_args + args, check=check, **kwargs)
+
+
+def popen(args, unshared: bool = False, chroot_dir: Path | None = None, **kwargs):
+    prefix_args, args, kwargs = _prepare_subprocess_args(args, unshared=unshared, chroot_dir=chroot_dir, **kwargs)
+    return subprocess.Popen(prefix_args + args, **kwargs)
+
+
+def run_chrooted(chroot_dir: Path, args, check: bool = True, unshared: bool = True, **kwargs):
     """Run program with arguments in chroot chroot_dir."""
     kwargs["env"] = {
         "PATH": "/usr/sbin:/sbin:/usr/bin:/bin",
         "TERM": "dumb",
     } | kwargs.get("env", {})
-    return run_x(["chroot", chroot_dir, *args], check=check, **kwargs)
+    return run_x(
+        args,
+        check=check,
+        unshared=unshared,
+        chroot_dir=chroot_dir,
+        **kwargs,
+    )
 
 
 def chrooted_dpkg_print_architecture(chroot_dir: Path) -> str:
@@ -144,12 +204,12 @@ def run_script(chroot_dir: Path, script: Path, helper_tools_paths: list[Path], e
 
     env = {
         "target": str(chroot_dir),
-        "ROOTCMD": f"chroot {chroot_dir!s} ",
+        "ROOTCMD": "grml-live-chroot",
         "PATH": ":".join([str(p) for p in helper_tools_paths] + [os.environ["PATH"]]),
     } | env
     print()
     print(f"I: *** Running script {script} ***")
-    proc = run_x([script], check=False, env=env, stdin=subprocess.DEVNULL)
+    proc = run_x([script], check=False, unshared=True, env=env, stdin=subprocess.DEVNULL)
     if proc.returncode != 0:
         print(f"E: Script {script} failed with exitcode {proc.returncode} - aborting.")
         raise FaiScriptFailed()
@@ -182,6 +242,7 @@ def install_packages_for_classes(
     helper_tools_paths: list[Path],
     hook_env: dict,
     dynamic_state: DynamicState,
+    unshared_service: UnsharedService,
 ):
     """Run equivalent of "instsoft" task: set debconf selections and install packages listed in package lists."""
 
@@ -220,11 +281,16 @@ def install_packages_for_classes(
     print()
     print("I: Installing all packages together to detect relationship errors")
     chrooted_apt_install(chroot_dir, full_package_list.as_apt_params(restrict_to_arch=dpkg_architecture))
-
-    with (chroot_dir / "grml-live" / "log" / "install_packages.list").open("wt") as file:
-        file.write("# List of packages installed by minifai\n")
-        file.write("\n".join(full_package_list.list_for_arch(dpkg_architecture)))
-        file.write("\n")
+    unshared_service.run(
+        unshared_helper.write_file_text(
+            (chroot_dir / "grml-live" / "log" / "install_packages.list"),
+            (
+                "# List of packages installed by minifai\n"
+                + ("\n".join(full_package_list.list_for_arch(dpkg_architecture)))
+                + "\n"
+            ),
+        )
+    )
 
 
 def show_env(log_text: str, env):
@@ -243,7 +309,13 @@ def do_skiptask(dynamic_state: DynamicState, skiptask_args: list[str]) -> int:
 
 
 def helper_socket_thread(
-    tempdir: Path, conf_dir: Path, chroot_dir: Path, classes: list[str], exit_event: Event, dynamic_state: DynamicState
+    tempdir: Path,
+    conf_dir: Path,
+    chroot_dir: Path,
+    classes: list[str],
+    exit_event: Event,
+    dynamic_state: DynamicState,
+    unshared_service: UnsharedService,
 ):
     address_family = socket.AF_UNIX
     socket_type = socket.SOCK_STREAM
@@ -271,9 +343,13 @@ def helper_socket_thread(
             else:
                 req = req[0].split(" ")
                 if req[0] == "fcopy":
-                    rc = intarget_tools.do_fcopy(conf_dir, chroot_dir, classes, req[1:])
+                    rc = unshared_service.run(
+                        unshared_helper.fcopy(conf_dir, chroot_dir, " ".join(classes), " ".join(req[1:]))
+                    )
                 elif req[0] == "copy-media-files":
-                    rc = intarget_tools.do_copy_media_files(conf_dir, chroot_dir, classes, req[1:])
+                    rc = unshared_service.run(
+                        unshared_helper.copy_media_files(conf_dir, chroot_dir, " ".join(classes), " ".join(req[1:]))
+                    )
                 elif req[0] == "skiptask":
                     rc = do_skiptask(dynamic_state, req[1:])
                 else:
@@ -297,7 +373,9 @@ def write_helper_tool(tools_path: Path, tool_name: str, body: str):
 
 
 @contextlib.contextmanager
-def helper_tools(conf_dir: Path, chroot_dir: Path, classes: list[str], dynamic_state: DynamicState):
+def helper_tools(
+    conf_dir: Path, chroot_dir: Path, classes: list[str], dynamic_state: DynamicState, unshared_service: UnsharedService
+):
     tempdir = Path(tempfile.mkdtemp())
 
     write_helper_tool(
@@ -340,10 +418,35 @@ fi
 """,
     )
 
+    # Tool to provide $ROOTCMD. Will be invoked from scripts, which run in an
+    # unshared context. Usually each script gets its own unshared context,
+    # therefore each script gets a new mount namespace, and so on.
+    # However, each script can run $ROOTCMD multiple times, so we should also
+    # avoid mounting one /proc per $ROOTCMD invocation.
+    write_helper_tool(
+        tempdir,
+        "grml-live-chroot",
+        f"""#!/bin/bash
+set -e
+export PATH=/usr/sbin:/usr/bin:/sbin:/bin
+CHROOT_DIR="{chroot_dir}"
+test -d "$CHROOT_DIR"/proc/self || mount --rbind /proc "$CHROOT_DIR"/proc
+for filename in null full tty ; do
+  if ! test -c "$CHROOT_DIR"/dev/$filename ; then
+    rm -f "$CHROOT_DIR"/dev/$filename
+    touch "$CHROOT_DIR"/dev/$filename
+    mount --bind /dev/$filename "$CHROOT_DIR"/dev/$filename
+  fi
+done
+set +e
+exec chroot "$CHROOT_DIR" "$@"
+""",
+    )
+
     exit_event = Event()
     thread = Thread(
         target=helper_socket_thread,
-        args=(tempdir, conf_dir, chroot_dir, classes, exit_event, dynamic_state),
+        args=(tempdir, conf_dir, chroot_dir, classes, exit_event, dynamic_state, unshared_service),
         daemon=False,
     )
     thread.start()
@@ -356,13 +459,12 @@ fi
 
 
 @contextlib.contextmanager
-def policy_rcd(chroot_dir: Path):
+def policy_rcd(chroot_dir: Path, unshared_service: UnsharedService):
     marker = "!MINIFAI!"
     print("I: Installing temporary policy-rc.d")
     program = chroot_dir / "usr" / "sbin" / "policy-rc.d"
-    with program.open("wt") as file:
-        file.write(f"#!/bin/sh\n# Installed by grml-live minifai {marker}\nexit 101\n")
-        os.fchmod(file.fileno(), 0o755)
+    contents = f"#!/bin/sh\n# Installed by grml-live minifai {marker}\nexit 101\n"
+    unshared_service.run(unshared_helper.write_file_text(program, contents, executable=True))
 
     try:
         yield
@@ -375,6 +477,31 @@ def policy_rcd(chroot_dir: Path):
                 print(f"I: Not cleaning up {program} - our marker went missing")
         except Exception:
             print(f"W: Failed cleaning up {program}")
+
+
+@contextlib.contextmanager
+def start_unshared_service():
+    tempdir = Path(tempfile.mkdtemp())
+
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as listen_socket:
+        socket_path = f"{tempdir}/sock"
+        listen_socket.bind(socket_path)
+        listen_socket.listen(1)  # queue size
+
+        args = unshared_helper.make_server_command(socket_path)
+        subproc = popen(args, unshared=True)
+
+        listen_socket.settimeout(120)
+        try:
+            request_socket, _ = listen_socket.accept()
+        except TimeoutError:
+            print("E: unshared helper service did not connect")
+            subproc.kill()
+            raise
+
+        yield UnsharedService(request_socket)
+
+    subproc.kill()
 
 
 def read_envvars_for_classes(conf_dir: Path, classes: list[str]) -> dict:
@@ -456,32 +583,32 @@ def task_updatebase(chroot_dir: Path, dynamic_state: DynamicState):
     run_chrooted(chroot_dir, ["apt", "-oapt::cmd::disable-script-warning=1", "--error-on=any", "update", "-q"])
 
 
-def _create_dirs(chroot_dir: Path) -> BuildDirectories:
+def _create_dirs(chroot_dir: Path, unshared_service: UnsharedService) -> BuildDirectories:
     """Create required directories _inside_ the chroot."""
+
     # This code is as ugly as it looks.
     build_dir_relative = "grml-live"
     build_dir = chroot_dir / build_dir_relative
-    if build_dir.exists():
-        print(f'I: Deleting build directory "{build_dir_relative}" from previous run: {build_dir}')
-        shutil.rmtree(build_dir)
-    print(f"I: Creating build directory: {build_dir}")
-    build_dir.mkdir()
 
     log_dir_name = "log"
     log_dir = build_dir / log_dir_name
-    log_dir.mkdir()
 
     media_dir_name = "media"
     media_dir = build_dir / media_dir_name
-    media_dir.mkdir()
 
     netboot_dir_name = "netboot"
     netboot_dir = build_dir / netboot_dir_name
-    netboot_dir.mkdir()
 
     sources_dir_name = "grml_sources"
     sources_dir = build_dir / sources_dir_name
-    sources_dir.mkdir()
+
+    print(f"I: Creating build directory and subdirs: {build_dir}")
+    unshared_service.batch(
+        [
+            unshared_helper.ensure_empty_dir(absolute_dir)
+            for absolute_dir in [build_dir, log_dir, netboot_dir, media_dir, sources_dir]
+        ]
+    )
 
     return BuildDirectories(
         build_dir_inside=f"/{build_dir_relative}/",
@@ -497,7 +624,12 @@ def _create_dirs(chroot_dir: Path) -> BuildDirectories:
     )
 
 
-def install_class_helper_tools(conf_dir: Path, build_dir: Path, classes: list[str]) -> Path:
+def install_class_helper_tools(
+    conf_dir: Path,
+    build_dir: Path,
+    classes: list[str],
+    unshared_service: UnsharedService,
+) -> Path:
     """
     Copy class-config helpers into chroot.
 
@@ -505,30 +637,48 @@ def install_class_helper_tools(conf_dir: Path, build_dir: Path, classes: list[st
     """
 
     class_helper_tools_path = build_dir / "tools"
-    class_helper_tools_path.mkdir()
+    unshared_service.run(unshared_helper.ensure_empty_dir(class_helper_tools_path))
     for class_name in classes:
         class_path = conf_dir / "tools" / class_name
         if not class_path.exists():
             continue
-        shutil.copytree(class_path, class_helper_tools_path, symlinks=False, dirs_exist_ok=True)
+        for helper in class_path.glob("*"):
+            if not helper.is_file():
+                continue
+            unshared_service.run(
+                unshared_helper.write_file_text(
+                    class_helper_tools_path / helper.name,
+                    helper.read_text(),
+                    executable=True,
+                )
+            )
 
     return class_helper_tools_path
 
 
 def _run_tasks(
-    conf_dir: Path, chroot_dir: Path, classes: list[str], grml_live_config: Path, fai_action: str, skip_tasks: list[str]
+    conf_dir: Path,
+    chroot_dir: Path,
+    classes: list[str],
+    grml_live_config: Path,
+    fai_action: str,
+    skip_tasks: list[str],
+    unshared_service: UnsharedService,
 ) -> int:
     dynamic_state = DynamicState()
-    directories = _create_dirs(chroot_dir)
+    directories = _create_dirs(chroot_dir, unshared_service)
 
-    # Create a file in there, so grml-live does not complain.
-    (directories.log_dir / "minifai").write_text(
-        "This chroot was created by grml-live minifai. Not all FAI features are supported.\n"
+    # Create a file in log_dir, so grml-live does not complain.
+    unshared_service.run(
+        unshared_helper.write_file_text(
+            (directories.log_dir / "minifai"),
+            ("This chroot was created by grml-live minifai. Not all FAI features are supported.\n"),
+        )
     )
 
     # duplicate grml_live_config into the chroot, so chrooted scripts can use it.
     grml_live_config_chroot = directories.build_dir / "config"
-    grml_live_config_chroot.write_bytes(grml_live_config.read_bytes())
+    unshared_service.run(unshared_helper.write_file_text(grml_live_config_chroot, grml_live_config.read_text()))
 
     do_skiptask(dynamic_state, skip_tasks)
 
@@ -542,8 +692,11 @@ def _run_tasks(
     } | read_envvars_for_classes(conf_dir, classes)
     show_env("Merged class variables", env)
 
-    with helper_tools(conf_dir, chroot_dir, classes, dynamic_state) as helper_tools_path:
-        class_helper_tools_path = install_class_helper_tools(conf_dir, directories.build_dir, classes)
+    # Setup /proc, /sys inside chroot_dir, so future chroot calls will have these mounts.
+    unshared_service.run(unshared_helper.bindmount_proc_sys_into(chroot_dir))
+
+    with helper_tools(conf_dir, chroot_dir, classes, dynamic_state, unshared_service) as helper_tools_path:
+        class_helper_tools_path = install_class_helper_tools(conf_dir, directories.build_dir, classes, unshared_service)
 
         helper_tools_paths = [helper_tools_path, class_helper_tools_path]
 
@@ -551,11 +704,13 @@ def _run_tasks(
         for class_name in classes:
             run_script(chroot_dir, conf_dir / "hooks" / class_name / "updatebase", helper_tools_paths, hook_env)
 
-        with policy_rcd(chroot_dir):
+        with policy_rcd(chroot_dir, unshared_service):
             task_updatebase(chroot_dir, dynamic_state)
 
             if not should_skip_task(dynamic_state, "instsoft"):
-                install_packages_for_classes(conf_dir, chroot_dir, classes, helper_tools_paths, hook_env, dynamic_state)
+                install_packages_for_classes(
+                    conf_dir, chroot_dir, classes, helper_tools_paths, hook_env, dynamic_state, unshared_service
+                )
 
         if not should_skip_task(dynamic_state, "configure"):
             for class_name in classes:
@@ -602,31 +757,42 @@ def _main(program_name: str, argv: list[str]) -> int:
     if not chroot_dir.exists():
         raise ValueError(f"Chroot directory {chroot_dir} does not exist")
 
-    skiptasks = []
-    rc = 0
+    with start_unshared_service() as unshared_service:
+        unshared_service.run(unshared_helper.hello_world())
 
-    try:
-        if args.action == FaiAction.DIRINSTALL:
-            install_base(conf_dir, chroot_dir, classes, args.debian_suite, args.mirror_url)
-        elif args.action == FaiAction.SOFTUPDATE:
-            pass
-        elif args.action == FaiAction.RECONFIGURE:
-            skiptasks = ["updatebase", "instsoft"]
-        elif args.action == FaiAction.REBUILD:
-            skiptasks = ["updatebase", "instsoft", "configure"]
-        else:
-            print(f"E: minifai: Unknown fai action: {args.action!r}")
-            rc = 1
+        skiptasks = []
+        rc = 0
 
-        if not rc:
-            rc = _run_tasks(conf_dir, chroot_dir, classes, args.grml_live_config, args.action, skiptasks)
-    except (ClassFileParsingFailed, FaiScriptFailed):
-        # assume exception site already printed relevant info
-        rc = 3
-    except Exception:
-        print(f"E: {now_for_log()} minifai main caught fatal exception")
-        traceback.print_exc()
-        rc = 2
+        try:
+            if args.action == FaiAction.DIRINSTALL:
+                install_base(conf_dir, chroot_dir, classes, args.debian_suite, args.mirror_url)
+            elif args.action == FaiAction.SOFTUPDATE:
+                pass
+            elif args.action == FaiAction.RECONFIGURE:
+                skiptasks = ["updatebase", "instsoft"]
+            elif args.action == FaiAction.REBUILD:
+                skiptasks = ["updatebase", "instsoft", "configure"]
+            else:
+                print(f"E: minifai: Unknown fai action: {args.action!r}")
+                rc = 1
+
+            if not rc:
+                rc = _run_tasks(
+                    conf_dir,
+                    chroot_dir,
+                    classes,
+                    args.grml_live_config,
+                    args.action,
+                    skiptasks,
+                    unshared_service,
+                )
+        except (ClassFileParsingFailed, FaiScriptFailed):
+            # assume exception site already printed relevant info
+            rc = 3
+        except Exception:
+            print(f"E: {now_for_log()} minifai main caught fatal exception")
+            traceback.print_exc()
+            rc = 2
 
     print(f"I: minifai exiting with exit code {rc}")
     return rc

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -425,6 +425,9 @@ def install_base(conf_dir: Path, chroot_dir: Path, classes, debian_suite: str, m
         f"--keyring={keyring_tempfile.name}",
         # Delete keyring_tempfile from within mmdebstrap's userns.
         f"--chrooted-customize-hook=rm /{Path(keyring_tempfile.name).name}",
+        # Mark most leaf packages as automatically installed, so autoremove could remove them if possible.
+        r"--chrooted-customize-hook="
+        + r"apt-mark auto \~i\ \?not\(\~prequired\)\ \?not\(\~pimportant\)\ \?not\(\~pstandard\)",
         f"--include={','.join(included_packages)}",
         debian_suite,
         chroot_dir,
@@ -438,9 +441,6 @@ def install_base(conf_dir: Path, chroot_dir: Path, classes, debian_suite: str, m
         args.insert(1, "--aptopt='Acquire::http { Proxy \"" + os.environ["APT_PROXY"] + '"; }')
 
     run_x(args)
-
-    # Mark most leaf packages as automatically installed, so autoremove could remove them if possible.
-    run_chrooted(chroot_dir, ["apt-mark", "auto", "~i ?not(~prequired) ?not(~pimportant) ?not(~pstandard)"])
 
 
 def should_skip_task(dynamic_state: DynamicState, task: str) -> bool:

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -660,6 +660,28 @@ def install_class_helper_tools(
     return class_helper_tools_path
 
 
+def copy_directory_out(
+    target_dir: Path,
+    source_dir: Path,
+):
+    """
+    Copy contents of a directory from A (source_dir) to B (target_dir).
+    Intended to be used when copying from unshared context to the "outside".
+    Does not preserve file modes, ownership, etc.
+    """
+    target_dir.mkdir(exist_ok=True)
+    run_x(
+        [
+            "/bin/cp",
+            "--no-preserve=all",
+            "--preserve=timestamp",
+            "-r",
+            str(source_dir) + "/.",
+            str(target_dir) + "/",
+        ]
+    )
+
+
 def _run_tasks(
     conf_dir: Path,
     output_dir: Path,
@@ -674,6 +696,8 @@ def _run_tasks(
     chroot_directories = _create_chroot_dirs(chroot_dir, unshared_service)
     grml_cd_dir = output_dir / "grml_cd"
     grml_cd_dir.mkdir()
+    grml_logs_dir = output_dir / "grml_logs"
+    grml_logs_dir.mkdir(exist_ok=True)
 
     # Create a file in log_dir, so grml-live does not complain.
     unshared_service.run(
@@ -702,32 +726,36 @@ def _run_tasks(
     # Setup /proc, /sys inside chroot_dir, so future chroot calls will have these mounts.
     unshared_service.run(unshared_helper.bindmount_proc_sys_into(chroot_dir))
 
-    with helper_tools(conf_dir, chroot_dir, classes, dynamic_state, unshared_service) as helper_tools_path:
-        class_helper_tools_path = install_class_helper_tools(
-            conf_dir, chroot_directories.build_dir, classes, unshared_service
-        )
+    try:
+        with helper_tools(conf_dir, chroot_dir, classes, dynamic_state, unshared_service) as helper_tools_path:
+            class_helper_tools_path = install_class_helper_tools(
+                conf_dir, chroot_directories.build_dir, classes, unshared_service
+            )
 
-        helper_tools_paths = [helper_tools_path, class_helper_tools_path]
+            helper_tools_paths = [helper_tools_path, class_helper_tools_path]
 
-        hook_env = env | {"FAI_ACTION": fai_action}
-        for class_name in classes:
-            run_script(chroot_dir, conf_dir / "hooks" / class_name / "updatebase", helper_tools_paths, hook_env)
-
-        with policy_rcd(chroot_dir, unshared_service):
-            task_updatebase(chroot_dir, dynamic_state)
-
-            if not should_skip_task(dynamic_state, "instsoft"):
-                install_packages_for_classes(
-                    conf_dir, chroot_dir, classes, helper_tools_paths, hook_env, dynamic_state, unshared_service
-                )
-
-        if not should_skip_task(dynamic_state, "configure"):
+            hook_env = env | {"FAI_ACTION": fai_action}
             for class_name in classes:
-                run_class_scripts("scripts", conf_dir, chroot_dir, class_name, helper_tools_paths, env)
+                run_script(chroot_dir, conf_dir / "hooks" / class_name / "updatebase", helper_tools_paths, hook_env)
 
-        if not should_skip_task(dynamic_state, "build"):
-            for class_name in classes:
-                run_class_scripts("media-scripts", conf_dir, chroot_dir, class_name, helper_tools_paths, env)
+            with policy_rcd(chroot_dir, unshared_service):
+                task_updatebase(chroot_dir, dynamic_state)
+
+                if not should_skip_task(dynamic_state, "instsoft"):
+                    install_packages_for_classes(
+                        conf_dir, chroot_dir, classes, helper_tools_paths, hook_env, dynamic_state, unshared_service
+                    )
+
+            if not should_skip_task(dynamic_state, "configure"):
+                for class_name in classes:
+                    run_class_scripts("scripts", conf_dir, chroot_dir, class_name, helper_tools_paths, env)
+
+            if not should_skip_task(dynamic_state, "build"):
+                for class_name in classes:
+                    run_class_scripts("media-scripts", conf_dir, chroot_dir, class_name, helper_tools_paths, env)
+
+    finally:
+        copy_directory_out(grml_logs_dir / "fai", chroot_directories.log_dir)
 
     return 0
 

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -1223,11 +1223,11 @@ def _main(program_name: str, argv: list[str]) -> int:
     args = create_argparser().parse_args(argv[1:])
     print(f"I: {program_name} parsed args: {args}")
     classes = args.classes.split(",")
-    print(f"I: Using classes: {classes}")
+    print(f"I: Using classes: {','.join(classes)}")
     conf_dir = args.config.absolute()
-    print(f"I: Using conf_dir: {conf_dir}")
+    print(f"I: Using conf_dir: {conf_dir!s}")
     output_dir: Path = args.output_dir.absolute()
-    print(f"I: Using output_dir: {args.output_dir}")
+    print(f"I: Using output_dir: {args.output_dir!s}")
 
     if not conf_dir.exists():
         raise ValueError(f"Config directory {conf_dir} does not exist")

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -754,6 +754,18 @@ def _run_tasks(
                 for class_name in classes:
                     run_class_scripts("media-scripts", conf_dir, chroot_dir, class_name, helper_tools_paths, env)
 
+                print("I: installing media files from chroot build")
+                run_x(
+                    [
+                        "/bin/cp",
+                        "--no-preserve=all",
+                        "--preserve=timestamp",
+                        "-rv",
+                        str(chroot_directories.media_dir) + "/.",
+                        grml_cd_dir,
+                    ],
+                )
+
     finally:
         copy_directory_out(grml_logs_dir / "fai", chroot_directories.log_dir)
 

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -39,6 +39,7 @@ class FaiAction(StrEnum):
     SOFTUPDATE = "softupdate"
     RECONFIGURE = "reconfigure"
     REBUILD = "rebuild"
+    REBUILD_MEDIA = "rebuild_media"
 
 
 @dataclass
@@ -712,6 +713,57 @@ def copy_directory_out(
     )
 
 
+def _build_mksquashfs_options(conf_dir: Path) -> list[str]:
+    squashfs_excludes_file = conf_dir / "grml" / "squashfs-excludes"
+    options = [
+        "-noappend",
+        # use block size 1m as this gives good result with regards to time + compression
+        "-b",
+        "1m",
+        "-comp",
+        "xz",
+        # Ignore all extended attributes. This avoids:
+        # 1) leaking containerization supplied selinux attributes into the squashfs,
+        # 2) prevents unpacking errors in a later build-only step in containers not supporting xattrs.
+        "-no-xattrs",
+        # Static file exclusion list.
+        "-wildcards",
+        "-ef",
+        str(squashfs_excludes_file),
+        "-one-file-system",
+    ]
+    return options
+
+
+def mksquashfs(
+    conf_dir: Path,
+    grml_cd_dir: Path,
+    chroot_dir: Path,
+    grml_name: str,
+    unshared_service: UnsharedService,
+):
+    live_dir = grml_cd_dir / "live"
+    squashfs_dir = live_dir / grml_name
+    squashfs_file = squashfs_dir / f"{grml_name}.squashfs"
+
+    mksquashfs_binary = os.environ["MKSQUASHFS_BINARY"]
+    options = _build_mksquashfs_options(conf_dir)
+    args = [mksquashfs_binary, str(chroot_dir) + "/", squashfs_file, *options]
+
+    # We must run mksquashfs inside the userns so it sees the correct ownership info,
+    # but we want the resulting file to be owned by the user outside of the userns.
+    unshared_service.batch(
+        [
+            unshared_helper.ensure_dir(live_dir),
+            unshared_helper.ensure_dir(squashfs_dir),
+            unshared_helper.run_program(args),
+            unshared_helper.chown(squashfs_file, str(UNSHARE_UID), str(UNSHARE_GID)),
+            unshared_helper.chown(squashfs_dir, str(UNSHARE_UID), str(UNSHARE_GID)),
+            unshared_helper.chown(live_dir, str(UNSHARE_UID), str(UNSHARE_GID)),
+        ]
+    )
+
+
 def _run_tasks(
     conf_dir: Path,
     output_dir: Path,
@@ -744,6 +796,9 @@ def _run_tasks(
             grml_live_config_chroot, "\n".join(f"{k}={shlex.quote(v)}" for k, v in grml_live_config.items())
         )
     )
+
+    grml_name = os.environ["GRML_NAME"]
+    print(f"I: GRML_NAME: {grml_name!r}")
 
     do_skiptask(dynamic_state, skip_tasks)
 
@@ -783,6 +838,10 @@ def _run_tasks(
             if not should_skip_task(dynamic_state, "configure"):
                 for class_name in classes:
                     run_class_scripts("scripts", conf_dir, chroot_dir, class_name, helper_tools_paths, env)
+
+            if not should_skip_task(dynamic_state, "squashfs"):
+                # mksquashfs is the last thing that should need the userns.
+                mksquashfs(conf_dir, grml_cd_dir, chroot_dir, grml_name, unshared_service)
 
             if not should_skip_task(dynamic_state, "build"):
                 for class_name in classes:
@@ -863,6 +922,8 @@ def _main(program_name: str, argv: list[str]) -> int:
                 skiptasks = ["updatebase", "instsoft"]
             elif args.action == FaiAction.REBUILD:
                 skiptasks = ["updatebase", "instsoft", "configure"]
+            elif args.action == FaiAction.REBUILD_MEDIA:
+                skiptasks = ["updatebase", "instsoft", "configure", "squashfs"]
             else:
                 print(f"E: minifai: Unknown fai action: {args.action!r}")
                 rc = 1

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -49,7 +49,7 @@ class DynamicState:
 
 
 @dataclass(kw_only=True)
-class BuildDirectories:
+class ChrootBuildDirectories:
     # xxx_inside is always the path _inside_ the chroot ("relative", if chrooted).
     build_dir_inside: str
     build_dir: Path
@@ -587,7 +587,7 @@ def task_updatebase(chroot_dir: Path, dynamic_state: DynamicState):
     run_chrooted(chroot_dir, ["apt", "-oapt::cmd::disable-script-warning=1", "--error-on=any", "update", "-q"])
 
 
-def _create_dirs(chroot_dir: Path, unshared_service: UnsharedService) -> BuildDirectories:
+def _create_chroot_dirs(chroot_dir: Path, unshared_service: UnsharedService) -> ChrootBuildDirectories:
     """Create required directories _inside_ the chroot."""
 
     # This code is as ugly as it looks.
@@ -614,7 +614,7 @@ def _create_dirs(chroot_dir: Path, unshared_service: UnsharedService) -> BuildDi
         ]
     )
 
-    return BuildDirectories(
+    return ChrootBuildDirectories(
         build_dir_inside=f"/{build_dir_relative}/",
         build_dir=build_dir,
         log_dir_inside=f"/{build_dir_relative}/{log_dir_name}/",
@@ -662,6 +662,7 @@ def install_class_helper_tools(
 
 def _run_tasks(
     conf_dir: Path,
+    output_dir: Path,
     chroot_dir: Path,
     classes: list[str],
     grml_live_config: Path,
@@ -670,29 +671,31 @@ def _run_tasks(
     unshared_service: UnsharedService,
 ) -> int:
     dynamic_state = DynamicState()
-    directories = _create_dirs(chroot_dir, unshared_service)
+    chroot_directories = _create_chroot_dirs(chroot_dir, unshared_service)
+    grml_cd_dir = output_dir / "grml_cd"
+    grml_cd_dir.mkdir()
 
     # Create a file in log_dir, so grml-live does not complain.
     unshared_service.run(
         unshared_helper.write_file_text(
-            (directories.log_dir / "minifai"),
+            (chroot_directories.log_dir / "minifai"),
             ("This chroot was created by grml-live minifai. Not all FAI features are supported.\n"),
         )
     )
 
     # duplicate grml_live_config into the chroot, so chrooted scripts can use it.
-    grml_live_config_chroot = directories.build_dir / "config"
+    grml_live_config_chroot = chroot_directories.build_dir / "config"
     unshared_service.run(unshared_helper.write_file_text(grml_live_config_chroot, grml_live_config.read_text()))
 
     do_skiptask(dynamic_state, skip_tasks)
 
     env = {
         "GRML_LIVE_CONFIG": str(grml_live_config_chroot),
-        "GRML_LIVE_BUILDDIR": directories.build_dir_inside,
-        "GRML_LIVE_MEDIADIR": directories.media_dir_inside,
-        "GRML_LIVE_NETBOOTDIR": directories.netboot_dir_inside,
-        "GRML_LIVE_SOURCESDIR": directories.sources_dir_inside,
-        "LOGDIR": str(directories.log_dir),
+        "GRML_LIVE_BUILDDIR": chroot_directories.build_dir_inside,
+        "GRML_LIVE_MEDIADIR": chroot_directories.media_dir_inside,
+        "GRML_LIVE_NETBOOTDIR": chroot_directories.netboot_dir_inside,
+        "GRML_LIVE_SOURCESDIR": chroot_directories.sources_dir_inside,
+        "LOGDIR": str(chroot_directories.log_dir),
     } | read_envvars_for_classes(conf_dir, classes)
     show_env("Merged class variables", env)
 
@@ -700,7 +703,9 @@ def _run_tasks(
     unshared_service.run(unshared_helper.bindmount_proc_sys_into(chroot_dir))
 
     with helper_tools(conf_dir, chroot_dir, classes, dynamic_state, unshared_service) as helper_tools_path:
-        class_helper_tools_path = install_class_helper_tools(conf_dir, directories.build_dir, classes, unshared_service)
+        class_helper_tools_path = install_class_helper_tools(
+            conf_dir, chroot_directories.build_dir, classes, unshared_service
+        )
 
         helper_tools_paths = [helper_tools_path, class_helper_tools_path]
 
@@ -738,7 +743,7 @@ def create_argparser() -> argparse.ArgumentParser:
         metavar="ACTION",
         help="FAI action to execute (choices: %(choices)s)",
     )
-    parser.add_argument("chroot_dir", type=Path)
+    parser.add_argument("output_dir", type=Path)
     parser.add_argument("grml_live_config", type=Path)
     parser.add_argument("debian_suite", type=str)
     parser.add_argument("mirror_url", type=str)
@@ -753,13 +758,18 @@ def _main(program_name: str, argv: list[str]) -> int:
     print(f"I: Using classes: {classes}")
     conf_dir = args.config.absolute()
     print(f"I: Using conf_dir: {conf_dir}")
-    chroot_dir: Path = args.chroot_dir.absolute()
-    print(f"I: Using chroot_dir: {args.chroot_dir}")
+    output_dir: Path = args.output_dir.absolute()
+    print(f"I: Using output_dir: {args.output_dir}")
 
     if not conf_dir.exists():
         raise ValueError(f"Config directory {conf_dir} does not exist")
-    if not chroot_dir.exists():
-        raise ValueError(f"Chroot directory {chroot_dir} does not exist")
+    if not output_dir.exists():
+        raise ValueError(f"Output directory {output_dir} does not exist")
+
+    chroot_dir = output_dir / "grml_chroot"
+    chroot_dir.mkdir(
+        exist_ok=True  # for now, as grml_live has to mount the mirror
+    )
 
     with start_unshared_service() as unshared_service:
         unshared_service.run(unshared_helper.hello_world())
@@ -783,6 +793,7 @@ def _main(program_name: str, argv: list[str]) -> int:
             if not rc:
                 rc = _run_tasks(
                     conf_dir,
+                    output_dir,
                     chroot_dir,
                     classes,
                     args.grml_live_config,

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -861,7 +861,7 @@ def create_netboot_package(
     """
     output_basename = iso_name.rpartition(".iso")[0] + "-netboot"
     output_netboot_dir = output_dir / "netboot"
-    output_netboot_dir.mkdir()
+    output_netboot_dir.mkdir(exist_ok=True)  # some workflows accept that this already exists
     output_name = output_netboot_dir / (output_basename + ".tar")
     print(f"I: building netboot tar: {output_name.name}")
 
@@ -1059,7 +1059,7 @@ def create_media(
     arch: str,
 ):
     iso_dir = output_dir / "grml_isos"
-    iso_dir.mkdir()
+    iso_dir.mkdir(exist_ok=True)  # some workflows accept that this already exists
     print("I: Generating ISO file ...")
     run_x(_build_xorriso_options(iso_dir, grml_cd_dir, grml_name, version, iso_name, arch))
 

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -833,6 +833,8 @@ def _run_tasks(
 
     grml_name = os.environ["GRML_NAME"]
     print(f"I: GRML_NAME: {grml_name!r}")
+    iso_name = os.environ["ISO_NAME"]
+    print(f"I: ISO_NAME: {iso_name!r}")
 
     do_skiptask(dynamic_state, skip_tasks)
 

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -423,6 +423,8 @@ def install_base(conf_dir: Path, chroot_dir: Path, classes, debian_suite: str, m
         "--verbose",
         "--skip=check/empty",  # grml-live pre-creates directories in chroot, skip emptyness check.
         f"--keyring={keyring_tempfile.name}",
+        # Delete keyring_tempfile from within mmdebstrap's userns.
+        f"--chrooted-customize-hook=rm /{Path(keyring_tempfile.name).name}",
         f"--include={','.join(included_packages)}",
         debian_suite,
         chroot_dir,
@@ -436,7 +438,6 @@ def install_base(conf_dir: Path, chroot_dir: Path, classes, debian_suite: str, m
         args.insert(1, "--aptopt='Acquire::http { Proxy \"" + os.environ["APT_PROXY"] + '"; }')
 
     run_x(args)
-    os.unlink(keyring_tempfile.name)
 
     # Mark most leaf packages as automatically installed, so autoremove could remove them if possible.
     run_chrooted(chroot_dir, ["apt-mark", "auto", "~i ?not(~prequired) ?not(~pimportant) ?not(~pstandard)"])

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -1200,6 +1200,18 @@ def _run_tasks(
     return 0
 
 
+def _check_dir_usable(path: Path):
+    if not path.exists():
+        raise ValueError(f"Directory {path} does not exist")
+    p = path
+    while True:
+        if not p.stat().st_mode & os.X_OK:
+            raise ValueError(f"Directory {p} (parent of {path}) must be world-executable")
+        if p == Path("/"):
+            break
+        p = p.parent
+
+
 def create_argparser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     # path to fai classes, scripts, ...
@@ -1229,10 +1241,8 @@ def _main(program_name: str, argv: list[str]) -> int:
     output_dir: Path = args.output_dir.absolute()
     print(f"I: Using output_dir: {args.output_dir!s}")
 
-    if not conf_dir.exists():
-        raise ValueError(f"Config directory {conf_dir} does not exist")
-    if not output_dir.exists():
-        raise ValueError(f"Output directory {output_dir} does not exist")
+    _check_dir_usable(conf_dir)
+    _check_dir_usable(output_dir)
 
     chroot_dir = output_dir / "grml_chroot"
 

--- a/usr/lib/grml-live/grml_live/unshared_helper.py
+++ b/usr/lib/grml-live/grml_live/unshared_helper.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # called by minifai inside an unshare environment.
 # Ideally uses nothing from minifai.
-import itertools
 import json
 import os
 import shutil
@@ -132,34 +131,6 @@ def bindmount_proc_sys_into(root_dir: Path | str):
         dest_dir = str(root_dir / mount)
         print(f"I: Bind-mounting /{mount} into {dest_dir}")
         subprocess.run(["mount", "--rbind", f"/{mount}", dest_dir], check=True, stdin=subprocess.DEVNULL)
-
-
-@_operation
-def clamp_to_source_date(root_dir: Path | str, source_date_epoch: str):
-    root_dir = Path(root_dir)
-    epoch = int(source_date_epoch)
-    dev0 = root_dir.lstat().st_dev
-
-    print(f"I: Clamping mtimes in {root_dir} to {epoch}")
-    os.utime(root_dir, (epoch, epoch), follow_symlinks=False)
-
-    for dirpath, dirnames, filenames in os.walk(root_dir, followlinks=False):
-        kept_dirs = []
-        for name in dirnames:
-            path = os.path.join(dirpath, name)
-            stat_result = os.lstat(path)
-            if stat_result.st_dev != dev0:
-                continue
-            kept_dirs.append(name)
-            if stat_result.st_mtime > epoch:
-                os.utime(path, (epoch, epoch), follow_symlinks=False)
-
-        dirnames[:] = kept_dirs
-
-        for name in itertools.chain(dirnames, filenames):
-            path = os.path.join(dirpath, name)
-            if os.lstat(path).st_mtime > epoch:
-                os.utime(path, (epoch, epoch), follow_symlinks=False)
 
 
 def _parse_and_run(ops_stream: list[dict], operations: dict) -> int:

--- a/usr/lib/grml-live/grml_live/unshared_helper.py
+++ b/usr/lib/grml-live/grml_live/unshared_helper.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+# called by minifai inside an unshare environment.
+# Ideally uses nothing from minifai.
+import json
+import os
+import shutil
+import socket
+import struct
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, ParamSpec
+
+from . import intarget_tools
+
+SELF = Path(__file__)
+ENTRY_POINT = Path(__file__).parent.parent / "unshared_helper"
+assert ENTRY_POINT.exists()
+_IS_EXECUTING = False
+_OPERATIONS = {}
+
+_P = ParamSpec("_P")
+
+
+def _encodable_arg(arg):
+    if isinstance(arg, Path):
+        return str(arg)
+    if isinstance(arg, list):
+        return [_encodable_arg(value) for value in arg]
+    return arg
+
+
+def _operation(func: Callable[_P, Any]) -> Callable[_P, dict]:
+    # Types are for the building mode. The execution path is not type checked.
+    op_name = func.__name__
+    assert op_name not in _OPERATIONS, f"operation {op_name} already registered"
+    _OPERATIONS[op_name] = func
+
+    def inner(*args: _P.args, **kwargs: _P.kwargs) -> dict:
+        if _IS_EXECUTING:
+            return func(*args, **kwargs)
+        else:
+            return {
+                "op": op_name,
+                "args": [_encodable_arg(arg) for arg in args],
+                "kwargs": {k: _encodable_arg(v) for (k, v) in kwargs.items()},
+            }
+
+    inner.__name__ = op_name
+    return inner
+
+
+@_operation
+def hello_world():
+    print(f"Hi from {SELF} - running as {os.getuid()} in {os.getcwd()}")
+
+
+@_operation
+def mkdir(path: Path | str):
+    Path(path).mkdir()
+
+
+@_operation
+def ensure_empty_dir(path: Path | str):
+    path = Path(path)
+    if path.exists():
+        shutil.rmtree(path)
+    path.mkdir()
+
+
+@_operation
+def fcopy(conf_dir: Path | str, chroot_dir: Path | str, classes: str, arglist: str):
+    conf_dir = Path(conf_dir)
+    chroot_dir = Path(chroot_dir)
+    rc = intarget_tools.do_fcopy(conf_dir, chroot_dir, classes.split(" "), arglist.split(" "))
+    return rc
+
+
+@_operation
+def copy_media_files(conf_dir: Path | str, chroot_dir: Path | str, classes: str, arglist: str):
+    conf_dir = Path(conf_dir)
+    chroot_dir = Path(chroot_dir)
+    rc = intarget_tools.do_copy_media_files(conf_dir, chroot_dir, classes.split(" "), arglist.split(" "))
+    return rc
+
+
+@_operation
+def write_file_text(path: Path | str, contents: str, executable: bool = False):
+    path = Path(path)
+    with path.open("wt") as file:
+        file.write(contents)
+        if executable:
+            os.fchmod(file.fileno(), 0o755)
+
+
+@_operation
+def have_text_in_file(path: Path | str, text: str):
+    return 0 if (text in Path(path).read_text()) else 1
+
+
+@_operation
+def unlink(path: Path | str):
+    path = Path(path)
+    path.unlink()
+
+
+@_operation
+def run_program(args, **kwargs):
+    """Run program. Output goes to stdout/stderr. Caller needs to check returncode."""
+    kwargs["stdin"] = subprocess.DEVNULL
+    print(f"D: run_program: {args=}")
+    return subprocess.run(args, check=False, **kwargs).returncode
+
+
+@_operation
+def bindmount_proc_sys_into(root_dir: Path | str):
+    root_dir = Path(root_dir)
+    for mount in ["proc", "sys"]:
+        dest_dir = str(root_dir / mount)
+        print(f"I: Bind-mounting /{mount} into {dest_dir}")
+        subprocess.run(["mount", "--rbind", f"/{mount}", dest_dir], check=True, stdin=subprocess.DEVNULL)
+
+
+def _parse_and_run(ops_stream: list[dict], operations: dict) -> int:
+    for op in ops_stream:
+        op_name = op["op"]
+        args = op["args"]
+        kwargs = op["kwargs"]
+        try:
+            print(f"I: unshared_helper executing {op_name} {' '.join(str(arg) for arg in args)} {kwargs}", flush=True)
+            rc = operations[op_name](*args, **kwargs)
+        except Exception as except_inst:
+            print(f"E: {op_name} failed: {except_inst}", flush=True)
+            print(f"E: {op_name} args: {args=}", flush=True)
+            print(f"E: {op_name} kwargs: {kwargs=}", flush=True)
+            rc = 1
+
+        sys.stdout.flush()
+        if rc:
+            return rc
+
+    return 0
+
+
+def _reply(sock, jsonable_data):
+    encoded = json.dumps(jsonable_data).encode()
+    sock.send(encoded)
+
+
+def _server(socket_path, operations) -> int:
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+        sock.connect(socket_path)
+        while True:
+            size = sock.recv(4)
+            if not size:
+                return 0
+            (size,) = struct.unpack("<L", size)
+            if not size:
+                return 0
+            data = sock.recv(size).decode()
+            try:
+                decoded = json.loads(data)
+            except Exception as except_inst:
+                print(f"E: JSON decode failed: {except_inst}")
+                _reply(sock, {"error": "invalid_json"})
+                continue
+            if "ops" not in decoded:
+                print("E: JSON is missing ops key")
+                _reply(sock, {"error": "invalid_json"})
+                continue
+            rc = _parse_and_run(decoded["ops"], operations)
+            _reply(sock, {"returncode": rc})
+
+
+def send_ops_to_server(socket, ops: list[dict]):
+    sys.stdout.flush()
+    assert ops
+    assert isinstance(ops[0]["op"], str)
+    try:
+        encoded = json.dumps({"ops": ops}).encode()
+    except TypeError:
+        print(f"ops: {ops}", flush=True)
+        raise
+    size = struct.pack("<L", len(encoded))
+    socket.send(size + encoded)
+    result = socket.recv(4096)
+    res = json.loads(result)
+    sys.stdout.flush()
+    return res["returncode"]
+
+
+def make_server_command(socket_path):
+    return [str(ENTRY_POINT), "--server", socket_path]
+
+
+def main() -> int:
+    if len(sys.argv) != 3 or sys.argv[1:2] != ["--server"]:
+        print(f"E: Usage: {ENTRY_POINT} --server <socket_path>")
+        return 1
+    return _server(sys.argv[2], _OPERATIONS)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/usr/lib/grml-live/grml_live/unshared_helper.py
+++ b/usr/lib/grml-live/grml_live/unshared_helper.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # called by minifai inside an unshare environment.
 # Ideally uses nothing from minifai.
+import itertools
 import json
 import os
 import shutil
@@ -131,6 +132,34 @@ def bindmount_proc_sys_into(root_dir: Path | str):
         dest_dir = str(root_dir / mount)
         print(f"I: Bind-mounting /{mount} into {dest_dir}")
         subprocess.run(["mount", "--rbind", f"/{mount}", dest_dir], check=True, stdin=subprocess.DEVNULL)
+
+
+@_operation
+def clamp_to_source_date(root_dir: Path | str, source_date_epoch: str):
+    root_dir = Path(root_dir)
+    epoch = int(source_date_epoch)
+    dev0 = root_dir.lstat().st_dev
+
+    print(f"I: Clamping mtimes in {root_dir} to {epoch}")
+    os.utime(root_dir, (epoch, epoch), follow_symlinks=False)
+
+    for dirpath, dirnames, filenames in os.walk(root_dir, followlinks=False):
+        kept_dirs = []
+        for name in dirnames:
+            path = os.path.join(dirpath, name)
+            stat_result = os.lstat(path)
+            if stat_result.st_dev != dev0:
+                continue
+            kept_dirs.append(name)
+            if stat_result.st_mtime > epoch:
+                os.utime(path, (epoch, epoch), follow_symlinks=False)
+
+        dirnames[:] = kept_dirs
+
+        for name in itertools.chain(dirnames, filenames):
+            path = os.path.join(dirpath, name)
+            if os.lstat(path).st_mtime > epoch:
+                os.utime(path, (epoch, epoch), follow_symlinks=False)
 
 
 def _parse_and_run(ops_stream: list[dict], operations: dict) -> int:

--- a/usr/lib/grml-live/grml_live/unshared_helper.py
+++ b/usr/lib/grml-live/grml_live/unshared_helper.py
@@ -62,6 +62,11 @@ def mkdir(path: Path | str):
 
 
 @_operation
+def ensure_dir(path: Path | str):
+    Path(path).mkdir(exist_ok=True)
+
+
+@_operation
 def ensure_empty_dir(path: Path | str):
     path = Path(path)
     if path.exists():
@@ -103,6 +108,12 @@ def have_text_in_file(path: Path | str, text: str):
 def unlink(path: Path | str):
     path = Path(path)
     path.unlink()
+
+
+@_operation
+def chown(path: Path | str, numeric_owner: str, numeric_group: str):
+    path = Path(path)
+    os.chown(str(path), int(numeric_owner), int(numeric_group), follow_symlinks=False)
 
 
 @_operation

--- a/usr/lib/grml-live/unshared_helper
+++ b/usr/lib/grml-live/unshared_helper
@@ -1,0 +1,15 @@
+#!/usr/bin/env -S python3 -B
+"""
+Loader script for unshared_helper to allow running it without installing the grml_live package.
+"""
+import sys
+from pathlib import Path
+
+# Add the current directory to Python path so we can import grml_live
+grml_live_path = Path(__file__).parent
+sys.path.insert(0, str(grml_live_path))
+
+from grml_live import unshared_helper
+
+if __name__ == "__main__":
+    sys.exit(unshared_helper.main())


### PR DESCRIPTION
Produces a working ISO, and GHA CI passes.

There might be hidden dragons.

Known broken / TODO:

- [x] apt mark auto in mmdebstrap produces thousands lines of log output
- [x] iso unpacking
- [x] md5sums file
- [x] log file moving
- [x] CI
- [x] `2026-06-25T16:44:09.6767960Z xorriso : FAILURE : Given path does not exist on disk: -boot_image system_area='/tmp/glbuildwbavewd9/grml_chroot/usr/lib/grub/i386-pc/boot_hybrid.img'`
- [x] ~chroot is now always destroyed~ - need to deprecate some modes and need docs

discarded:
- mksquashfs should show numeric uids only, with name-based user ids the output is very confusing - seems impossible with mksquashfs

changes that were included:
- dropped cap_timestamps before mksquashfs, see #536
- minifai.py became multiple python files
- configdump now also has all variables even if they are empty, was necessary to keep minifai.py simple in its current state
- `GRML_FAI_CONFIG` now gets defaulted to source/config if running from a source checkout

for later:
- parsing the configdump in minifai is brittle - need to see what we need
- buildinfo: moved, but needs big improvement - best have each step record some buildinfo artifact, instead of reconstructing all data when writing the json
- move option parsing from grml-live to a new grml_live.py, merge minifai.py

Closes: #533 