### PR TITLE
grub: make boot_hybrid.img available in ISO9660 filesystem

### DIFF
--- a/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt
+++ b/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt
@@ -260,7 +260,7 @@ the configuration framework of grml.
         -no-emul-boot -boot-load-size 4 -boot-info-table \
         -b boot/grub/i386-pc/eltorito.img \
         --grub2-boot-info --grub2-mbr \
-        /chroot/usr/lib/grub/i386-pc/boot_hybrid.img
+        grml_cd/boot/grub/i386-pc/boot_hybrid.img
 
 as option to mkisofs/xorriso. Otherwise your CD won't be bootable. The
 directory live, containing the squashfs compressed filesystem file,

--- a/config/media-scripts/GRMLBASE/31-grub
+++ b/config/media-scripts/GRMLBASE/31-grub
@@ -141,9 +141,13 @@ if ifclass AMD64 ; then
   echo "I: Copying GRUB core.img for BIOS boot"
   cp --preserve=timestamp "${target}"/boot/grub/i386-pc/core.img "${media_dir}"/boot/grub/i386-pc/
 
+  echo "I: Copying GRUB boot_hybrid.img for BIOS boot"
+  # boot_hybrid.img needs to be available to xorriso
+  cp --preserve=timestamp "${target}"/usr/lib/grub/i386-pc/boot_hybrid.img "${media_dir}"/boot/grub/i386-pc/
+
   # Create El Torito boot image for BIOS
   # This is a bootable image that will be embedded in the ISO
-  echo "I: Creating GRUB El Torito boot image for BIOS"
+  echo "I: Creating GRUB El Torito boot image for BIOS boot"
 
   # The eltorito.img needs to contain:
   # 1. boot.img (first 512 bytes - MBR boot sector)

--- a/grml-live
+++ b/grml-live
@@ -963,7 +963,7 @@ if [ "$ARCH" = "arm64" ]; then
   BOOT_ARGS=""
 else
   # Use GRUB for BIOS boot via El Torito
-  BOOT_ARGS="-b boot/grub/i386-pc/eltorito.img -no-emul-boot -boot-load-size 4 -boot-info-table --grub2-boot-info --grub2-mbr ${CHROOT_OUTPUT}/usr/lib/grub/i386-pc/boot_hybrid.img"
+  BOOT_ARGS="-b boot/grub/i386-pc/eltorito.img -no-emul-boot -boot-load-size 4 -boot-info-table --grub2-boot-info --grub2-mbr ${BUILD_OUTPUT}/boot/grub/i386-pc/boot_hybrid.img"
 fi
 
 if [ -n "$SKIP_MKISOFS" ] ; then

--- a/remaster/grml-live-remaster
+++ b/remaster/grml-live-remaster
@@ -131,13 +131,11 @@ mkdir -p "$(dirname "$SQUASHFS_FQNAME")"
 basename "$SQUASHFS_FQNAME" > "$(dirname "$SQUASHFS_FQNAME")/filesystem.module"
 $MKSQUASHFS /remaster/chroot "$SQUASHFS_FQNAME"
 
-cp /remaster/cdrom/usr/lib/grub/i386-pc/boot_hybrid.img /remaster/tmp/
-
 umount /remaster/chroot /remaster/cdrom
 
 $MKISO -b boot/grub/i386-pc/eltorito.img -no-emul-boot \
         -boot-load-size 4 -boot-info-table \
-        --grub2-boot-info --grub2-mbr /remaster/tmp/boot_hybrid.img \
+        --grub2-boot-info --grub2-mbr "${LIVE_PATH_BOOT}"/grub/i386-pc/boot_hybrid.img \
         -no-pad \
         -l -r -J -o "$1" /remaster/iso
 # pad for partition table


### PR DESCRIPTION
Necessary for remastering, but also for unshare based building when the chroot is already cleaned up when xorriso runs.

Fixes: 3e4c53a595c908647193b130675e1cfc4a054914

Extracted out of #537