### PR TITLE
Add some flexibility to grub configuration

### DIFF
--- a/config/media-files/GRMLBASE/boot/grub/%SHORT_NAME%_default.cfg
+++ b/config/media-files/GRMLBASE/boot/grub/%SHORT_NAME%_default.cfg
@@ -1,7 +1,7 @@
 menuentry "%GRML_NAME% %VERSION%" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux   /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% "${loopback}" ${kernelopts} nomce 
+    linux   /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% "${loopback}" ${kernelopts} ${extraopts} nomce 
     echo 'Loading initrd...'
     initrd  /boot/%SHORT_NAME%/initrd.img
 }

--- a/config/media-files/GRMLBASE/boot/grub/%SHORT_NAME%_options.cfg
+++ b/config/media-files/GRMLBASE/boot/grub/%SHORT_NAME%_options.cfg
@@ -2,7 +2,7 @@ submenu "  ⇢ Options" --class=submenu {
 menuentry "Enable SSH (with random password)" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} ssh 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} ${extraopts} ssh 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -10,7 +10,7 @@ menuentry "Enable SSH (with random password)" {
 menuentry "Load Grml to RAM" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} toram=%GRML_NAME%.squashfs 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} ${extraopts} toram=%GRML_NAME%.squashfs 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -18,7 +18,7 @@ menuentry "Load Grml to RAM" {
 menuentry "Load whole medium to RAM" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} toram 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} ${extraopts} toram 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -26,7 +26,7 @@ menuentry "Load whole medium to RAM" {
 menuentry "Forensic Mode" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} read-only nofstab noraid nolvm noautoconfig noswap raid=noautodetect 
+    linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} ${extraopts} read-only nofstab noraid nolvm noautoconfig noswap raid=noautodetect 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -34,7 +34,7 @@ menuentry "Forensic Mode" {
 menuentry "Persistency Mode" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} persistence 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} ${extraopts} persistence 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -42,7 +42,7 @@ menuentry "Persistency Mode" {
 menuentry "Load German Keyboard Layout" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} lang=de 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} ${extraopts} lang=de 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -50,7 +50,7 @@ menuentry "Load German Keyboard Layout" {
 menuentry "Graphical Mode" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} startx 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} ${extraopts} startx 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -60,7 +60,7 @@ if [ "${grub_platform}" != "efi" ] ; then
 menuentry "Disable Framebuffer and Kernel Mode Setting" {
     set gfxpayload=text
     echo 'Loading kernel...'
-    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset 
+    linux  /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} ${extraopts} radeon.modeset=0 i915.modeset=0 nouveau.modeset=0 cirrus.modeset=0 mgag200.modeset=0 nomodeset 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -69,7 +69,7 @@ fi
 menuentry "Debug Mode" {
     set gfxpayload=keep
     echo 'Loading kernel...'
-    linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} initcall verbose debug=vc systemd.log_level=debug systemd.log_target=kmsg log_buf_len=1M 
+    linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} ${extraopts} initcall verbose debug=vc systemd.log_level=debug systemd.log_target=kmsg log_buf_len=1M 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }
@@ -77,7 +77,7 @@ menuentry "Debug Mode" {
 menuentry "Serial Console" {
     set gfxpayload=text
     echo 'Loading kernel...'
-    linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} video=vesafb:off console=tty1 console=ttyS0,115200n8 
+    linux /boot/%SHORT_NAME%/vmlinuz apm=power-off boot=live live-media-path=/live/%GRML_NAME%/ bootid=%BOOTID% nomce "${loopback}" ${kernelopts} ${extraopts} video=vesafb:off console=tty1 console=ttyS0,115200n8 
     echo 'Loading initrd...'
     initrd /boot/%SHORT_NAME%/initrd.img
 }

--- a/config/media-files/GRMLBASE/boot/grub/grub.cfg
+++ b/config/media-files/GRMLBASE/boot/grub/grub.cfg
@@ -1,7 +1,16 @@
 ## grub2 configuration
+
+if [ -f /boot/grub/grub_local_custom_early.cfg ] ; then
+    source "/boot/grub/grub_local_custom_early.cfg"
+fi
+
 source /boot/grub/header.cfg
 
 insmod regexp
+
+if [ -f /boot/grub/grub_local_custom_pre_entry.cfg ] ; then
+    source "/boot/grub/grub_local_custom_pre_entry.cfg"
+fi
 
 for config in /boot/grub/*_default.cfg ; do
     source "$config"
@@ -34,4 +43,9 @@ menuentry "Boot from next device" {
 }
 
 source /boot/grub/footer.cfg
+
+if [ -f /boot/grub/grub_local_custom_late.cfg ] ; then
+    source "/boot/grub/grub_local_custom_late.cfg"
+fi
+
 # EOF


### PR DESCRIPTION
Hi,

this will allow adding extra commands and extra options to be added to grub configuration and the grml menuentries by just adding hook files to /boot/grub on a remastered image. This, for example, allows to create an image to directly and non-interactively boot to serial console.

Technically, when i am already remastering the image, I could directly modify the grub configuration, but having the hook looks less clumsy to me and it also allows me to take advantage of your changes without manually reviewing and locally applying them.

Greetings
Marc
