### PR TITLE
docs: remove obsolete "requires root" requirement

### DIFF
--- a/docs/grml-live.8.adoc
+++ b/docs/grml-live.8.adoc
@@ -347,7 +347,7 @@ Overview of all files relevant to grml-live and the config area.
 
   /usr/sbin/grml-live
 
-Main program driving the build process. Requires root permissions for execution.
+Main program driving the build process.
 
   /etc/grml/grml-live.conf
 


### PR DESCRIPTION
Gbp-Dch: ignore
