### PR TITLE
minifai: fix policy-rc.d cleanup

### DIFF
--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -519,8 +519,8 @@ def policy_rcd(chroot_dir: Path, unshared_service: UnsharedService):
                 unshared_service.run(unshared_helper.unlink(program))
             else:
                 print(f"I: Not cleaning up {program} - our marker went missing")
-        except Exception:
-            print(f"W: Failed cleaning up {program}")
+        except Exception as except_inst:
+            print(f"W: Failed cleaning up {program}: {except_inst}")
 
 
 @contextlib.contextmanager

--- a/usr/lib/grml-live/grml_live/minifai.py
+++ b/usr/lib/grml-live/grml_live/minifai.py
@@ -510,9 +510,13 @@ def policy_rcd(chroot_dir: Path, unshared_service: UnsharedService):
         yield
     finally:
         try:
-            if marker in program.read_text():
+            have_marker = not bool(
+                unshared_service.run(unshared_helper.have_text_in_file(program, marker), check=False)
+            )
+
+            if have_marker:
                 print(f"I: Cleaning up {program}")
-                program.unlink()
+                unshared_service.run(unshared_helper.unlink(program))
             else:
                 print(f"I: Not cleaning up {program} - our marker went missing")
         except Exception:


### PR DESCRIPTION
Unlinking was done directly in the minifai process, instead of using the
unshared helper. This leads to a permission error, and the build logs
indeed show:
```
  W: Failed cleaning up /tmp/glbuildjgsbsp6x/grml_chroot/usr/sbin/policy-rc.d
```