### PR TITLE
grml-live: remove a noisy debug message

### DIFF
--- a/usr/lib/grml-live/grml_live/unshared_helper.py
+++ b/usr/lib/grml-live/grml_live/unshared_helper.py
@@ -139,7 +139,6 @@ def _parse_and_run(ops_stream: list[dict], operations: dict) -> int:
         args = op["args"]
         kwargs = op["kwargs"]
         try:
-            print(f"I: unshared_helper executing {op_name} {' '.join(str(arg) for arg in args)} {kwargs}", flush=True)
             rc = operations[op_name](*args, **kwargs)
         except Exception as except_inst:
             print(f"E: {op_name} failed: {except_inst}", flush=True)


### PR DESCRIPTION
The debug message was useful during unshared_helper development, but now its a bit noisy.