### PR TITLE
format /boot/grub/help/cheatcodes.txt

### DIFF
--- a/config/media-files/GRMLBASE/boot/grub/help/cheatcodes.txt
+++ b/config/media-files/GRMLBASE/boot/grub/help/cheatcodes.txt
@@ -29,8 +29,8 @@ startx[=windowmanager]                     autostart X.org using grml-x
 swap                                   activate present swap partitions
 testcd                              check CD data integrity and md5sums
 toram / grml2ram      copy the whole CD/media to RAM and run from there
-toram=%SQUASHFS_NAME%      copy only specified squashfs file to RAM and
-                                                         run from there
+toram=%SQUASHFS_NAME%      
+            copy only specified squashfs file to RAM and run from there
 
 Additional kernel and initramfs boot options:
 


### PR DESCRIPTION
The string which will be replaced by %SQUASHFS_NAME% will differ in length. Print the information in the next line to not see outputs like this:
```
  ...
  toram / grml2ram      copy the whole CD/media to RAM and run from there
  toram=grml-trixie-small.squashfs      copy only specified squashfs file to RAM and
                                                           run from there
  ...
```
