### PR TITLE
grml-live: remove -z, SQUASHFS_OPTIONS

### DIFF
--- a/docs/grml-live.8.adoc
+++ b/docs/grml-live.8.adoc
@@ -12,7 +12,7 @@ Synopsis
 grml-live [-a <architecture>] [-c <classe[s]>] [-C <configfile>] [
 -e <extract_iso_name>] [-g <grml_name>] [-i <iso_name>] [
 -o <output_directory>] [-r <release_name>] [-s <suite>] [
--v <version_number>] [-U <username>] [-w <date>] [-AbBFnNqQRuz]
+-v <version_number>] [-U <username>] [-w <date>] [-AbBFnNqQRu]
 
 Description
 -----------
@@ -238,9 +238,6 @@ Debian repositories only, as referred to in /etc/apt/sources.list.d/debian.list
 (so neither the Grml repositories nor any further custom ones are affected by
 the wayback machine).
 
-  -z::
-
-Use ZLIB instead of LZMA/XZ compression in mksquashfs part of the build process.
 
 [[usage-examples]]
 Usage examples
@@ -513,9 +510,6 @@ Make a branch for your customizations:
 Adjust grml-live configuration for our needs:
 
   cat > ./etc/grml/grml-live.local << EOF
-  ## want a faster build process and don't need smaller ISOs?
-  ## if so use zlib compression
-  # SQUASHFS_OPTIONS="-comp gzip -b 256k"
   ## install local files into the chroot
   # CHROOT_INSTALL="/srv/config/chroot_install"
   ## adjust if necessary (defaults to ./grml/):

--- a/etc/grml/grml-live.conf
+++ b/etc/grml/grml-live.conf
@@ -94,10 +94,6 @@
 # SECURE_BOOT='disable'         # do not enable Secure Boot (default)
 # SECURE_BOOT='debian'          # use Debian's GRUB version requiring a signed kernel
 
-# Options that should be used by mksquashfs during build process.
-# Defaults to '-b 1m' and the according LZMA/XZ option.
-# SQUASHFS_OPTIONS='-b 1m'
-
 # exclude files from compressed squashfs file using the
 # the mksquashfs option -ef:
 # SQUASHFS_EXCLUDES_FILE="${GRML_FAI_CONFIG}/grml/squashfs-excludes"

--- a/grml-live
+++ b/grml-live
@@ -852,11 +852,7 @@ else
 
    # log stuff
    SQUASHFS_STDERR="$(mktemp -t grml-live.XXXXXX)"
-
-   # informational stuff
-   [ -n "$SQUASHFS_OPTIONS" ]  && SQUASHFS_INFO_MSG="$SQUASHFS_OPTIONS"
-   [ -n "$SQUASHFS_INFO_MSG" ] && SQUASHFS_INFO_MSG="using options: $SQUASHFS_INFO_MSG"
-   einfo "Squashfs build information: running $MKSQUASHFS_BINARY $SQUASHFS_INFO_MSG"
+   einfo "Squashfs build information: running $MKSQUASHFS_BINARY using options: $SQUASHFS_OPTIONS"
 
    log "$MKSQUASHFS_BINARY $CHROOT_OUTPUT/ $BUILD_OUTPUT/live/${GRML_NAME}/${GRML_NAME}.squashfs -noappend $SQUASHFS_OPTIONS"
    # shellcheck disable=SC2086 # $SQUASHFS_OPTIONS needs splitting

--- a/grml-live
+++ b/grml-live
@@ -72,7 +72,6 @@ Usage: $PN [options, see as follows]
    -v <version_number>     specify version number of the release
    -w <date>               wayback machine, build system using Debian archives
                            from specified date
-   -z                      use ZLIB instead of LZMA/XZ compression
 
 Usage examples:
 
@@ -263,7 +262,6 @@ while getopts "a:C:c:d:D:e:g:i:I:o:r:s:S:t:U:v:w:AbBFhnNqQRuVz" opt; do
     u) UPDATE=1 ;;
     U) CHOWN_USER="$OPTARG" ;;
     w) export WAYBACK_DATE="$OPTARG" ;;
-    z) SQUASHFS_ZLIB=1 ;;
     ?) echo "invalid option -$OPTARG" >&2; usage; bailout 1 ;;
   esac
 done
@@ -361,6 +359,11 @@ fi
 if [ -n "$NETBOOT" ] ; then
   eerror "The variable \$NETBOOT is set, but it is unsupported." ; eend 1
   eerror "Please unset it. Current value: \$NETBOOT=${NETBOOT}" ; eend 1
+  bailout
+fi
+if [ -n "$SQUASHFS_OPTIONS" ] ; then
+  eerror "The variable \$SQUASHFS_OPTIONS is set, but it is unsupported." ; eend 1
+  eerror "Please unset it. Current value: \$SQUASHFS_OPTIONS=${SQUASHFS_OPTIONS}" ; eend 1
   bailout
 fi
 
@@ -508,8 +511,6 @@ echo "  SOURCE_DATE_EPOCH: $SOURCE_DATE_EPOCH"
 [ -n "$CHOWN_USER" ]          && echo "  Output owner:      $CHOWN_USER"
 [ -n "$DEFAULT_BOOTOPTIONS" ] && echo "  Adding default bootoptions: \"$DEFAULT_BOOTOPTIONS\""
 [ -n "$LOGFILE" ]             && echo "  Logging to file:   $LOGFILE"
-[ -n "$SQUASHFS_ZLIB" ]       && echo "  Using ZLIB (instead of LZMA/XZ) compression."
-[ -n "$SQUASHFS_OPTIONS" ]    && echo "  Using SQUASHFS_OPTIONS ${SQUASHFS_OPTIONS}"
 [ -n "$CLEAN_ARTIFACTS" ]     && echo "  Will clean output before and after running."
 [ -n "$UPDATE" ]              && echo "  Executing UPDATE instead of fresh installation."
 if [ -n "$BOOTSTRAP_ONLY" ] ; then
@@ -836,18 +837,8 @@ if [ -n "$SKIP_MKSQUASHFS" ] ; then
 else
    mkdir -p "$BUILD_OUTPUT"/live/"${GRML_NAME}"/
 
-   # use sane defaults if $SQUASHFS_OPTIONS isn't set
-   if [ -z "$SQUASHFS_OPTIONS" ] ; then
-     # use block size 1m as this gives good result with regards to time + compression
-     SQUASHFS_OPTIONS="-b 1m"
-
-     # set lzma/xz compression by default, unless -z option has been specified on command line
-     if [ -z "$SQUASHFS_ZLIB" ] ; then
-        SQUASHFS_OPTIONS="$SQUASHFS_OPTIONS -comp xz"
-     else
-        SQUASHFS_OPTIONS="$SQUASHFS_OPTIONS -comp gzip"
-     fi
-   fi
+   # use block size 1m as this gives good result with regards to time + compression
+   SQUASHFS_OPTIONS="-b 1m -comp xz"
 
    # Ignore all extended attributes. This avoids:
    # 1) leaking containerization supplied selinux attributes into the squashfs,


### PR DESCRIPTION
Remove support for `-z` (SQUASHFS_ZLIB), and for setting SQUASHFS_OPTIONS. Both were intended as workarounds for older squashfs-tools.

Reference: https://github.com/grml/grml-live/issues/559

