### PR TITLE
minifai: fix netboot_dir value

### DIFF
--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -721,7 +721,7 @@ def _create_dirs(chroot_dir: Path) -> BuildDirectories:
         media_dir_inside=f"/{build_dir_relative}/{media_dir_name}/",
         media_dir=media_dir,
         netboot_dir_inside=f"/{build_dir_relative}/{netboot_dir_name}/",
-        netboot_dir=media_dir,
+        netboot_dir=netboot_dir,
         sources_dir_inside=f"/{build_dir_relative}/{sources_dir_name}/",
         sources_dir=sources_dir,
     )


### PR DESCRIPTION
Very clear thinko-style error. netboot_dir was apparently unused by minifai so far. (netboot_dir_inside _is_ used.)

Fixes: d46f91b633aa8ff424ea9a7559c40d76da252155

Noticed in #537 