### PR TITLE
CI: fix artifact filenames

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -73,7 +73,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
-          name: grml-live-build-result-initial-${{github.event.pull_request.number && format('pr{0}-', github.event.pull_request.number) || ''}}-${{matrix.arch}}${{matrix.extra_classes && format('-{0}', matrix.extra_classes) || ''}}
+          name: grml-live-build-result-initial-${{github.event.pull_request.number && format('pr{0}', github.event.pull_request.number) || 'unknown'}}-${{matrix.arch}}${{matrix.extra_classes && format('-{0}', matrix.extra_classes) || ''}}
           if-no-files-found: error
           retention-days: 15
           path: |
@@ -90,7 +90,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
-          name: grml-live-build-result-repack-${{github.event.pull_request.number && format('pr{0}-', github.event.pull_request.number) || ''}}-${{matrix.arch}}${{matrix.extra_classes && format('-{0}', matrix.extra_classes) || ''}}
+          name: grml-live-build-result-repack-${{github.event.pull_request.number && format('pr{0}', github.event.pull_request.number) || 'unknown'}}-${{matrix.arch}}${{matrix.extra_classes && format('-{0}', matrix.extra_classes) || ''}}
           if-no-files-found: error
           retention-days: 15
           path: |


### PR DESCRIPTION
The zips ended up like this "grml-live-build-result-initial-pr595--amd64.zip", that is with a double "--". Really because the filename creation in the yaml is unreadable.

Remove the "-" from the "pr{0}-" format, and always have a string in that place, even for non-PR runs.
