### PR TITLE
memtest: install IA32 EFI binaries

### DIFF
--- a/config/media-scripts/GRMLBASE/41-memtest
+++ b/config/media-scripts/GRMLBASE/41-memtest
@@ -23,6 +23,7 @@ mkdir -p "${media_dir}/boot/addons"
 if ifclass AMD64 ; then
   grml-live-copy-file-logged "${media_dir}"/boot/addons/memtest86+x64.efi "${target}" /boot/mt86+x64 || true
   grml-live-copy-file-logged "${media_dir}"/boot/addons/memtest "${target}" /boot/mt86+x64 || true
+  grml-live-copy-file-logged "${media_dir}"/boot/addons/memtest86+ia32.efi "${target}" /boot/mt86+ia32 || true
 elif ifclass I386 ; then
   grml-live-copy-file-logged "${media_dir}"/boot/addons/memtest86+ia32.efi "${target}" /boot/mt86+ia32 || true
   grml-live-copy-file-logged "${media_dir}"/boot/addons/memtest "${target}" /boot/mt86+ia32 || true
@@ -32,6 +33,7 @@ fi
 if ifclass AMD64 ; then
   grml-live-copy-file-logged "${media_dir}"/boot/addons/memtest86+x64.efi "${target}" /boot/memtest86+x64.efi || true
   grml-live-copy-file-logged "${media_dir}"/boot/addons/memtest "${target}" /boot/memtest86+x64.bin || true
+  grml-live-copy-file-logged "${media_dir}"/boot/addons/memtest86+ia32.efi "${target}" /boot/memtest86+ia32.efi || true
 elif ifclass I386 ; then
   grml-live-copy-file-logged "${media_dir}"/boot/addons/memtest86+ia32.efi "${target}" /boot/memtest86+ia32.efi || true
   grml-live-copy-file-logged "${media_dir}"/boot/addons/memtest "${target}" /boot/memtest86+ia32.bin || true


### PR DESCRIPTION
Commit 6725bfa1ffc4b823d0413b1fa018776e4f4a432d added IA32 EFI support to the AMD64 target, mirror this for memtest86.

In preparation for removing ARCH=i386.