### PR TITLE
grml-live: fix chroot bootstrap condition

### DIFF
--- a/grml-live
+++ b/grml-live
@@ -745,7 +745,7 @@ elif [ -n "$UPDATE" ] ; then
   FAI_ACTION=softupdate
 elif [ -n "$BUILD_DIRTY" ] ; then
   FAI_ACTION=rebuild
-elif [ -d "$CHROOT_OUTPUT/etc/debian_version" ] ; then
+elif [ -r "$CHROOT_OUTPUT/etc/debian_version" ] ; then
   log   "Skipping chroot bootstrap as $CHROOT_OUTPUT exists already."
   ewarn "Skipping chroot bootstrap as $CHROOT_OUTPUT exists already." ; eend 0
   FAI_ACTION=rebuild


### PR DESCRIPTION
Fixes: ed997c717ddf3800c2afdc139f404263c1a030aa

/etc/debian_version is never a directory, so -d there was just a bug.