### PR TITLE
grml-live: abort if GRML_FAI_CONFIG is empty/absent

### DIFF
--- a/grml-live
+++ b/grml-live
@@ -387,6 +387,11 @@ specify it on the command line using the -c option."
 [ -n "$OUTPUT" ] || bailout 1 "Error: \$OUTPUT unset, please set it in $LIVE_CONF or
 specify it on the command line using the -o option."
 
+if [ ! -d "$GRML_FAI_CONFIG"/scripts ] ; then
+  eerror "Config directory \"${GRML_FAI_CONFIG}\" does not exist. Set -D to a valid config directory."
+  bailout 1
+fi
+
 if [ -e "$GRML_FAI_CONFIG"/fai.conf ] ; then
   ewarn "The file ${GRML_FAI_CONFIG}/fai.conf exists but will be ignored."
   eend 1


### PR DESCRIPTION
Guard against -D pointing to a non-existing directory, as commonly seen when running directly from git.