### PR TITLE
grml-live: drop MIRROR_DIRECTORY support

### DIFF
--- a/docs/grml-live.8.adoc
+++ b/docs/grml-live.8.adoc
@@ -545,9 +545,6 @@ BOOTSTRAP_MIRROR in /etc/grml/grml-live.conf[.local]. If you're setting up
 your own class file make sure to include the class name in the class list
 (grml-live -c ...).
 
-If you want to use a local (for example NFS mount) mirror additionally then
-adjust MIRROR_DIRECTORY in /etc/grml/grml-live.conf[.local] as well.
-
 If you want to use a HTTP Proxy (like apt-cacher-ng), set APT_PROXY. Example:
 
   APT_PROXY="http://localhost:3142/"
@@ -615,30 +612,7 @@ How to use your own local repository
 
 Let's assume you have Debian package(s) in your filesystem inside
 `/home/foobar/local-packages` and want to provide them to your grml-live build.
-This can be achieved either 1) through a bind mount (using the MIRROR_DIRECTORY
-configuration) or 2) by serving a repository via HTTP.
-
-Serving via bind mount / MIRROR_DIRECTORY
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Make sure to create an according sources.list configuration file, e.g. using
-your own class name `CUSTOM`:
-
-  # cat > $GRML_FAI_CONFIG/files/CUSTOM/etc/apt/sources.list.d/local-packages.list << EOF
-  deb file:///home/foobar/local-packages ./
-  EOF
-
-Add the according MIRROR_DIRECTORY configuration to your grml-live configuration:
-
-  # echo "MIRROR_DIRECTORY='/home/foobar/packages'" >> /etc/grml/grml-live.local
-
-Make sure the local directory looks like a mirror:
-
-  % cd /home/foobar/packages
-  % dpkg-scanpackages . /dev/null | gzip > Packages.gz
-
-Finally invoke grml-live with your class name (`CUSTOM` in this example) added
-to the list of classes on the command line (see grml-live option `-c`).
+The easiest option is by serving this repository via HTTP.
 
 Serving a repository via HTTP
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/etc/grml/grml-live.conf
+++ b/etc/grml/grml-live.conf
@@ -35,14 +35,6 @@
 # Which Debian mirror do you want to use for bootstrapping?
 # BOOTSTRAP_MIRROR="http://deb.debian.org/debian"
 
-# Do you want to use a local mirror (like NFS)?
-# If so specify the directory where debian/ is available:
-# MIRROR_DIRECTORY="/media/mirror"
-# ... and then set up an according file in
-# ${GRML_FAI_CONFIG}/files/${CLASS}/etc/apt/sources.list.d/custom.list
-# containing something like:
-# deb file:///media/mirror/debian sid main contrib non-free-firmware non-free
-
 # Version number of ISO:
 # VERSION="0.0-1"
 

--- a/grml-live
+++ b/grml-live
@@ -140,12 +140,6 @@ else
 fi
 # }}}
 
-# umount all directories {{{
-umount_all() {
-   [ -n "$MIRROR_DIRECTORY" ] && umount "${CHROOT_OUTPUT}/${MIRROR_DIRECTORY}"
-}
-# }}}
-
 # store logfiles {{{
 store_logfiles() {
   # move minifai logs into grml_logs directory
@@ -162,7 +156,6 @@ store_logfiles() {
 bailout() {
   [ -n "$CONFIGDUMP"      ]  && rm -f  "$CONFIGDUMP"
   [ -n "$SQUASHFS_STDERR" ]  && rm -rf "$SQUASHFS_STDERR"
-  umount_all
   [ -n "$1" ] && EXIT="$1" || EXIT="1"
   [ -n "$2" ] && eerror "$2">&2
   if [ -n "$CLEAN_ARTIFACTS" ]; then
@@ -176,7 +169,6 @@ bailout() {
   exit "$EXIT"
 }
 trap bailout 1 2 3 3 6 14 15
-trap umount_all EXIT
 # }}}
 
 # some important functions {{{
@@ -696,11 +688,6 @@ fi
 
 mkdir -p "$CHROOT_OUTPUT" || bailout 5 "Problem with creating $CHROOT_OUTPUT"
 
-if [ -n "${MIRROR_DIRECTORY}" ] ; then
-  mkdir -p "${CHROOT_OUTPUT}/${MIRROR_DIRECTORY}"
-  mount --bind "${MIRROR_DIRECTORY}" "${CHROOT_OUTPUT}/${MIRROR_DIRECTORY}"
-fi
-
 log "Executed FAI command line:"
 log "${FAI_PROGRAM} ${GRML_FAI_CONFIG} ${CLASSES} ${FAI_ACTION} ${CHROOT_OUTPUT} ${CONFIGDUMP} ${SUITE} ${BOOTSTRAP_MIRROR}"
 einfo "${FAI_PROGRAM} ${GRML_FAI_CONFIG} ${CLASSES} ${FAI_ACTION} ${CHROOT_OUTPUT} ${CONFIGDUMP} ${SUITE} ${BOOTSTRAP_MIRROR}"
@@ -718,8 +705,6 @@ if [ "$RC" != 0 ] ; then
 fi
 
 mv "${CHROOT_OUTPUT}"/grml-live/grml_sources/ "${OUTPUT}"
-
-umount_all
 
 log "Finished execution of stage 'fai $FAI_ACTION' [$(date)]"
 einfo "Finished execution of stage 'fai $FAI_ACTION'"


### PR DESCRIPTION
The unshare based builder will (at least initially) not be able to support this. Drop the support for now.