### PR TITLE
grml-live: remove support for PRESERVE_LOGFILE

### DIFF
--- a/etc/grml/grml-live.conf
+++ b/etc/grml/grml-live.conf
@@ -17,10 +17,6 @@
 # You have enough RAM? Use shared memory for fast testing-purposes:
 # OUTPUT="/dev/shm" # mount -o remount,suid,dev,rw /dev/shm
 
-# Do you want to preserve the logfile from being cleaned after each execution
-# of grml-live? By default the logfile is cleaned so the log doesn't fill up.
-# PRESERVE_LOGFILE='1'
-
 # Which Debian suite/release do you want to use?
 # Supported values are: stable, testing, unstable (or their corresponding release
 # names like "bookworm").

--- a/grml-live
+++ b/grml-live
@@ -581,16 +581,11 @@ fi
 
 # create log file {{{
 [ -n "$LOGFILE" ] || LOGFILE=${LOG_OUTPUT}/grml-live.log
+rm -f "$LOGFILE"
 mkdir -p "$(dirname "${LOGFILE}")"
 touch "$LOGFILE"
 chown root:adm "$LOGFILE"
 chmod 664 "$LOGFILE"
-if [ -n "$PRESERVE_LOGFILE" ] ; then
-   echo "Preserving logfile $LOGFILE as requested via \$PRESERVE_LOGFILE"
-else
-   # make sure it is empty
-   echo -n > "$LOGFILE"
-fi
 # }}}
 
 # source config and startup {{{


### PR DESCRIPTION
We assume that most users never change LOGFILE, thus the logfile should be local to the current build, and thus PRESERVE_LOGFILE should not be necessary and is thus probably not used by anyone. Remove it now to spare some complexity.

In the future we expect that grml-live will gain improved automatic logfile handling.

Link: https://github.com/grml/grml-live/issues/559