### PR TITLE
Drop support for i386 architecture

### DIFF
--- a/build-driver/build.py
+++ b/build-driver/build.py
@@ -395,7 +395,7 @@ def _main(program_name: str, argv: list[str]) -> int:
         usage(program_name)
         return 2
 
-    if arch not in ("amd64", "i386", "arm64"):
+    if arch not in ("amd64", "arm64"):
         return bail(f"unknown build_arch: {arch}")
 
     if not is_ci():

--- a/config/media-scripts/GRMLBASE/31-grub
+++ b/config/media-scripts/GRMLBASE/31-grub
@@ -28,6 +28,7 @@ if ifclass ARM64 ; then
 fi
 
 if ifclass AMD64 ; then
+  # UEFI 64bit boot
   if [ -r "${target}"/usr/lib/grub/x86_64-efi/moddep.lst ] ; then
     GRUB_ARCHS+=(x86_64-efi)
     ADDITIONAL_MODULES[x86_64-efi]="efi_gop"
@@ -35,10 +36,8 @@ if ifclass AMD64 ; then
     echo "/usr/lib/grub/x86_64-efi/moddep.lst could not be found, skipping."
     echo "NOTE: grub-efi-amd64-bin not installed?"
   fi
-fi
 
-# note: enabled also on AMD64 for UEFI 32bit boot support
-if ifclass I386 || ifclass AMD64 ; then
+  # UEFI 32bit boot
   if [ -r "${target}"/usr/lib/grub/i386-efi/moddep.lst ] ; then
     GRUB_ARCHS+=(i386-efi)
     ADDITIONAL_MODULES[i386-efi]="efi_gop"
@@ -102,7 +101,7 @@ if [ "${ARCH}" = "arm64" ] ; then
   mkdir -p "${media_dir}"/boot/grub/arm64-efi/
   cp -a "${target}"/usr/lib/grub/arm64-efi/*.mod "${media_dir}"/boot/grub/arm64-efi/
   cp -a "${target}"/usr/lib/grub/arm64-efi/*.lst "${media_dir}"/boot/grub/arm64-efi/
-elif [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "i386" ] ; then
+elif [ "${ARCH}" = "amd64" ] ; then
   # grub-pc-bin
   mkdir -p "${media_dir}"/boot/grub/i386-pc/
   cp -a "${target}"/usr/lib/grub/*-pc/*.mod  "${media_dir}"/boot/grub/i386-pc/
@@ -136,64 +135,60 @@ for param in ARCH DATE DISTRI_INFO DISTRI_NAME GRML_NAME SQUASHFS_NAME \
 done
 
 
-# don't include shim + grubnetx64 + grub files in i386 netboot packages,
-# as those don't make much sense there
-if ifclass AMD64 || ifclass ARM64 ; then
-  if ! [ -r "${media_dir}/boot/grub/netboot.cfg" ] ; then
-    echo "W: File /boot/grub/netboot.cfg not found." >&2
-    echo "W: Are you using custom media-files which do not provide netboot.cfg?" >&2
-  else
-    cp --preserve=timestamp "${media_dir}/boot/grub/netboot.cfg" "${tftpboot_dir}/grub.cfg"
+if ! [ -r "${media_dir}/boot/grub/netboot.cfg" ] ; then
+  echo "W: File /boot/grub/netboot.cfg not found." >&2
+  echo "W: Are you using custom media-files which do not provide netboot.cfg?" >&2
+else
+  cp --preserve=timestamp "${media_dir}/boot/grub/netboot.cfg" "${tftpboot_dir}/grub.cfg"
 
-    if [ "$ARCH" = "amd64" ] ; then
-      if ! grml-live-copy-file-logged "${tftpboot_dir}"/shim.efi "${target}" \
-        /usr/lib/shim/shimx64.efi.signed \
-        /usr/lib/shim/shimx64.efi
-      then
-        echo "W: No shimx64.efi for usage with PXE boot found (shim-signed not present?)" >&2
-      fi
-
-      if ! grml-live-copy-file-logged "${tftpboot_dir}"/grubx64.efi "${target}" \
-        /usr/lib/grub/x86_64-efi-signed/grubnetx64.efi.signed \
-        /usr/lib/grub/x86_64-efi/monolithic/grubnetx64.efi
-      then
-        echo "W: No grubnetx64.efi for usage with PXE boot found (grub-efi-amd64-signed not present?)." >&2
-      fi
-
-      # UEFI 32bit boot
-      if ! grml-live-copy-file-logged "${tftpboot_dir}"/grubia32.efi "${target}" \
-        /usr/lib/grub/i386-efi-signed/grubnetia32.efi.signed \
-        /usr/lib/grub/i386-efi/monolithic/grubnetia32.efi
-      then
-        echo "W: No grubnetia32.efi for usage with PXE boot found (grub-efi-ia32-unsigned present?)." >&2
-      fi
+  if [ "$ARCH" = "amd64" ] ; then
+    if ! grml-live-copy-file-logged "${tftpboot_dir}"/shim.efi "${target}" \
+      /usr/lib/shim/shimx64.efi.signed \
+      /usr/lib/shim/shimx64.efi
+    then
+      echo "W: No shimx64.efi for usage with PXE boot found (shim-signed not present?)" >&2
     fi
 
-    if [ "$ARCH" = "arm64" ] ; then
-      if ! grml-live-copy-file-logged "${tftpboot_dir}"/shim.efi "${target}" \
-        /usr/lib/shim/shimaa64.efi.signed \
-        /usr/lib/shim/shimaa64.efi
-      then
-        echo "W: No shimaa64.efi for usage with PXE boot found (shim-signed not present?)" >&2
-      fi
-
-      if ! grml-live-copy-file-logged "${tftpboot_dir}"/grubaa64.efi "${target}" \
-        /usr/lib/grub/arm64-efi-signed/grubnetaa64.efi.signed \
-        /usr/lib/grub/arm64-efi/monolithic/grubnetaa64.efi
-      then
-        echo "W: No grubnetaa64.efi for usage with PXE boot found (grub-efi-arm64-signed not present?)." >&2
-      fi
+    if ! grml-live-copy-file-logged "${tftpboot_dir}"/grubx64.efi "${target}" \
+      /usr/lib/grub/x86_64-efi-signed/grubnetx64.efi.signed \
+      /usr/lib/grub/x86_64-efi/monolithic/grubnetx64.efi
+    then
+      echo "W: No grubnetx64.efi for usage with PXE boot found (grub-efi-amd64-signed not present?)." >&2
     fi
 
-    if [ -r "${target}"/usr/share/grub/unicode.pf2 ] ; then
-      echo "I: Installing ${target}/usr/share/grub/unicode.pf2 as grub/fonts/unicode.pf2 in netboot package"
-      mkdir -p "${tftpboot_dir}"/grub/fonts/
-      cp --preserve=timestamp "${target}"/usr/share/grub/unicode.pf2 "${tftpboot_dir}"/grub/fonts/
-    else
-      echo "W: No unicode.pf2 for usage with PXE boot found (grub-common not present?)" >&2
+    # UEFI 32bit boot
+    if ! grml-live-copy-file-logged "${tftpboot_dir}"/grubia32.efi "${target}" \
+      /usr/lib/grub/i386-efi-signed/grubnetia32.efi.signed \
+      /usr/lib/grub/i386-efi/monolithic/grubnetia32.efi
+    then
+      echo "W: No grubnetia32.efi for usage with PXE boot found (grub-efi-ia32-unsigned present?)." >&2
     fi
   fi
-fi # amd64 or arm64
+
+  if [ "$ARCH" = "arm64" ] ; then
+    if ! grml-live-copy-file-logged "${tftpboot_dir}"/shim.efi "${target}" \
+      /usr/lib/shim/shimaa64.efi.signed \
+      /usr/lib/shim/shimaa64.efi
+    then
+      echo "W: No shimaa64.efi for usage with PXE boot found (shim-signed not present?)" >&2
+    fi
+
+    if ! grml-live-copy-file-logged "${tftpboot_dir}"/grubaa64.efi "${target}" \
+      /usr/lib/grub/arm64-efi-signed/grubnetaa64.efi.signed \
+      /usr/lib/grub/arm64-efi/monolithic/grubnetaa64.efi
+    then
+      echo "W: No grubnetaa64.efi for usage with PXE boot found (grub-efi-arm64-signed not present?)." >&2
+    fi
+  fi
+
+  if [ -r "${target}"/usr/share/grub/unicode.pf2 ] ; then
+    echo "I: Installing ${target}/usr/share/grub/unicode.pf2 as grub/fonts/unicode.pf2 in netboot package"
+    mkdir -p "${tftpboot_dir}"/grub/fonts/
+    cp --preserve=timestamp "${target}"/usr/share/grub/unicode.pf2 "${tftpboot_dir}"/grub/fonts/
+  else
+    echo "W: No unicode.pf2 for usage with PXE boot found (grub-common not present?)" >&2
+  fi
+fi
 
 if ifclass AMD64 ; then
   echo "I: Copying GRUB i386-pc modules to ISO"

--- a/config/media-scripts/GRMLBASE/39-efi
+++ b/config/media-scripts/GRMLBASE/39-efi
@@ -30,7 +30,7 @@ grub_setup() {
   EFI_IMG="/boot/efi.img"
 
   local efi_size
-  if [[ "${SECURE_BOOT:-}" == "disable" ]] || [[ "${ARCH:-}" == "i386" ]] ; then
+  if [[ "${SECURE_BOOT:-}" == "disable" ]] ; then
     efi_size='4M'
   else
     # e.g. EFI/debian for Secure Boot has >4MB and needs more space
@@ -123,19 +123,6 @@ grub_setup() {
           ;;
       esac
     fi
-  fi
-
-  if [[ "$ARCH" == "i386" ]] ; then
-    BOOTX32="/boot/bootia32.efi"
-    if ! [ -r "${target}/${BOOTX32}" ] ; then
-      echo "E: Cannot access GRUB 32-bit PC EFI image ${target}/${BOOTX32}." >&2
-      echo "W: Possible reason is failure to run ${GRML_FAI_CONFIG}/media-scripts/GRMLBASE/31-grub" >&2
-      exit 50
-    fi
-
-    create_efi_img "${target}/${EFI_IMG}" "${efi_size}"
-    mcopy -i "${target}/${EFI_IMG}" "${target}/${BOOTX32}" ::EFI/BOOT/bootia32.efi >/dev/null || exit 53
-    echo "I: Created 32-bit PC EFI image $EFI_IMG from $BOOTX32"
   fi
 }
 # }}}

--- a/config/media-scripts/GRMLBASE/41-memtest
+++ b/config/media-scripts/GRMLBASE/41-memtest
@@ -14,29 +14,19 @@ target=${target:?}
 # shellcheck source=/dev/null
 . "$GRML_LIVE_CONFIG"
 
-echo "I: installing memtest86+."
-
 media_dir="${target}/${GRML_LIVE_MEDIADIR}"
 mkdir -p "${media_dir}/boot/addons"
 
-# memtest86+ >=8.00-1. The binary can be booted in UEFI or BIOS mode.
 if ifclass AMD64 ; then
+  echo "I: installing memtest86+ if available."
+  # memtest86+ >=8.00-1. The binary can be booted in UEFI or BIOS mode.
   grml-live-copy-file-logged "${media_dir}"/boot/addons/memtest86+x64.efi "${target}" /boot/mt86+x64 || true
   grml-live-copy-file-logged "${media_dir}"/boot/addons/memtest "${target}" /boot/mt86+x64 || true
   grml-live-copy-file-logged "${media_dir}"/boot/addons/memtest86+ia32.efi "${target}" /boot/mt86+ia32 || true
-elif ifclass I386 ; then
-  grml-live-copy-file-logged "${media_dir}"/boot/addons/memtest86+ia32.efi "${target}" /boot/mt86+ia32 || true
-  grml-live-copy-file-logged "${media_dir}"/boot/addons/memtest "${target}" /boot/mt86+ia32 || true
-fi
-
-# memtest86+ >=6.00-1. Separate binaries for UEFI and BIOS mode.
-if ifclass AMD64 ; then
+  # memtest86+ >=6.00-1. Separate binaries for UEFI and BIOS mode.
   grml-live-copy-file-logged "${media_dir}"/boot/addons/memtest86+x64.efi "${target}" /boot/memtest86+x64.efi || true
   grml-live-copy-file-logged "${media_dir}"/boot/addons/memtest "${target}" /boot/memtest86+x64.bin || true
   grml-live-copy-file-logged "${media_dir}"/boot/addons/memtest86+ia32.efi "${target}" /boot/memtest86+ia32.efi || true
-elif ifclass I386 ; then
-  grml-live-copy-file-logged "${media_dir}"/boot/addons/memtest86+ia32.efi "${target}" /boot/memtest86+ia32.efi || true
-  grml-live-copy-file-logged "${media_dir}"/boot/addons/memtest "${target}" /boot/memtest86+ia32.bin || true
 fi
 
 ## END OF FILE #################################################################

--- a/config/package_config/GRMLBASE
+++ b/config/package_config/GRMLBASE
@@ -77,13 +77,6 @@ wireless-regdb
 libpam-systemd
 systemd-container
 
-PACKAGES install I386
-grub-pc
-grub-efi-amd64-bin
-grub-efi-ia32-bin
-pxelinux
-syslinux syslinux-common syslinux-utils
-
 PACKAGES install AMD64
 grub-pc
 grub-efi-amd64-bin

--- a/config/package_config/GRML_FULL
+++ b/config/package_config/GRML_FULL
@@ -338,28 +338,6 @@ man-db
 lolcat
 toilet
 
-PACKAGES install I386
-# kernel related
-linux-image-686
-linux-cpupower
-# disk subsystems support/debugging, I386/AMD64 specific
-cciss-vol-status
-# x86 hardware support
-cmospwd
-cpuid
-memtest86+
-# broken userland debugging
-ltrace
-
-# PXE boot
-grml-terminalserver
-
-# firmware updates
-fwupd-i386-signed
-
-# X - not relevant on more recent systems, so ship on i386 only
-xserver-xorg-video-intel
-
 PACKAGES install AMD64
 # kernel related
 linux-image-amd64

--- a/config/package_config/GRML_SMALL
+++ b/config/package_config/GRML_SMALL
@@ -156,10 +156,6 @@ wget
 # special terminal output
 toilet
 
-PACKAGES install I386
-linux-image-686
-memtest86+
-
 PACKAGES install AMD64
 linux-image-amd64
 memtest86+

--- a/docs/grml-live.8.adoc
+++ b/docs/grml-live.8.adoc
@@ -56,12 +56,8 @@ clean up the Chroot target and Build target directories.
 
   -a **ARCHITECTURE**::
 
-Use the specified architecture instead of the currently running one.  This
-allows building a 32bit system on a 64bit host (though you can't build a 64bit
-system on a 32bit system/kernel of course). Please notice that real
-crosscompiling (like building a ppc system on x86) isn't possible due to the
-nature and the need of working in a chroot. Currently supported values: i386,
-amd64 and arm64.
+Use the specified architecture instead of the auto-detected one.
+Currently supported values: amd64 and arm64.
 
   -b::
 
@@ -271,7 +267,7 @@ and strength without losing the simplicity in the build process.
 
 The main and base class provided by grml-live is named GRMLBASE. grml-live will
 automatically add it, together with the architecture-dependent class (being
-'I386' for x86_32, 'AMD64' for x86_64 and 'ARM64' for arm64).
+'AMD64' for x86_64 and 'ARM64' for arm64).
 The GRML_SMALL and GRML_FULL classes define the official ISO builds.
 
 The following files and directories are relevant for class GRMLBASE by default:
@@ -638,8 +634,8 @@ Make sure apt-cacher-ng is running ('/etc/init.d/apt-cacher-ng restart').
 That's it.  All downloaded files will be cached in /var/cache/apt-cacher-ng then.
 
 [[create-a-base-tgz]]
-How do I create a base tar.gz (I386.tar.gz or AMD64.tar.gz or ARM64.tar.gz)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+How do I create a base tar.gz (AMD64.tar.gz or ARM64.tar.gz)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [[basetgz]]
 
 This is no longer supported. grml-live will call mmdebstrap for you.

--- a/etc/grml/grml-live.conf
+++ b/etc/grml/grml-live.conf
@@ -74,7 +74,7 @@
 
 # Which architecture do you want to build?
 # It defaults to output of 'dpkg --print-architecture'
-# ARCH="i386"
+# ARCH="amd64"
 
 # Name of distribution that should be build. By default
 # it's "grml", if you want to adjust please make sure

--- a/grml-live
+++ b/grml-live
@@ -44,7 +44,7 @@ $PN - build process script for generating a (grml based) Linux Live-ISO
 
 Usage: $PN [options, see as follows]
 
-   -a <architecture>       architecture; available values: i386, amd64 + arm64
+   -a <architecture>       architecture; available values: amd64 + arm64
    -A                      clean build directories before and after running
    -b                      build the ISO without updating the chroot
    -B                      build the ISO without touching the chroot (do not clean up)
@@ -396,7 +396,7 @@ specify it on the command line using the -c option."
 [ -n "$OUTPUT" ] || bailout 1 "Error: \$OUTPUT unset, please set it in $LIVE_CONF or
 specify it on the command line using the -o option."
 
-if [ "$ARCH" != "i386" ] && [ "$ARCH" != "amd64" ] && [ "$ARCH" != "arm64" ] ; then
+if [ "$ARCH" != "amd64" ] && [ "$ARCH" != "arm64" ] ; then
   eerror "Error: Unsupported ARCH '$ARCH', sorry. Want to support it? Contribute!"
   eend 1
   bailout
@@ -685,26 +685,18 @@ export SUITE # make sure it's available in FAI scripts
 
 # validate whether the specified architecture class matches the
 # architecture (option), otherwise installation of kernel will fail
-if hasclass I386 ; then
-   if ! [[ "$ARCH" == "i386" ]] ; then
-      log    "Error: You specified the I386 class but are trying to build something else (AMD64/ARM64?)."
-      eerror "Error: You specified the I386 class but are trying to build something else (AMD64/ARM64?)."
-      eerror "Tip:   Either invoke grml-live with '-a i386' or adjust the architecture class. Exiting."
-      eend 1
-      bailout
-   fi
-elif hasclass AMD64 ; then
+if hasclass AMD64 ; then
    if ! [[ "$ARCH" == "amd64" ]] ; then
-      log    "Error: You specified the AMD64 class but are trying to build something else (I386/ARM64?)."
-      eerror "Error: You specified the AMD64 class but are trying to build something else (I386/ARM64?)."
+      log    "Error: You specified the AMD64 class but are trying to build something else (ARM64?)."
+      eerror "Error: You specified the AMD64 class but are trying to build something else (ARM64?)."
       eerror "Tip:   Either invoke grml-live with '-a amd64' or adjust the architecture class. Exiting."
       eend 1
       bailout
    fi
 elif hasclass ARM64 ; then
    if ! [[ "$ARCH" == "arm64" ]] ; then
-      log    "Error: You specified the ARM64 class but are trying to build something else (I386/AMD64?)."
-      eerror "Error: You specified the ARM64 class but are trying to build something else (I386/AMD64?)."
+      log    "Error: You specified the ARM64 class but are trying to build something else (AMD64?)."
+      eerror "Error: You specified the ARM64 class but are trying to build something else (AMD64?)."
       eerror "Tip:   Either invoke grml-live with '-a arm64' or adjust the architecture class. Exiting."
       eend 1
       bailout

--- a/usr/share/zsh/vendor-completions/_grml-live
+++ b/usr/share/zsh/vendor-completions/_grml-live
@@ -24,7 +24,6 @@ _grmllive_archs() { #{{{
 
   runningarch="$(dpkg --print-architecture)"
   archs=( ${runningarch} )
-  [[ ${runningarch} == 'amd64' ]] && archs=( ${archs} 'i386')
   _wanted list expl 'target architecture' compadd ${expl} -- ${archs}
 }
 #}}}

--- a/usr/share/zsh/vendor-completions/_grml-live
+++ b/usr/share/zsh/vendor-completions/_grml-live
@@ -11,9 +11,9 @@ _grmllive_flavours() { #{{{
   local -a flavours
 
   flavours=(
-    grml        grml64
-    grml-full   grml64-full
-    grml-small  grml64-small
+    grml
+    grml-full
+    grml-small
   )
   _wanted list expl 'grml flavour(s)' compadd ${expl} -- ${flavours}
 }
@@ -34,7 +34,7 @@ _grmllive_classes() { #{{{
     static_classes=(
         DEBORPHAN FRESHCLAM
         GRML_FULL GRML_SMALL
-        LATEX LATEX_CLEANUP LOCALES NO_ONLINE REMOVE_DOCS SOURCES XORG ZFS
+        LATEX LOCALES NO_ONLINE REMOVE_DOCS SOURCES XORG ZFS
     )
     compset -P '*,'
     already=(${(s<,>)IPREFIX})
@@ -89,13 +89,9 @@ arguments=( #{{{
   '-Q[skip netboot package build]'
   '-r[release name]:release name:'
   '-s[debian suite to be used for live-system]:Debian suite:_grmllive_suites'
-  '-S[place of scripts (defaults to /usr/share/grml-live/scripts)]:script directory:_path_files -/'
-  '-t[template directory]:template directory:_path_files -/'
   '-u[update existing chroot instead of rebuilding it from scratch]'
   '-U[arrange output to be owned by specified username]'
-  '-V[increase verbosity]'
   '-w[wayback machine, build system using Debian archives from specified date]:wayback date(s):_grmllive_apt_snapshot_dates'
-  '-z[use ZLIB instead of LZMA/XZ compression]'
 )
 #}}}
 


### PR DESCRIPTION
Removes package lists for i386, removes ifclass/hasclass checks for i386. Removes "i386" to option `-a`.

UEFI 32bit boot on an AMD64 ISO should continue to work.

Link: https://github.com/grml/grml-live/issues/559