### PR TITLE
GRMLBASE/18-timesetup: use ROOTCMD instead of chroot $target

### DIFF
--- a/config/scripts/GRMLBASE/18-timesetup
+++ b/config/scripts/GRMLBASE/18-timesetup
@@ -25,7 +25,7 @@ if [ -n "$TIMEZONE" ] ; then
       # only for tzdata before 2024b-6 (Debian trixie).
       echo "$TIMEZONE" > "$target"/etc/timezone
    fi
-   chroot "$target" ln -sf /usr/share/zoneinfo/"$TIMEZONE" /etc/localtime
+   $ROOTCMD ln -sf /usr/share/zoneinfo/"$TIMEZONE" /etc/localtime
 fi
 
 ## END OF FILE ################################################################


### PR DESCRIPTION
chroot-ing by directly calling `chroot` worked in the past, but with unshare this will explode. Instead use the provided `$ROOTCMD`.

Extracted from https://github.com/grml/grml-live/pull/537.