### PR TITLE
Misc SecureBoot changes

### DIFF
--- a/config/media-files/GRMLBASE/boot/grub/grub.cfg
+++ b/config/media-files/GRMLBASE/boot/grub/grub.cfg
@@ -1,5 +1,12 @@
 ## grub2 configuration
 
+# secure boot, read only if not already sourced elsewhere
+if [ "${grml_secureboot}" = "" ] ; then
+    if [ -f "${prefix}/../../secureboot/grub.cfg" ] ; then
+        source "${prefix}/../../secureboot/grub.cfg"
+    fi
+fi
+
 if [ -f "${prefix}/grub_local_custom_early.cfg" ] ; then
     source "${prefix}/grub_local_custom_early.cfg"
 fi

--- a/config/media-files/GRMLBASE/secureboot/grub.cfg
+++ b/config/media-files/GRMLBASE/secureboot/grub.cfg
@@ -7,7 +7,7 @@ set grml_orig_root=$root
 export grml_orig_root
 
 search.file %BOOT_FILE% root
-set prefix=($root)/${prefix}/
+set prefix=($root)/boot/grub/
 
 # this is a simple test to identify whether GRUB is running in Secure Boot mode
 # or not; "wrmsr" is in the list of disabled_mods of GRUB and is supposed to be

--- a/config/media-files/GRMLBASE/secureboot/grub.cfg
+++ b/config/media-files/GRMLBASE/secureboot/grub.cfg
@@ -36,7 +36,8 @@ echo \$prefix
 echo \$root
 echo \$grml_orig_prefix
 echo \$grml_orig_root
-search.file "${prefix}/grub.cfg"
+ls \$prefix/grub.cfg
+search.file /boot/grub/grub.cfg
 
 Hint: Create a screenshot or a picture with your digital camera or mobile phone."
 

--- a/config/media-scripts/GRMLBASE/10-efi
+++ b/config/media-scripts/GRMLBASE/10-efi
@@ -93,7 +93,7 @@ grub_setup() {
           echo "I: Secure Boot is enabled [mode: ${SECURE_BOOT}]"
 
           grml-live-command copy-media-files media /secureboot/grub.cfg
-          $ROOTCMD mv "${GRML_LIVE_MEDIADIR}"/secureboot/grub.cfg /tmp
+          $ROOTCMD cp "${GRML_LIVE_MEDIADIR}"/secureboot/grub.cfg /tmp
 
           grml-live-adjust-boot-files "${target}"/tmp/grub.cfg
 


### PR DESCRIPTION
* SecureBoot: read secureboot/grub.cfg also from main GRUB configuration
* SecureBoot: fix prefix setting
* SecureBoot: update debugging hints in grub.cfg

Disclaimer: I still don't know why the SecureBoot theme usage broke, `secureboot/grub.cfg` in the efi.img just isn't read any longer. :-/