### PR TITLE
Use squashfs-excludes to ignore ldconfig cache

### DIFF
--- a/config/grml/squashfs-excludes
+++ b/config/grml/squashfs-excludes
@@ -3,4 +3,4 @@ run/*
 var/run/*
 var/lock/*
 var/lib/dkms/*
-grml-live/*
+grml-live

--- a/config/grml/squashfs-excludes
+++ b/config/grml/squashfs-excludes
@@ -1,5 +1,7 @@
 dev/*
 run/*
+# The dynamic linker auxiliary cache is not reproducible and is always invalid at boot (see Debian bug #845034).
+var/cache/ldconfig/aux-cache
 var/run/*
 var/lock/*
 var/lib/dkms/*

--- a/grml-live
+++ b/grml-live
@@ -751,13 +751,6 @@ if [ -n "$CHROOT_INSTALL" ] ; then
   fi
 fi
 
-# The dynamic linker auxiliary cache is not reproducible and is always
-# invalid at boot (see Debian bug #845034). Unfortunately this must be
-# done from outside the chroot, as *any* program invocation inside will
-# recreate the file.
-rm -f "$CHROOT_OUTPUT"/var/cache/ldconfig/aux-cache
-rmdir --ignore-fail-on-non-empty "$CHROOT_OUTPUT"/var/cache/ldconfig
-
 cap_timestamps "$CHROOT_OUTPUT"
 
 if [ -n "$SKIP_MKSQUASHFS" ] ; then


### PR DESCRIPTION
This should allow us reordering mksquashfs and media-scripts running order in the future, if necessary. Also its just nicer.

Fix exclusion of toplevel `/grml-live` directory while we are here.