### PR TITLE
grml-live: remove option -a (ARCH)

### DIFF
--- a/build-driver/build.py
+++ b/build-driver/build.py
@@ -24,7 +24,6 @@ TOOL_DIR = Path(__file__).parent
 class JobProperties:
     job_timestamp: datetime.datetime
     job_name: str
-    arch: str
     classes: list
     debian_suite: str
     version: str
@@ -107,7 +106,6 @@ def print_grml_live_version(grml_live_path: Path):
 def run_grml_live(
     grml_live_path: Path,
     output_dir: Path,
-    arch: str,
     classes: list,
     debian_suite: str,
     version: str,
@@ -131,8 +129,6 @@ def run_grml_live(
         grml_live_path / "grml-live",
         "-F",  # do not prompt
         "-A",  # cleanup afterwards
-        "-a",
-        arch,
         "-c",
         ",".join(classes),
         "-s",
@@ -263,7 +259,6 @@ def build(
     run_grml_live(
         grml_live_path,
         build_dir,
-        job_properties.arch,
         job_properties.classes,
         job_properties.debian_suite,
         job_properties.version,
@@ -395,6 +390,8 @@ def _main(program_name: str, argv: list[str]) -> int:
         usage(program_name)
         return 2
 
+    # TODO: *ask* grml-live which architecture it will build for, and remove
+    # TODO: the arch parameter.
     if arch not in ("amd64", "arm64"):
         return bail(f"unknown build_arch: {arch}")
 
@@ -438,7 +435,6 @@ def _main(program_name: str, argv: list[str]) -> int:
         job_properties = JobProperties(
             job_timestamp=datetime.datetime.now(),
             job_name=f"{build_grml_name}-release",
-            arch=arch,
             classes=classes,
             # XXX: should load this from ISO or metadata file
             debian_suite=build_config["debian_suite"],
@@ -462,7 +458,6 @@ def _main(program_name: str, argv: list[str]) -> int:
         job_properties = JobProperties(
             job_timestamp=job_timestamp,
             job_name=f"{build_grml_name}-{debian_suite}",
-            arch=arch,
             classes=classes,
             debian_suite=debian_suite,
             version=build_version,

--- a/docs/grml-live.8.adoc
+++ b/docs/grml-live.8.adoc
@@ -9,7 +9,7 @@ grml-live - build framework for the Grml Live Linux system
 Synopsis
 --------
 
-grml-live [-a <architecture>] [-c <classe[s]>] [-C <configfile>] [
+grml-live [-c <classe[s]>] [-C <configfile>] [
 -e <extract_iso_name>] [-g <grml_name>] [-i <iso_name>] [
 -o <output_directory>] [-r <release_name>] [-s <suite>] [
 -v <version_number>] [-U <username>] [-w <date>] [-AbBFnNqQRu]
@@ -53,11 +53,6 @@ Options
 
 Clean up all output directories before running the build process. After finishing,
 clean up the Chroot target and Build target directories.
-
-  -a **ARCHITECTURE**::
-
-Use the specified architecture instead of the auto-detected one.
-Currently supported values: amd64 and arm64.
 
   -b::
 
@@ -510,7 +505,6 @@ Adjust grml-live configuration for our needs:
   # CHROOT_INSTALL="/srv/config/chroot_install"
   ## adjust if necessary (defaults to ./grml/):
   ## OUTPUT="/srv/grml-live"
-  # ARCH="amd64"
   CLASSES="GRML_FULL"
   EOF
 
@@ -717,7 +711,7 @@ Usage example:
     $ git clone --depth 1 https://github.com/grml/grml-live
     $ cd grml-live
     $ sudo apt install <packages>  # see debian/control
-    $ sudo GRML_FAI_CONFIG=$PWD/config ./grml-live -s sid -a amd64 -c GRML_FULL
+    $ sudo GRML_FAI_CONFIG=$PWD/config ./grml-live -s sid -c GRML_FULL
 
 
 Debian package

--- a/grml-live
+++ b/grml-live
@@ -44,7 +44,6 @@ $PN - build process script for generating a (grml based) Linux Live-ISO
 
 Usage: $PN [options, see as follows]
 
-   -a <architecture>       architecture; available values: amd64 + arm64
    -A                      clean build directories before and after running
    -b                      build the ISO without updating the chroot
    -B                      build the ISO without touching the chroot (do not clean up)
@@ -234,9 +233,8 @@ hasclass() {
 # }}}
 
 # command line parsing {{{
-while getopts "a:C:c:d:D:e:g:i:I:o:r:s:U:v:w:AbBFhnNqQRu" opt; do
+while getopts "C:c:d:D:e:g:i:I:o:r:s:U:v:w:AbBFhnNqQRu" opt; do
   case "$opt" in
-    a) ARCH="$OPTARG" ;;
     A) CLEAN_ARTIFACTS=1 ;;
     b) BUILD_ONLY=1 ;;
     B) BUILD_DIRTY=1; SKIP_RELEASE=1 ;;
@@ -333,6 +331,10 @@ if [ -n "$EXTRACT_ISO_NAME" ] ; then
 fi
 # }}}
 
+# setup static build settings {{{
+ARCH="$("$DPKG_BINARY" --print-architecture)"
+# }}}
+
 if [ -n "$SQUASHFS_EXCLUDES_FILE" ] ; then
   eerror "The variable \$SQUASHFS_EXCLUDES_FILE is set, but it is unsupported." ; eend 1
   eerror "Please unset it. Current value: \$SQUASHFS_EXCLUDES_FILE=${SQUASHFS_EXCLUDES_FILE}" ; eend 1
@@ -370,8 +372,7 @@ if [ -n "$SQUASHFS_OPTIONS" ] ; then
 fi
 
 # assume sane defaults (if not set already) {{{
-[ -n "$ARCH" ]                    || ARCH="$("$DPKG_BINARY" --print-architecture)"
-[ -n "$CLASSES" ]                 || CLASSES="GRML_FULL,$(echo "${ARCH}" | tr '[:lower:]' '[:upper:]')"
+[ -n "$CLASSES" ]                 || CLASSES="GRML_FULL"
 [ -n "$DATE" ]                    || DATE="$(date --utc -d "@${SOURCE_DATE_EPOCH}" +%Y-%m-%d)"
 [ -n "$DEFAULT_BOOTOPTIONS" ]     || DEFAULT_BOOTOPTIONS=''
 [ -n "$DISTRI_INFO" ]             || DISTRI_INFO='Grml - Live Linux for system administrators'
@@ -392,18 +393,6 @@ fi
 specify it on the command line using the -c option."
 [ -n "$OUTPUT" ] || bailout 1 "Error: \$OUTPUT unset, please set it in $LIVE_CONF or
 specify it on the command line using the -o option."
-
-if [ "$ARCH" != "amd64" ] && [ "$ARCH" != "arm64" ] ; then
-  eerror "Error: Unsupported ARCH '$ARCH', sorry. Want to support it? Contribute!"
-  eend 1
-  bailout
-fi
-
-if [[ "$(dpkg --print-architecture)" != "arm64" ]] && [[ "$ARCH" == "arm64" ]] ; then
-  eerror "Failure: trying to build for arm64, but not running on arm64."
-  eend 1
-  bailout
-fi
 
 if [ -e "$GRML_FAI_CONFIG"/fai.conf ] ; then
   ewarn "The file ${GRML_FAI_CONFIG}/fai.conf exists but will be ignored."
@@ -468,16 +457,18 @@ if hasclass RELEASE ; then
 elif [[ -z "$SKIP_RELEASE" ]]; then
   CLASSES="${CLASSES},RELEASE"
 fi
+
 if hasclass AMD64 ; then
-  ewarn "Class AMD64 explicitly requested. This is now automatic, please remove it."; eend 1
-elif [[ "$ARCH" == "amd64" ]]; then
-  CLASSES="${CLASSES},AMD64"
+  eerror "Class AMD64 explicitly requested. This is now automatic. Remove it to continue."
+  bailout 1
 fi
 if hasclass ARM64 ; then
-  ewarn "Class ARM64 explicitly requested. This is now automatic, please remove it."; eend 1
-elif [[ "$ARCH" == "arm64" ]]; then
-  CLASSES="${CLASSES},ARM64"
+  eerror "Class ARM64 explicitly requested. This is now automatic. Remove it to continue."
+  bailout 1
 fi
+
+# Add architecture-specific class now.
+CLASSES="${CLASSES},$(echo "${ARCH}" | tr '[:lower:]' '[:upper:]')"
 # }}}
 
 # Warn user if addons from grml-live-addons are absent {{{
@@ -502,7 +493,7 @@ echo "  SOURCE_DATE_EPOCH: $SOURCE_DATE_EPOCH"
 [ -n "$WAYBACK_DATE" ]        && echo "  Wayback date:      $WAYBACK_DATE"
 [ -n "$VERSION" ]             && echo "  Grml version:      $VERSION"
 [ -n "$SUITE" ]               && echo "  Debian suite:      $SUITE"
-[ -n "$ARCH" ]                && echo "  Architecture:      $ARCH"
+echo "  Architecture:      $ARCH"
 [ -n "$SECURE_BOOT" ]         && echo "  Secure Boot:       $SECURE_BOOT"
 [ -n "$CHROOT_INSTALL" ]      && echo "  Install files from directory to chroot:  $CHROOT_INSTALL"
 [ -n "$BOOTID" ]              && echo "  Boot identifier:   $BOOTID"
@@ -674,26 +665,6 @@ case "${SUITE}" in
           *)               CLASSES="DEBIAN_$(echo "$SUITE" | tr '[:lower:]' '[:upper:]'),$CLASSES";;
 esac
 export SUITE # make sure it's available in FAI scripts
-
-# validate whether the specified architecture class matches the
-# architecture (option), otherwise installation of kernel will fail
-if hasclass AMD64 ; then
-   if ! [[ "$ARCH" == "amd64" ]] ; then
-      log    "Error: You specified the AMD64 class but are trying to build something else (ARM64?)."
-      eerror "Error: You specified the AMD64 class but are trying to build something else (ARM64?)."
-      eerror "Tip:   Either invoke grml-live with '-a amd64' or adjust the architecture class. Exiting."
-      eend 1
-      bailout
-   fi
-elif hasclass ARM64 ; then
-   if ! [[ "$ARCH" == "arm64" ]] ; then
-      log    "Error: You specified the ARM64 class but are trying to build something else (AMD64?)."
-      eerror "Error: You specified the ARM64 class but are trying to build something else (AMD64?)."
-      eerror "Tip:   Either invoke grml-live with '-a arm64' or adjust the architecture class. Exiting."
-      eend 1
-      bailout
-   fi
-fi
 
 if [[ -n "${BOOT_METHOD:-}" ]] ; then
   log    "Error: You specified the unsupported BOOT_METHOD option. Please unset it."

--- a/grml-live
+++ b/grml-live
@@ -234,7 +234,7 @@ hasclass() {
 # }}}
 
 # command line parsing {{{
-while getopts "a:C:c:d:D:e:g:i:I:o:r:s:S:t:U:v:w:AbBFhnNqQRuVz" opt; do
+while getopts "a:C:c:d:D:e:g:i:I:o:r:s:U:v:w:AbBFhnNqQRu" opt; do
   case "$opt" in
     a) ARCH="$OPTARG" ;;
     A) CLEAN_ARTIFACTS=1 ;;

--- a/usr/share/zsh/vendor-completions/_grml-live
+++ b/usr/share/zsh/vendor-completions/_grml-live
@@ -18,15 +18,6 @@ _grmllive_flavours() { #{{{
   _wanted list expl 'grml flavour(s)' compadd ${expl} -- ${flavours}
 }
 #}}}
-_grmllive_archs() { #{{{
-  local expl runningarch
-  local -a archs
-
-  runningarch="$(dpkg --print-architecture)"
-  archs=( ${runningarch} )
-  _wanted list expl 'target architecture' compadd ${expl} -- ${archs}
-}
-#}}}
 _grmllive_classes() { #{{{
     local expl
     local -a already static_classes
@@ -68,7 +59,6 @@ _grmllive_apt_snapshot_dates() { #{{{
 #}}}
 
 arguments=( #{{{
-  '-a[specifiy architecture to use]:arch(s):_grmllive_archs'
   '-A[clean build directories before and after running]'
   '-b[build the ISO without updating the chroot via FAI]'
   '-B[build the ISO without touching the chroot (skips cleanup)]'


### PR DESCRIPTION
Now that i386 is fully gone, there is no point in specifying the target
architecture. It always has to equal the running architecture.

Link: https://github.com/grml/grml-live/issues/559